### PR TITLE
Enhance error logging in run.sh to include failure emoji issues (❌) i…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -767,6 +767,10 @@ scan_log_errors() {
         # Count warning emoji issues (⚠️)
         local warning_emoji_errors=$(grep -c "⚠️" "$log_file" 2>/dev/null | tr -d ' \n' || echo "0")
         
+        # Count failure emoji issues (❌)
+        local failure_emoji_errors=$(grep -c "❌" "$log_file" 2>/dev/null | tr -d ' \n' || echo "0")
+        
+        
         # Lock acquisition failures (removed - these are expected for daily tasks)
         local lock_failures=0
         
@@ -780,7 +784,7 @@ scan_log_errors() {
         local deno_crashes=$(grep -c "==== C stack trace" "$log_file" 2>/dev/null | tr -d ' \n' || echo "0")
         
         # Sum all error types
-        exception_count=$((stack_trace_exceptions + missing_command_errors + warning_emoji_errors + lock_failures + permission_errors + network_errors + deno_crashes))
+        exception_count=$((stack_trace_exceptions + missing_command_errors + warning_emoji_errors + failure_emoji_errors + lock_failures + permission_errors + network_errors + deno_crashes))
         
         # If we found exceptions, get more details
         if [ "$exception_count" -gt 0 ]; then
@@ -796,6 +800,10 @@ scan_log_errors() {
             if [ "$warning_emoji_errors" -gt 0 ]; then
                 if [ -n "$error_details" ]; then error_details="${error_details}, "; fi
                 error_details="${error_details}${warning_emoji_errors} warning issues"
+            fi
+            if [ "$failure_emoji_errors" -gt 0 ]; then
+                if [ -n "$error_details" ]; then error_details="${error_details}, "; fi
+                error_details="${error_details}${failure_emoji_errors} failure issues"
             fi
             if [ "$lock_failures" -gt 0 ]; then
                 if [ -n "$error_details" ]; then error_details="${error_details}, "; fi


### PR DESCRIPTION
…n the scan_log_errors function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds detection of ❌ failure emoji to `scan_log_errors`, contributing to `exception_count` and detailed `exception_summary`.
> 
> - **Health monitoring (`run.sh`)**:
>   - `scan_log_errors`:
>     - Add `failure_emoji_errors` by grepping for "❌".
>     - Include `failure_emoji_errors` in `exception_count` calculation.
>     - Append corresponding "failure issues" to the detailed `exception_summary`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b0c16bd2efffc21bdc4cb33982e43c685bc2e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->