### PR TITLE
Update version to 1.0.40 across multiple files and enhance error logg…

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.39";
+const VERSION = "1.0.40";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.39" rel="stylesheet">
+    <link href="./styles.css?v=1.0.40" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -88,14 +88,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.39"></script>
+    <script src="./dashboard.js?v=1.0.40"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.39')
+                navigator.serviceWorker.register('./sw.js?v=1.0.40')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/log-viewer.html
+++ b/docs/log-viewer.html
@@ -204,7 +204,7 @@
                     /==== C stack trace/.test(line) ||
                     /Fatal error/.test(line)) {
                     return `<div class="error-line" data-line-index="${index}">${escapeHtml(line)}</div>`;
-                } else if (line.includes('⚠️') || line.includes('❌')) {
+                } else if (line.includes('❌')) {
                     return `<div class="error-line" data-line-index="${index}">${escapeHtml(line)}</div>`;
                 } else if (isStackTraceLine || isCStackTraceLine) {
                     return `<div class="stack-trace-line" data-line-index="${index}">${escapeHtml(line)}</div>`;

--- a/docs/log-viewer.html
+++ b/docs/log-viewer.html
@@ -204,7 +204,7 @@
                     /==== C stack trace/.test(line) ||
                     /Fatal error/.test(line)) {
                     return `<div class="error-line" data-line-index="${index}">${escapeHtml(line)}</div>`;
-                } else if (line.includes('⚠️')) {
+                } else if (line.includes('⚠️') || line.includes('❌')) {
                     return `<div class="error-line" data-line-index="${index}">${escapeHtml(line)}</div>`;
                 } else if (isStackTraceLine || isCStackTraceLine) {
                     return `<div class="stack-trace-line" data-line-index="${index}">${escapeHtml(line)}</div>`;

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.39
+// Version: 1.0.40
 
-const CACHE_NAME = 'grq-health-v1.0.39';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.39';
+const CACHE_NAME = 'grq-health-v1.0.40';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.40';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.39',
+  './dashboard.js?v=1.0.40',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=6
-VERSION="1.0.39"
+VERSION="1.0.40"
 
 # Parse command line arguments
 FORCE_UPDATE=false


### PR DESCRIPTION
…ing in log-viewer.html to include failure emoji (❌).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps version to 1.0.40 across dashboard, HTML, service worker, and script; updates log viewer to flag ❌ lines as errors.
> 
> - **PWA/Dashboard**:
>   - Update version to `1.0.40` in `docs/dashboard.js`, `docs/index.html` (asset query params), and `docs/sw.js` (cache names and static files).
>   - Update `run.sh` `VERSION` to `1.0.40`.
> - **Log Viewer**:
>   - Treat lines containing `❌` as errors in `docs/log-viewer.html` (render with `error-line`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e2eefde25e0c4cce06b50cfc6f7d25de6088d79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->