### PR TITLE
Fix log viewer scroll to skip git commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ A distributed health monitoring system that tracks the status of multiple hosts 
   2. Scroll to that first issue
   3. If no issues found, stay at the top
 - **Highlighted Issues**: ERROR, Exception, Error:, ⚠️ (warning emoji), WARNING, Warning:, DEBUG:
-- **Stack Trace Detection**: Lines matching `/^\s+at /` pattern
+- **Stack Trace Detection**: 
+  - JavaScript stack traces: Lines matching `/^\s+at /` pattern
+  - C stack traces: Lines matching `/^\s+\d+\s+\w+\s+0x[0-9a-fA-F]+/` pattern (requires hex address to avoid false positives from git messages)
 - **All issues are counted** in the dashboard exception count
 
 #### Exception Detection in run.sh:

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.41";
+const VERSION = "1.0.43";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.41" rel="stylesheet">
+    <link href="./styles.css?v=1.0.43" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -88,14 +88,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.41"></script>
+    <script src="./dashboard.js?v=1.0.43"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.41')
+                navigator.serviceWorker.register('./sw.js?v=1.0.43')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/log-viewer.html
+++ b/docs/log-viewer.html
@@ -190,8 +190,9 @@
                 // Check if this is a stack trace line (starts with whitespace + "at ")
                 const isStackTraceLine = /^\s+at /.test(line);
                 
-                // Check if this is a C stack trace line (starts with whitespace + number)
-                const isCStackTraceLine = /^\s+\d+\s+/.test(line);
+                // Check if this is a C stack trace line (starts with whitespace + number + hex address)
+                // Format: "    1 node             0x0000000104d3b2c4 ..."
+                const isCStackTraceLine = /^\s+\d+\s+\w+\s+0x[0-9a-fA-F]+/.test(line);
                 
                 // Highlight different types of log messages
                 // Be specific to avoid false positives from training metrics that mention "Error:"

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.41
+// Version: 1.0.43
 
-const CACHE_NAME = 'grq-health-v1.0.41';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.41';
+const CACHE_NAME = 'grq-health-v1.0.43';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.43';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.41',
+  './dashboard.js?v=1.0.43',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=6
-VERSION="1.0.42"
+VERSION="1.0.43"
 
 # Parse command line arguments
 FORCE_UPDATE=false


### PR DESCRIPTION
- Updated C stack trace detection regex to require hex address (0x...)
- This prevents false positives from git messages like '4 files changed, 87958 insertions(+)'
- Updated README to document the new stack trace detection patterns
- Bumped version to 1.0.43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines C stack trace detection to require a hex address and bumps versioning to 1.0.43 across scripts, HTML references, and service worker caches.
> 
> - **Log Viewer**:
>   - Updates C stack trace regex in `docs/log-viewer.html` to require hex address: `/^\s+\d+\s+\w+\s+0x[0-9a-fA-F]+/`.
> - **Documentation**:
>   - README clarifies stack trace detection patterns for JavaScript (`/^\s+at /`) and C (hex-address based) traces.
> - **Versioning/PWA**:
>   - Bumps version to `1.0.43` in `run.sh` and `docs/dashboard.js`.
>   - Updates `docs/index.html` asset query params for `styles.css`, `dashboard.js`, and `sw.js` to `v=1.0.43`.
>   - Updates `docs/sw.js` version comment, cache names, and static file references to `1.0.43`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94c55e6d106edd7c72e27c39e2f00e78132e0db1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->