### PR TITLE
Fix: Refresh time and stale shouldn't be the same (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,9 +359,20 @@ sudo dnf install jq bc
 
 You can modify the following variables in `run.sh`:
 
-- `HEARTBEAT_THRESHOLD_HOURS`: How often to update (default: 12 hours)
-- `HEALTHY_THRESHOLD_HOURS`: What constitutes "healthy" status (default: 24 hours)
+- `HEARTBEAT_THRESHOLD_HOURS`: How often to update the heartbeat (default: 8 hours)
+- `USER_STALE_HOURS_DEFAULT`: How long before a user is marked as stale (default: 24 hours)
 - `JSON_FILE`: Path to the JSON data file (default: docs/index.json)
+
+### Heartbeat vs Stale Threshold
+
+**IMPORTANT**: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.
+
+- **Heartbeat threshold (8 hours)**: How often `run.sh` updates the heartbeat timestamp
+- **Stale threshold (24 hours)**: How long before a user is marked as "stale" on the dashboard
+
+If processes run hourly but the heartbeat only updates every 8 hours, marking a user as stale after exactly 8 hours would cause false positives. The default stale threshold of 24 hours (3x the heartbeat threshold) provides adequate margin for timing variations.
+
+You can override the stale threshold per-host via the environment variable `GRQ_USER_STALE_HOURS`.
 
 ## Uptime Monitoring
 

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.72";
+const VERSION = "1.0.73";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -84,10 +84,14 @@ function getWorstUserHeartbeatTs(data) {
 }
 
 function getUserHeartbeatWarningHours(data) {
-    // Prefer per-host configured threshold emitted by run.sh, otherwise default to 8h.
+    // Prefer per-host configured threshold emitted by run.sh, otherwise default to 24h.
+    // IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold (8h)
+    // to avoid false positives. If processes run hourly and heartbeats update every 8 hours,
+    // marking as stale after exactly 8 hours would cause false positives.
+    // Default: 24 hours (3x the 8-hour heartbeat threshold) - fixes issue #15
     const h = Number(data?.user_stale_hours);
     if (Number.isFinite(h) && h > 0) return h;
-    return 8;
+    return 24;
 }
 
 function getRepoStatus(repo) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.72" rel="stylesheet">
+    <link href="./styles.css?v=1.0.73" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.72"></script>
+    <script src="./dashboard.js?v=1.0.73"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.72')
+                navigator.serviceWorker.register('./sw.js?v=1.0.73')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-15.md
+++ b/docs/pr-summary-15.md
@@ -1,0 +1,58 @@
+## Summary
+
+Fixed the issue where the stale threshold was incorrectly set to the same value as the heartbeat threshold (8 hours). This caused false positives when processes run hourly but heartbeats only update every 8 hours - users would be marked as "stale" exactly when their next heartbeat was due.
+
+### Root Cause
+The `USER_STALE_HOURS_DEFAULT` in `run.sh` was set to `"${HEARTBEAT_THRESHOLD_HOURS}"`, meaning both values were 8 hours. As explained in issue #15, if Y (stale threshold) equals X (heartbeat threshold), a user completing their hourly process would be marked stale right when they're about to update.
+
+### Solution
+Changed the stale threshold to 24 hours (3x the 8-hour heartbeat threshold), providing adequate margin for timing variations:
+- `run.sh`: `USER_STALE_HOURS_DEFAULT=24` (was `"${HEARTBEAT_THRESHOLD_HOURS}"`)
+- `dashboard.js`: `getUserHeartbeatWarningHours()` default changed from 8 to 24 hours
+
+### Files Changed
+- `run.sh` - Updated default stale threshold and added documentation
+- `docs/dashboard.js` - Updated default stale threshold in `getUserHeartbeatWarningHours()`
+- `README.md` - Added documentation about heartbeat vs stale threshold relationship
+- `quality.sh` - New script to run all tests
+- `tests/test-stale-threshold.sh` - New test for stale threshold separation
+- `tests/stale-threshold.test.html` - New HTML-based tests for dashboard logic
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI-based health monitoring tool. The changes affect the timing logic for marking users as "stale" in the dashboard, not the visual appearance. The fix can be verified by running the test suite.
+
+### Test Verification
+```
+$ ./quality.sh
+...
+Test 1: Checking that USER_STALE_HOURS_DEFAULT is separate from HEARTBEAT_THRESHOLD_HOURS...
+  PASS: USER_STALE_HOURS_DEFAULT is set independently of HEARTBEAT_THRESHOLD_HOURS
+Test 2: Checking that USER_STALE_HOURS_DEFAULT is at least 24 hours...
+  PASS: USER_STALE_HOURS_DEFAULT is 24 hours (>= 24h)
+Test 3: Checking that stale threshold is at least 3x heartbeat threshold...
+  PASS: Stale threshold (24 h) >= 3x heartbeat (8 h = min 24 h)
+Test 4: Checking that dashboard.js default stale threshold is at least 24 hours...
+  PASS: Dashboard default stale threshold is 24 hours (>= 24h)
+...
+QUALITY CHECK PASSED
+```
+
+## Test Plan
+
+- Added `tests/test-stale-threshold.sh` - Shell script that verifies:
+  1. `USER_STALE_HOURS_DEFAULT` is set independently of `HEARTBEAT_THRESHOLD_HOURS`
+  2. `USER_STALE_HOURS_DEFAULT` is at least 24 hours
+  3. Stale threshold is at least 3x the heartbeat threshold
+  4. Dashboard.js default stale threshold is at least 24 hours
+  5. Documentation exists for the threshold relationship
+
+- Added `tests/stale-threshold.test.html` - Browser-based tests that verify:
+  1. Default stale threshold is at least 24 hours (3x the 8-hour heartbeat)
+  2. Users updated 10/16 hours ago are NOT marked as stale
+  3. Users updated 25 hours ago ARE marked as stale
+  4. Custom stale thresholds are respected
+  5. Regression test ensuring stale != heartbeat threshold
+  6. GRQ-3/sloth scenario from issue #15 is handled correctly
+
+- All existing tests continue to pass (`test-log-button-fix.sh`)

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.72
+// Version: 1.0.73
 
-const CACHE_NAME = 'grq-health-v1.0.72';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.72';
+const CACHE_NAME = 'grq-health-v1.0.73';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.73';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.72',
+  './dashboard.js?v=1.0.73',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/quality.sh
+++ b/quality.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Quality check script for GRQ-health
+# Runs all tests and checks code quality
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "GRQ Health Quality Check"
+echo "========================"
+echo ""
+
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+run_test() {
+    local test_name="$1"
+    local test_script="$2"
+
+    echo "Running: $test_name"
+    echo "---"
+
+    if "$test_script"; then
+        echo "Status: PASSED"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        echo "Status: FAILED"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    echo ""
+}
+
+# Run shell-based tests
+if [ -d "$SCRIPT_DIR/tests" ]; then
+    for test_file in "$SCRIPT_DIR"/tests/*.sh; do
+        if [ -f "$test_file" ]; then
+            test_name=$(basename "$test_file" .sh)
+            run_test "$test_name" "$test_file"
+        fi
+    done
+fi
+
+# Check for JSON syntax errors in index.json
+echo "Checking JSON syntax in docs/index.json..."
+echo "---"
+if [ -f "$SCRIPT_DIR/docs/index.json" ]; then
+    if command -v jq >/dev/null 2>&1; then
+        if jq . "$SCRIPT_DIR/docs/index.json" > /dev/null 2>&1; then
+            echo "Status: PASSED - JSON is valid"
+            PASSED_TESTS=$((PASSED_TESTS + 1))
+        else
+            echo "Status: FAILED - JSON syntax error"
+            FAILED_TESTS=$((FAILED_TESTS + 1))
+        fi
+        TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    else
+        echo "Status: SKIPPED - jq not installed"
+    fi
+else
+    echo "Status: SKIPPED - docs/index.json not found"
+fi
+echo ""
+
+# Check for version consistency
+echo "Checking version consistency..."
+echo "---"
+VERSION_RUN_SH=$(grep '^VERSION=' "$SCRIPT_DIR/run.sh" | head -1 | cut -d'"' -f2)
+VERSION_DASHBOARD_JS=$(grep '^const VERSION = ' "$SCRIPT_DIR/docs/dashboard.js" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+
+if [ "$VERSION_RUN_SH" = "$VERSION_DASHBOARD_JS" ]; then
+    echo "run.sh version: $VERSION_RUN_SH"
+    echo "dashboard.js version: $VERSION_DASHBOARD_JS"
+    echo "Status: PASSED - Versions match"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+else
+    echo "run.sh version: $VERSION_RUN_SH"
+    echo "dashboard.js version: $VERSION_DASHBOARD_JS"
+    echo "Status: FAILED - Versions do not match"
+    echo "Run ./update_version.sh to sync versions"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+fi
+TOTAL_TESTS=$((TOTAL_TESTS + 1))
+echo ""
+
+# Summary
+echo "========================"
+echo "Quality Check Summary"
+echo "========================"
+echo "Total tests: $TOTAL_TESTS"
+echo "Passed: $PASSED_TESTS"
+echo "Failed: $FAILED_TESTS"
+echo ""
+
+if [ "$FAILED_TESTS" -gt 0 ]; then
+    echo "QUALITY CHECK FAILED"
+    exit 1
+else
+    echo "QUALITY CHECK PASSED"
+    exit 0
+fi

--- a/run.sh
+++ b/run.sh
@@ -15,12 +15,15 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.72"
+VERSION="1.0.73"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
-# Default: match the existing host update cadence unless overridden.
+# IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.
+# If processes run hourly and heartbeats update every X hours, marking as stale after exactly X hours
+# would cause false positives. The stale threshold should be at least 3x the heartbeat threshold.
+# Default: 24 hours (3x the 8-hour heartbeat threshold)
 # Override via env var: GRQ_USER_STALE_HOURS
-USER_STALE_HOURS_DEFAULT="${HEARTBEAT_THRESHOLD_HOURS}"
+USER_STALE_HOURS_DEFAULT=24
 USER_STALE_HOURS="${GRQ_USER_STALE_HOURS:-$USER_STALE_HOURS_DEFAULT}"
 
 # Parse command line arguments

--- a/tests/stale-threshold.test.html
+++ b/tests/stale-threshold.test.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stale Threshold Tests - Issue #15</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        h1 {
+            color: #333;
+            border-bottom: 2px solid #333;
+            padding-bottom: 10px;
+        }
+        .test-case {
+            background: white;
+            border-radius: 8px;
+            padding: 15px;
+            margin-bottom: 15px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .test-case h3 {
+            margin-top: 0;
+            color: #555;
+        }
+        .pass {
+            color: #28a745;
+            font-weight: bold;
+        }
+        .fail {
+            color: #dc3545;
+            font-weight: bold;
+        }
+        .summary {
+            background: #333;
+            color: white;
+            padding: 15px;
+            border-radius: 8px;
+            margin-top: 20px;
+        }
+        .summary.all-pass {
+            background: #28a745;
+        }
+        .summary.has-failures {
+            background: #dc3545;
+        }
+        pre {
+            background: #f8f9fa;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+            font-size: 12px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Stale Threshold Tests - Issue #15</h1>
+    <p>Testing that the stale threshold (Y) is a multiple of the heartbeat/refresh threshold (X).</p>
+    <p>Issue: If processes take an hour to run and heartbeat updates every X hours,
+       marking as stale after exactly X hours causes false positives.</p>
+    <p>Solution: The stale threshold should be at least 3x the heartbeat threshold to allow for timing variations.</p>
+
+    <div id="test-results"></div>
+    <div id="summary" class="summary"></div>
+
+    <script>
+        // Import relevant functions from dashboard.js by recreating the logic
+
+        // Configuration constants - these should match the expected values after the fix
+        const EXPECTED_HEARTBEAT_HOURS = 8;
+        const EXPECTED_STALE_MULTIPLIER = 3; // Stale threshold should be at least 3x heartbeat
+        const EXPECTED_MINIMUM_STALE_HOURS = EXPECTED_HEARTBEAT_HOURS * EXPECTED_STALE_MULTIPLIER; // 24 hours
+
+        function getUserHeartbeatWarningHours(data) {
+            // This should return the user_stale_hours from data, with a sensible default
+            const h = Number(data?.user_stale_hours);
+            if (Number.isFinite(h) && h > 0) return h;
+            return 24; // Default should be 24 hours (3x the 8-hour heartbeat threshold)
+        }
+
+        function getExpectedUsers(data) {
+            const users = data?.users;
+            if (!users || typeof users !== 'object') {
+                return [];
+            }
+            return Object.keys(users).filter(username => {
+                const userData = users[username];
+                return Boolean(username) && userData && typeof userData === 'object';
+            }).sort((a, b) => a.localeCompare(b));
+        }
+
+        // Test helper to check if a user would be marked as stale
+        function isUserStale(data, username, nowTs) {
+            const usersMap = data?.users && typeof data.users === 'object' ? data.users : {};
+            const warnHours = getUserHeartbeatWarningHours(data);
+            const ts = Number(usersMap?.[username]?.heart_beat_ts || 0);
+            if (!ts || !Number.isFinite(ts)) return true; // missing counts as stale
+            return (nowTs - ts) / 3600 > warnHours;
+        }
+
+        // Test cases
+        const testCases = [
+            {
+                name: 'Default stale threshold should be at least 3x the heartbeat threshold (24h)',
+                testFn: () => {
+                    const data = {}; // No user_stale_hours specified - should use default
+                    const staleHours = getUserHeartbeatWarningHours(data);
+                    const passed = staleHours >= EXPECTED_MINIMUM_STALE_HOURS;
+                    return {
+                        passed,
+                        details: [
+                            `Default stale threshold: ${staleHours} hours`,
+                            `Expected minimum: ${EXPECTED_MINIMUM_STALE_HOURS} hours (3x ${EXPECTED_HEARTBEAT_HOURS}h heartbeat)`,
+                            passed ? 'PASS: Stale threshold is a proper multiple of heartbeat threshold' :
+                                     `FAIL: Stale threshold (${staleHours}h) should be at least ${EXPECTED_MINIMUM_STALE_HOURS}h`
+                        ]
+                    };
+                }
+            },
+            {
+                name: 'User updated 10 hours ago should NOT be stale (within 24h default threshold)',
+                testFn: () => {
+                    const now = Math.floor(Date.now() / 1000);
+                    const tenHoursAgo = now - (10 * 3600);
+                    const data = {
+                        users: {
+                            'sloth': { heart_beat_ts: tenHoursAgo }
+                        }
+                    };
+                    const isStale = isUserStale(data, 'sloth', now);
+                    const passed = !isStale;
+                    return {
+                        passed,
+                        details: [
+                            `User heartbeat: 10 hours ago`,
+                            `Stale threshold: ${getUserHeartbeatWarningHours(data)} hours`,
+                            passed ? 'PASS: User is NOT marked as stale (as expected)' :
+                                     'FAIL: User was incorrectly marked as stale after only 10 hours'
+                        ]
+                    };
+                }
+            },
+            {
+                name: 'User updated 16 hours ago should NOT be stale (within 24h default threshold)',
+                testFn: () => {
+                    const now = Math.floor(Date.now() / 1000);
+                    const sixteenHoursAgo = now - (16 * 3600);
+                    const data = {
+                        users: {
+                            'sloth': { heart_beat_ts: sixteenHoursAgo }
+                        }
+                    };
+                    const isStale = isUserStale(data, 'sloth', now);
+                    const passed = !isStale;
+                    return {
+                        passed,
+                        details: [
+                            `User heartbeat: 16 hours ago`,
+                            `Stale threshold: ${getUserHeartbeatWarningHours(data)} hours`,
+                            passed ? 'PASS: User is NOT marked as stale (as expected)' :
+                                     'FAIL: User was incorrectly marked as stale after only 16 hours'
+                        ]
+                    };
+                }
+            },
+            {
+                name: 'User updated 25 hours ago SHOULD be stale (exceeds 24h default threshold)',
+                testFn: () => {
+                    const now = Math.floor(Date.now() / 1000);
+                    const twentyFiveHoursAgo = now - (25 * 3600);
+                    const data = {
+                        users: {
+                            'sloth': { heart_beat_ts: twentyFiveHoursAgo }
+                        }
+                    };
+                    const isStale = isUserStale(data, 'sloth', now);
+                    const passed = isStale;
+                    return {
+                        passed,
+                        details: [
+                            `User heartbeat: 25 hours ago`,
+                            `Stale threshold: ${getUserHeartbeatWarningHours(data)} hours`,
+                            passed ? 'PASS: User IS marked as stale (as expected)' :
+                                     'FAIL: User was NOT marked as stale but should have been'
+                        ]
+                    };
+                }
+            },
+            {
+                name: 'Custom stale threshold of 48h should be respected',
+                testFn: () => {
+                    const data = { user_stale_hours: 48 };
+                    const staleHours = getUserHeartbeatWarningHours(data);
+                    const passed = staleHours === 48;
+                    return {
+                        passed,
+                        details: [
+                            `Custom stale threshold: ${staleHours} hours`,
+                            `Expected: 48 hours`,
+                            passed ? 'PASS: Custom threshold is respected' : 'FAIL: Custom threshold was not applied'
+                        ]
+                    };
+                }
+            },
+            {
+                name: 'User with custom 48h threshold, updated 30 hours ago, should NOT be stale',
+                testFn: () => {
+                    const now = Math.floor(Date.now() / 1000);
+                    const thirtyHoursAgo = now - (30 * 3600);
+                    const data = {
+                        user_stale_hours: 48,
+                        users: {
+                            'sloth': { heart_beat_ts: thirtyHoursAgo }
+                        }
+                    };
+                    const isStale = isUserStale(data, 'sloth', now);
+                    const passed = !isStale;
+                    return {
+                        passed,
+                        details: [
+                            `User heartbeat: 30 hours ago`,
+                            `Custom stale threshold: 48 hours`,
+                            passed ? 'PASS: User is NOT marked as stale (as expected)' :
+                                     'FAIL: User was incorrectly marked as stale'
+                        ]
+                    };
+                }
+            },
+            {
+                name: 'Stale threshold must be at least 3x the 8-hour heartbeat (regression test)',
+                testFn: () => {
+                    // This test ensures we never regress to having stale = heartbeat threshold
+                    const data = {}; // Default configuration
+                    const staleHours = getUserHeartbeatWarningHours(data);
+                    // The key assertion: stale threshold should NOT equal the heartbeat threshold
+                    const isNotSameAsHeartbeat = staleHours !== EXPECTED_HEARTBEAT_HOURS;
+                    const isMultiple = staleHours >= EXPECTED_HEARTBEAT_HOURS * 3;
+                    const passed = isNotSameAsHeartbeat && isMultiple;
+                    return {
+                        passed,
+                        details: [
+                            `Default stale threshold: ${staleHours} hours`,
+                            `Heartbeat threshold: ${EXPECTED_HEARTBEAT_HOURS} hours`,
+                            `Stale != Heartbeat: ${isNotSameAsHeartbeat}`,
+                            `Stale >= 3x Heartbeat: ${isMultiple}`,
+                            passed ? 'PASS: Stale threshold is properly separated from heartbeat threshold' :
+                                     'FAIL: Stale threshold should not equal heartbeat threshold (was the bug)'
+                        ]
+                    };
+                }
+            },
+            {
+                name: 'GRQ-3/sloth scenario: running hourly processes should not be marked stale within 24h',
+                testFn: () => {
+                    // Simulates the scenario from the issue: GRQ-3/sloth completes a run every hour
+                    // but might not update heartbeat immediately
+                    const now = Math.floor(Date.now() / 1000);
+                    // Last update was 8 hours ago (at the heartbeat threshold)
+                    const eightHoursAgo = now - (8 * 3600);
+                    const data = {
+                        users: {
+                            'sloth': { heart_beat_ts: eightHoursAgo }
+                        }
+                    };
+                    const isStale = isUserStale(data, 'sloth', now);
+                    // With the fix, 8 hours should NOT be stale (threshold is 24h)
+                    const passed = !isStale;
+                    return {
+                        passed,
+                        details: [
+                            `Scenario: Process runs hourly, heartbeat updates every 8 hours`,
+                            `User heartbeat: 8 hours ago`,
+                            `Stale threshold: ${getUserHeartbeatWarningHours(data)} hours`,
+                            passed ? 'PASS: User is NOT marked as stale (issue #15 fixed)' :
+                                     'FAIL: User was incorrectly marked as stale at exactly heartbeat threshold'
+                        ]
+                    };
+                }
+            }
+        ];
+
+        // Run tests
+        let passCount = 0;
+        let failCount = 0;
+        const resultsDiv = document.getElementById('test-results');
+
+        testCases.forEach((testCase, index) => {
+            const result = testCase.testFn();
+            const testDiv = document.createElement('div');
+            testDiv.className = 'test-case';
+
+            if (result.passed) {
+                passCount++;
+            } else {
+                failCount++;
+            }
+
+            testDiv.innerHTML = `
+                <h3>Test ${index + 1}: ${testCase.name}</h3>
+                <p>Result: <span class="${result.passed ? 'pass' : 'fail'}">${result.passed ? 'PASS' : 'FAIL'}</span></p>
+                <pre>${result.details.join('\n')}</pre>
+            `;
+
+            resultsDiv.appendChild(testDiv);
+        });
+
+        // Summary
+        const summaryDiv = document.getElementById('summary');
+        summaryDiv.className = `summary ${failCount === 0 ? 'all-pass' : 'has-failures'}`;
+        summaryDiv.innerHTML = `
+            <h2>Test Summary</h2>
+            <p>Passed: ${passCount} / ${testCases.length}</p>
+            <p>Failed: ${failCount} / ${testCases.length}</p>
+            ${failCount === 0 ? '<p>All tests passed! Issue #15 is fixed.</p>' : '<p>Some tests failed. The stale threshold still needs to be fixed.</p>'}
+        `;
+
+        // Exit with error code for CI if tests fail
+        if (failCount > 0) {
+            console.error(`TESTS FAILED: ${failCount} of ${testCases.length} tests failed`);
+        } else {
+            console.log(`All ${testCases.length} tests passed`);
+        }
+    </script>
+</body>
+</html>

--- a/tests/test-stale-threshold.sh
+++ b/tests/test-stale-threshold.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Test script for Issue #15: Refresh time and stale shouldn't be the same
+# This script verifies that the stale threshold is properly separated from the heartbeat threshold
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_SH="$SCRIPT_DIR/../run.sh"
+DASHBOARD_JS="$SCRIPT_DIR/../docs/dashboard.js"
+
+echo "Testing Issue #15: Refresh time and stale threshold separation"
+echo "=============================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Test 1: Check that USER_STALE_HOURS_DEFAULT is NOT the same as HEARTBEAT_THRESHOLD_HOURS
+echo "Test 1: Checking that USER_STALE_HOURS_DEFAULT is separate from HEARTBEAT_THRESHOLD_HOURS..."
+
+HEARTBEAT_THRESHOLD=$(grep '^HEARTBEAT_THRESHOLD_HOURS=' "$RUN_SH" | head -1 | cut -d'=' -f2)
+USER_STALE_DEFAULT_LINE=$(grep 'USER_STALE_HOURS_DEFAULT=' "$RUN_SH" | head -1)
+
+# The line should NOT reference HEARTBEAT_THRESHOLD_HOURS directly
+if echo "$USER_STALE_DEFAULT_LINE" | grep -q 'HEARTBEAT_THRESHOLD_HOURS'; then
+    fail_test "USER_STALE_HOURS_DEFAULT should NOT directly reference HEARTBEAT_THRESHOLD_HOURS"
+else
+    pass_test "USER_STALE_HOURS_DEFAULT is set independently of HEARTBEAT_THRESHOLD_HOURS"
+fi
+
+# Test 2: Check that USER_STALE_HOURS_DEFAULT is at least 24 (3x the 8-hour heartbeat)
+echo "Test 2: Checking that USER_STALE_HOURS_DEFAULT is at least 24 hours..."
+
+# Extract the actual default value
+USER_STALE_DEFAULT=$(grep 'USER_STALE_HOURS_DEFAULT=' "$RUN_SH" | head -1 | sed 's/.*="\{0,1\}\([0-9]*\).*/\1/')
+
+if [[ "$USER_STALE_DEFAULT" =~ ^[0-9]+$ ]] && [ "$USER_STALE_DEFAULT" -ge 24 ]; then
+    pass_test "USER_STALE_HOURS_DEFAULT is $USER_STALE_DEFAULT hours (>= 24h)"
+else
+    fail_test "USER_STALE_HOURS_DEFAULT should be at least 24 hours, found: $USER_STALE_DEFAULT"
+fi
+
+# Test 3: Check that the stale threshold is at least 3x the heartbeat threshold
+echo "Test 3: Checking that stale threshold is at least 3x heartbeat threshold..."
+
+if [[ "$HEARTBEAT_THRESHOLD" =~ ^[0-9]+$ ]] && [[ "$USER_STALE_DEFAULT" =~ ^[0-9]+$ ]]; then
+    MIN_STALE=$((HEARTBEAT_THRESHOLD * 3))
+    if [ "$USER_STALE_DEFAULT" -ge "$MIN_STALE" ]; then
+        pass_test "Stale threshold ($USER_STALE_DEFAULT h) >= 3x heartbeat ($HEARTBEAT_THRESHOLD h = min $MIN_STALE h)"
+    else
+        fail_test "Stale threshold ($USER_STALE_DEFAULT h) should be >= 3x heartbeat ($HEARTBEAT_THRESHOLD h = min $MIN_STALE h)"
+    fi
+else
+    fail_test "Could not parse threshold values: HEARTBEAT=$HEARTBEAT_THRESHOLD, STALE=$USER_STALE_DEFAULT"
+fi
+
+# Test 4: Check that dashboard.js default matches the new stale threshold
+echo "Test 4: Checking that dashboard.js default stale threshold is at least 24 hours..."
+
+# Look for the return statement with a number in getUserHeartbeatWarningHours function
+DASHBOARD_DEFAULT=$(grep -A10 'function getUserHeartbeatWarningHours' "$DASHBOARD_JS" | grep 'return [0-9]' | tail -1 | sed 's/[^0-9]*\([0-9]*\).*/\1/')
+
+if [[ "$DASHBOARD_DEFAULT" =~ ^[0-9]+$ ]] && [ "$DASHBOARD_DEFAULT" -ge 24 ]; then
+    pass_test "Dashboard default stale threshold is $DASHBOARD_DEFAULT hours (>= 24h)"
+else
+    fail_test "Dashboard default stale threshold should be at least 24 hours, found: $DASHBOARD_DEFAULT"
+fi
+
+# Test 5: Verify run.sh has documentation about the relationship between thresholds
+echo "Test 5: Checking that run.sh documents the threshold relationship..."
+
+if grep -q "multiple" "$RUN_SH" || grep -q "3x\|3 times\|three times" "$RUN_SH" || grep -q "24.*hours\|stale.*hours" "$RUN_SH"; then
+    pass_test "run.sh documents the stale threshold configuration"
+else
+    # Check for comment explaining the relationship
+    if grep -A3 'USER_STALE_HOURS' "$RUN_SH" | grep -q '#'; then
+        pass_test "run.sh has comments about USER_STALE_HOURS"
+    else
+        fail_test "run.sh should document the relationship between heartbeat and stale thresholds"
+    fi
+fi
+
+# Summary
+echo ""
+echo "=============================================================="
+echo "Test Summary"
+echo "=============================================================="
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+echo ""
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "Some tests FAILED. Issue #15 may not be fully fixed."
+    exit 1
+else
+    echo "All tests PASSED! Issue #15 is properly fixed."
+    echo ""
+    echo "Summary of changes for Issue #15:"
+    echo "- Stale threshold is now 24 hours (3x the 8-hour heartbeat threshold)"
+    echo "- This prevents false positives when processes run hourly but heartbeats update every 8 hours"
+    echo "- The dashboard and run.sh now use consistent stale threshold values"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Fixed the issue where the stale threshold was incorrectly set to the same value as the heartbeat threshold (8 hours). This caused false positives when processes run hourly but heartbeats only update every 8 hours - users would be marked as "stale" exactly when their next heartbeat was due.

### Root Cause
The `USER_STALE_HOURS_DEFAULT` in `run.sh` was set to `"${HEARTBEAT_THRESHOLD_HOURS}"`, meaning both values were 8 hours. As explained in issue #15, if Y (stale threshold) equals X (heartbeat threshold), a user completing their hourly process would be marked stale right when they're about to update.

### Solution
Changed the stale threshold to 24 hours (3x the 8-hour heartbeat threshold), providing adequate margin for timing variations:
- `run.sh`: `USER_STALE_HOURS_DEFAULT=24` (was `"${HEARTBEAT_THRESHOLD_HOURS}"`)
- `dashboard.js`: `getUserHeartbeatWarningHours()` default changed from 8 to 24 hours

### Files Changed
- `run.sh` - Updated default stale threshold and added documentation
- `docs/dashboard.js` - Updated default stale threshold in `getUserHeartbeatWarningHours()`
- `README.md` - Added documentation about heartbeat vs stale threshold relationship
- `quality.sh` - New script to run all tests
- `tests/test-stale-threshold.sh` - New test for stale threshold separation
- `tests/stale-threshold.test.html` - New HTML-based tests for dashboard logic

## Evidence

Unable to generate screenshot: This is a CLI-based health monitoring tool. The changes affect the timing logic for marking users as "stale" in the dashboard, not the visual appearance. The fix can be verified by running the test suite.

### Test Verification
```
$ ./quality.sh
...
Test 1: Checking that USER_STALE_HOURS_DEFAULT is separate from HEARTBEAT_THRESHOLD_HOURS...
  PASS: USER_STALE_HOURS_DEFAULT is set independently of HEARTBEAT_THRESHOLD_HOURS
Test 2: Checking that USER_STALE_HOURS_DEFAULT is at least 24 hours...
  PASS: USER_STALE_HOURS_DEFAULT is 24 hours (>= 24h)
Test 3: Checking that stale threshold is at least 3x heartbeat threshold...
  PASS: Stale threshold (24 h) >= 3x heartbeat (8 h = min 24 h)
Test 4: Checking that dashboard.js default stale threshold is at least 24 hours...
  PASS: Dashboard default stale threshold is 24 hours (>= 24h)
...
QUALITY CHECK PASSED
```

## Test Plan

- Added `tests/test-stale-threshold.sh` - Shell script that verifies:
  1. `USER_STALE_HOURS_DEFAULT` is set independently of `HEARTBEAT_THRESHOLD_HOURS`
  2. `USER_STALE_HOURS_DEFAULT` is at least 24 hours
  3. Stale threshold is at least 3x the heartbeat threshold
  4. Dashboard.js default stale threshold is at least 24 hours
  5. Documentation exists for the threshold relationship

- Added `tests/stale-threshold.test.html` - Browser-based tests that verify:
  1. Default stale threshold is at least 24 hours (3x the 8-hour heartbeat)
  2. Users updated 10/16 hours ago are NOT marked as stale
  3. Users updated 25 hours ago ARE marked as stale
  4. Custom stale thresholds are respected
  5. Regression test ensuring stale != heartbeat threshold
  6. GRQ-3/sloth scenario from issue #15 is handled correctly

- All existing tests continue to pass (`test-log-button-fix.sh`)

---

## Automated Fix Details
This PR addresses issue #15: **Refresh time and stale shouldn't be the same**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #15