### PR TITLE
Update stack trace detection regex and version bump to 1.0.44

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A distributed health monitoring system that tracks the status of multiple hosts 
 - **Highlighted Issues**: ERROR, Exception, Error:, ⚠️ (warning emoji), WARNING, Warning:, DEBUG:
 - **Stack Trace Detection**: 
   - JavaScript stack traces: Lines matching `/^\s+at /` pattern
-  - C stack traces: Lines matching `/^\s+\d+\s+\w+\s+0x[0-9a-fA-F]+/` pattern (requires hex address to avoid false positives from git messages)
+  - C stack traces: Lines matching `/^\s+\d+\s+[^\s]+\s+0x[0-9a-fA-F]+/` pattern (allows periods, hyphens, and other valid characters in binary/library names, requires hex address to avoid false positives from git messages)
 - **All issues are counted** in the dashboard exception count
 
 #### Exception Detection in run.sh:

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.43";
+const VERSION = "1.0.44";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.43" rel="stylesheet">
+    <link href="./styles.css?v=1.0.44" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -88,14 +88,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.43"></script>
+    <script src="./dashboard.js?v=1.0.44"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.43')
+                navigator.serviceWorker.register('./sw.js?v=1.0.44')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/log-viewer.html
+++ b/docs/log-viewer.html
@@ -192,7 +192,8 @@
                 
                 // Check if this is a C stack trace line (starts with whitespace + number + hex address)
                 // Format: "    1 node             0x0000000104d3b2c4 ..."
-                const isCStackTraceLine = /^\s+\d+\s+\w+\s+0x[0-9a-fA-F]+/.test(line);
+                // Allow periods, hyphens, and other valid characters in binary/library names
+                const isCStackTraceLine = /^\s+\d+\s+[^\s]+\s+0x[0-9a-fA-F]+/.test(line);
                 
                 // Highlight different types of log messages
                 // Be specific to avoid false positives from training metrics that mention "Error:"

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.43
+// Version: 1.0.44
 
-const CACHE_NAME = 'grq-health-v1.0.43';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.43';
+const CACHE_NAME = 'grq-health-v1.0.44';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.44';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.43',
+  './dashboard.js?v=1.0.44',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=6
-VERSION="1.0.43"
+VERSION="1.0.44"
 
 # Parse command line arguments
 FORCE_UPDATE=false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Broaden C stack trace detection to accept non-whitespace binary/library names and bump version to 1.0.44 with related asset/cache references updated.
> 
> - **Log Viewer**:
>   - **C stack trace detection**: Update regex from `/^\s+\d+\s+\w+\s+0x[0-9a-fA-F]+/` to `/^\s+\d+\s+[^\s]+\s+0x[0-9a-fA-F]+/` in `docs/log-viewer.html` and document it in `README.md`.
> - **Version bump to `1.0.44`**:
>   - Update `VERSION` in `run.sh` and `docs/dashboard.js`.
>   - Refresh asset/query versions in `docs/index.html` (`styles.css`, `dashboard.js`, `sw.js`).
>   - Update service worker cache names and static file list in `docs/sw.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaee8496a69ea779983c59ee66ec422de1c2e24f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->