### PR TITLE
Fix: We waste a lot of space in the log view (#18)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.74";
+const VERSION = "1.0.75";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.74" rel="stylesheet">
+    <link href="./styles.css?v=1.0.75" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.74"></script>
+    <script src="./dashboard.js?v=1.0.75"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.74')
+                navigator.serviceWorker.register('./sw.js?v=1.0.75')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/log-viewer.html
+++ b/docs/log-viewer.html
@@ -14,87 +14,91 @@
         .log-container {
             background-color: #1e1e1e;
             color: #d4d4d4;
-            border-radius: 8px;
-            padding: 20px;
-            margin: 80px 20px 20px 20px;
-            max-height: 95vh;
+            border-radius: 6px;
+            padding: 0;
+            margin: 45px 8px 8px 8px;
+            max-height: 97vh;
             overflow-y: auto;
             font-size: 12px;
-            line-height: 1.4;
+            line-height: 1.2;
             white-space: pre-wrap;
             word-wrap: break-word;
         }
         @media (max-width: 768px) {
             .log-container {
-                margin: 60px 5px 5px 5px;
-                max-height: 93vh;
+                margin: 40px 4px 4px 4px;
+                max-height: 96vh;
             }
             .log-content {
-                max-height: 88vh;
+                max-height: 92vh;
             }
         }
         .log-header {
             background-color: #2d2d2d;
             color: #ffffff;
-            padding: 8px 15px;
-            border-radius: 8px 8px 0 0;
+            padding: 6px 10px;
+            border-radius: 6px 6px 0 0;
             margin-bottom: 0;
-            font-size: 14px;
+            font-size: 13px;
         }
         .log-header .log-title {
             margin: 0;
             font-weight: 600;
-            font-size: 14px;
+            font-size: 13px;
         }
         .back-button {
             position: fixed;
-            top: 20px;
-            left: 20px;
+            top: 8px;
+            left: 8px;
             z-index: 1000;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+        }
+        .back-button .btn {
+            font-size: 12px;
+            padding: 4px 8px;
         }
         @media (max-width: 768px) {
             .back-button {
-                top: 10px;
-                left: 10px;
+                top: 6px;
+                left: 6px;
             }
             .back-button .btn {
-                font-size: 14px;
-                padding: 8px 12px;
+                font-size: 11px;
+                padding: 3px 6px;
             }
         }
         .log-content {
             background-color: #1e1e1e;
             color: #d4d4d4;
-            padding: 20px;
-            border-radius: 0 0 8px 8px;
+            padding: 8px 10px;
+            border-radius: 0 0 6px 6px;
             font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
             font-size: 12px;
-            line-height: 1.4;
+            line-height: 1.25;
             white-space: pre-wrap;
             word-wrap: break-word;
-            max-height: 85vh;
+            max-height: 92vh;
             overflow-y: auto;
         }
         .error-line {
             background-color: rgba(220, 53, 69, 0.1);
-            border-left: 3px solid #dc3545;
-            padding-left: 10px;
+            border-left: 2px solid #dc3545;
+            padding-left: 6px;
         }
         .stack-trace-line {
             background-color: rgba(220, 53, 69, 0.05);
-            padding-left: 10px;
+            padding-left: 6px;
             color: #ff9999;
         }
         .warning-line {
             background-color: rgba(255, 193, 7, 0.1);
-            border-left: 3px solid #ffc107;
-            padding-left: 10px;
+            border-left: 2px solid #ffc107;
+            padding-left: 6px;
         }
         .debug-line {
             background-color: rgba(13, 202, 240, 0.1);
-            border-left: 3px solid #0dcaf0;
-            padding-left: 10px;
+            border-left: 2px solid #0dcaf0;
+            padding-left: 6px;
         }
         .loading {
             text-align: center;

--- a/docs/pr-summary-18.md
+++ b/docs/pr-summary-18.md
@@ -1,0 +1,70 @@
+## Summary
+
+Reduced wasted space in the log viewer by optimising CSS padding, margins, and line spacing. This allows more log content to be visible without scrolling, making it easier to review log files.
+
+### Changes Made
+
+| Element | Before | After | Improvement |
+|---------|--------|-------|-------------|
+| `.log-container` padding | 20px | 0px | Removed unnecessary inner padding |
+| `.log-container` top margin | 80px | 45px | 44% reduction |
+| `.log-container` side margins | 20px | 8px | 60% reduction |
+| `.log-content` padding | 20px | 8px 10px | 60% reduction |
+| `.log-content` line-height | 1.4 | 1.25 | 11% reduction |
+| `.log-header` padding | 8px 15px | 6px 10px | 33% reduction |
+| `.back-button` size | 20px top/left | 8px top/left | 60% reduction |
+| Border radius | 8px | 6px | More compact appearance |
+| Border-left on highlighted lines | 3px | 2px | More subtle indicators |
+
+### Mobile Responsiveness
+
+The optimisations extend to mobile viewports (≤768px) with further reduced margins and padding to maximise screen real estate on smaller devices.
+
+## Evidence
+
+Unable to generate screenshot: Playwright MCP is not available in this environment. However, the space improvements can be verified by:
+
+1. Opening the log viewer at `/docs/log-viewer.html?file=GRQ-25/node.log`
+2. Comparing the visible log content area before and after this change
+3. Running the automated tests which verify the CSS values meet the compact thresholds
+
+### CSS Value Verification
+
+The shell test (`tests/test-log-viewer-space.sh`) verifies:
+- `.log-container` padding ≤ 10px ✓
+- `.log-container` top margin ≤ 50px ✓
+- `.log-container` side margins ≤ 10px ✓
+- `.log-content` padding ≤ 12px ✓
+- `.log-content` line-height ≤ 1.3 ✓
+- `.log-header` padding ≤ 8px ✓
+
+## Test Plan
+
+- Added `tests/log-viewer-space.test.html` - Browser-based visual test for space optimisation
+- Added `tests/test-log-viewer-space.sh` - Shell script test that verifies CSS values meet compact thresholds
+- All existing tests continue to pass
+
+### Test Results
+
+```
+Testing Issue #18: Log viewer space optimisation
+=================================================
+
+Test 1: Checking .log-container padding...
+  PASS: .log-container padding is 0px (≤ 10px)
+Test 2: Checking .log-container margin...
+  PASS: .log-container top margin is 45px (≤ 50px)
+Test 3: Checking .log-content padding...
+  PASS: .log-content padding is 6px (≤ 12px)
+Test 4: Checking .log-content line-height...
+  PASS: .log-content line-height is  1.25 (≤ 1.3)
+Test 5: Checking .log-header padding...
+  PASS: .log-header padding is 6px (≤ 8px)
+Test 6: Checking .log-container side margins...
+  PASS: .log-container side margin is 8px (≤ 10px)
+
+=================================================
+All tests passed!
+```
+
+Fixes #18

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.74
+// Version: 1.0.75
 
-const CACHE_NAME = 'grq-health-v1.0.74';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.74';
+const CACHE_NAME = 'grq-health-v1.0.75';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.75';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.74',
+  './dashboard.js?v=1.0.75',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.74"
+VERSION="1.0.75"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/log-viewer-space.test.html
+++ b/tests/log-viewer-space.test.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Log Viewer Space Optimisation Tests - Issue #18</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+        }
+        h1 {
+            color: white;
+            border-bottom: 2px solid white;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+        }
+        .test-case {
+            background: white;
+            border-radius: 8px;
+            padding: 15px;
+            margin-bottom: 15px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .test-case h3 {
+            margin-top: 0;
+            color: #555;
+        }
+        .pass {
+            color: #28a745;
+            font-weight: bold;
+        }
+        .fail {
+            color: #dc3545;
+            font-weight: bold;
+        }
+        .summary {
+            background: #333;
+            color: white;
+            padding: 15px;
+            border-radius: 8px;
+            margin-top: 20px;
+        }
+        .summary.all-pass {
+            background: #28a745;
+        }
+        .summary.has-failures {
+            background: #dc3545;
+        }
+        pre {
+            background: #f8f9fa;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+            font-size: 12px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 10px 0;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: left;
+        }
+        th {
+            background-color: #f4f4f4;
+        }
+        .comparison {
+            display: flex;
+            gap: 20px;
+        }
+        .comparison > div {
+            flex: 1;
+        }
+    </style>
+</head>
+<body>
+    <h1>Log Viewer Space Optimisation Tests - Issue #18</h1>
+    <p style="color: white;">Testing that the log viewer uses space efficiently without excessive padding and margins.</p>
+    <p style="color: white;">The log viewer should maximise the visible content area.</p>
+
+    <div id="test-results"></div>
+    <div id="summary" class="summary"></div>
+
+    <script>
+        // Expected CSS values for optimised space usage
+        const expectedValues = {
+            logContainer: {
+                padding: { max: 10 },         // Should be 10px or less (was 20px)
+                marginTop: { max: 50 },       // Should be 50px or less (was 80px)
+                marginSides: { max: 10 }      // Should be 10px or less (was 20px)
+            },
+            logContent: {
+                padding: { max: 12 },         // Should be 12px or less (was 20px)
+                lineHeight: { max: 1.3 }      // Should be 1.3 or less (was 1.4)
+            },
+            logHeader: {
+                padding: { max: 8 }           // Should be compact
+            }
+        };
+
+        // Parse CSS value to number (handles px, em, etc.)
+        function parseSize(value) {
+            if (typeof value === 'number') return value;
+            if (!value) return 0;
+            const num = parseFloat(value);
+            return isNaN(num) ? 0 : num;
+        }
+
+        // Fetch and parse the log-viewer.html CSS
+        async function fetchLogViewerCSS() {
+            try {
+                const response = await fetch('../docs/log-viewer.html');
+                const html = await response.text();
+
+                // Extract CSS from style tag
+                const styleMatch = html.match(/<style>([\s\S]*?)<\/style>/);
+                if (!styleMatch) {
+                    throw new Error('Could not find style tag');
+                }
+                return styleMatch[1];
+            } catch (error) {
+                console.error('Error fetching log-viewer.html:', error);
+                return null;
+            }
+        }
+
+        // Parse CSS rules to extract property values
+        function extractCSSValue(css, selector, property) {
+            // Create a regex to find the selector block
+            const selectorRegex = new RegExp(selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{([^}]+)\\}', 'g');
+            const match = selectorRegex.exec(css);
+
+            if (!match) return null;
+
+            const block = match[1];
+            // Find the property value
+            const propRegex = new RegExp(property.replace('-', '\\-') + '\\s*:\\s*([^;]+);?', 'i');
+            const propMatch = propRegex.exec(block);
+
+            return propMatch ? propMatch[1].trim() : null;
+        }
+
+        // Parse shorthand padding (e.g., "10px 15px" or "10px")
+        function parsePadding(value) {
+            if (!value) return { top: 0, right: 0, bottom: 0, left: 0 };
+
+            const parts = value.split(/\s+/).map(p => parseSize(p));
+
+            if (parts.length === 1) {
+                return { top: parts[0], right: parts[0], bottom: parts[0], left: parts[0] };
+            } else if (parts.length === 2) {
+                return { top: parts[0], right: parts[1], bottom: parts[0], left: parts[1] };
+            } else if (parts.length === 4) {
+                return { top: parts[0], right: parts[1], bottom: parts[2], left: parts[3] };
+            }
+
+            return { top: 0, right: 0, bottom: 0, left: 0 };
+        }
+
+        // Parse margin (e.g., "50px 10px 10px 10px" or "50px auto")
+        function parseMargin(value) {
+            if (!value) return { top: 0, right: 0, bottom: 0, left: 0 };
+
+            const parts = value.split(/\s+/).map(p => p === 'auto' ? 0 : parseSize(p));
+
+            if (parts.length === 1) {
+                return { top: parts[0], right: parts[0], bottom: parts[0], left: parts[0] };
+            } else if (parts.length === 2) {
+                return { top: parts[0], right: parts[1], bottom: parts[0], left: parts[1] };
+            } else if (parts.length === 4) {
+                return { top: parts[0], right: parts[1], bottom: parts[2], left: parts[3] };
+            }
+
+            return { top: 0, right: 0, bottom: 0, left: 0 };
+        }
+
+        // Run all tests
+        async function runTests() {
+            const css = await fetchLogViewerCSS();
+
+            if (!css) {
+                document.getElementById('test-results').innerHTML = `
+                    <div class="test-case">
+                        <h3>Error</h3>
+                        <p class="fail">Could not fetch log-viewer.html CSS</p>
+                    </div>
+                `;
+                document.getElementById('summary').className = 'summary has-failures';
+                document.getElementById('summary').innerHTML = '<h2>Tests Failed</h2><p>Could not load CSS to test.</p>';
+                return;
+            }
+
+            const testResults = [];
+
+            // Test 1: Log container padding
+            const logContainerPadding = extractCSSValue(css, '.log-container', 'padding');
+            const padding = parsePadding(logContainerPadding);
+            const maxPaddingValue = Math.max(padding.top, padding.right, padding.bottom, padding.left);
+            testResults.push({
+                name: 'Log container padding should be compact',
+                description: `Padding should be ${expectedValues.logContainer.padding.max}px or less`,
+                actual: logContainerPadding || 'not set',
+                expected: `≤ ${expectedValues.logContainer.padding.max}px`,
+                pass: maxPaddingValue <= expectedValues.logContainer.padding.max
+            });
+
+            // Test 2: Log container margin top
+            const logContainerMargin = extractCSSValue(css, '.log-container', 'margin');
+            const margin = parseMargin(logContainerMargin);
+            testResults.push({
+                name: 'Log container top margin should be reduced',
+                description: `Top margin should be ${expectedValues.logContainer.marginTop.max}px or less`,
+                actual: margin.top + 'px',
+                expected: `≤ ${expectedValues.logContainer.marginTop.max}px`,
+                pass: margin.top <= expectedValues.logContainer.marginTop.max
+            });
+
+            // Test 3: Log container side margins
+            const maxSideMargin = Math.max(margin.left, margin.right);
+            testResults.push({
+                name: 'Log container side margins should be compact',
+                description: `Side margins should be ${expectedValues.logContainer.marginSides.max}px or less`,
+                actual: maxSideMargin + 'px',
+                expected: `≤ ${expectedValues.logContainer.marginSides.max}px`,
+                pass: maxSideMargin <= expectedValues.logContainer.marginSides.max
+            });
+
+            // Test 4: Log content padding
+            const logContentPadding = extractCSSValue(css, '.log-content', 'padding');
+            const contentPadding = parsePadding(logContentPadding);
+            const maxContentPadding = Math.max(contentPadding.top, contentPadding.right, contentPadding.bottom, contentPadding.left);
+            testResults.push({
+                name: 'Log content padding should be compact',
+                description: `Content padding should be ${expectedValues.logContent.padding.max}px or less`,
+                actual: logContentPadding || 'not set',
+                expected: `≤ ${expectedValues.logContent.padding.max}px`,
+                pass: maxContentPadding <= expectedValues.logContent.padding.max
+            });
+
+            // Test 5: Line height
+            const lineHeight = extractCSSValue(css, '.log-content', 'line-height');
+            const lineHeightValue = parseFloat(lineHeight) || 1.4;
+            testResults.push({
+                name: 'Line height should be compact',
+                description: `Line height should be ${expectedValues.logContent.lineHeight.max} or less`,
+                actual: lineHeight || 'not set',
+                expected: `≤ ${expectedValues.logContent.lineHeight.max}`,
+                pass: lineHeightValue <= expectedValues.logContent.lineHeight.max
+            });
+
+            // Test 6: Log header padding
+            const logHeaderPadding = extractCSSValue(css, '.log-header', 'padding');
+            const headerPadding = parsePadding(logHeaderPadding);
+            const maxHeaderPadding = Math.max(headerPadding.top, headerPadding.right, headerPadding.bottom, headerPadding.left);
+            testResults.push({
+                name: 'Log header padding should be compact',
+                description: `Header padding should be ${expectedValues.logHeader.padding.max}px or less`,
+                actual: logHeaderPadding || 'not set',
+                expected: `≤ ${expectedValues.logHeader.padding.max}px`,
+                pass: maxHeaderPadding <= expectedValues.logHeader.padding.max
+            });
+
+            // Render results
+            const passCount = testResults.filter(t => t.pass).length;
+            const failCount = testResults.filter(t => !t.pass).length;
+
+            document.getElementById('test-results').innerHTML = testResults.map((test, index) => `
+                <div class="test-case">
+                    <h3>Test ${index + 1}: ${test.name}</h3>
+                    <p>${test.description}</p>
+                    <table>
+                        <tr>
+                            <th>Expected</th>
+                            <th>Actual</th>
+                            <th>Result</th>
+                        </tr>
+                        <tr>
+                            <td>${test.expected}</td>
+                            <td>${test.actual}</td>
+                            <td class="${test.pass ? 'pass' : 'fail'}">${test.pass ? 'PASS' : 'FAIL'}</td>
+                        </tr>
+                    </table>
+                </div>
+            `).join('');
+
+            const summaryDiv = document.getElementById('summary');
+            summaryDiv.className = `summary ${failCount === 0 ? 'all-pass' : 'has-failures'}`;
+            summaryDiv.innerHTML = `
+                <h2>Test Summary</h2>
+                <p>Passed: ${passCount} / ${testResults.length}</p>
+                <p>Failed: ${failCount} / ${testResults.length}</p>
+                ${failCount === 0
+                    ? '<p>All tests passed! The log viewer uses space efficiently.</p>'
+                    : '<p>Some tests failed. The log viewer has excessive padding/margins wasting space.</p>'}
+            `;
+        }
+
+        runTests();
+    </script>
+</body>
+</html>

--- a/tests/test-log-viewer-space.sh
+++ b/tests/test-log-viewer-space.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Test script for Issue #18: Log viewer space optimisation
+# This script verifies that the CSS changes reduce wasted space
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_VIEWER="$SCRIPT_DIR/../docs/log-viewer.html"
+
+echo "Testing Issue #18: Log viewer space optimisation"
+echo "================================================="
+echo ""
+
+# Test 1: Check that .log-container has reduced padding (10px or less)
+echo "Test 1: Checking .log-container padding..."
+PADDING=$(grep -A20 '\.log-container {' "$LOG_VIEWER" | grep 'padding:' | head -1 | sed 's/.*padding:\s*\([^;]*\).*/\1/')
+if [ -n "$PADDING" ]; then
+    # Extract the numeric value (first number in the padding)
+    PADDING_VALUE=$(echo "$PADDING" | grep -oE '[0-9]+' | head -1)
+    if [ "$PADDING_VALUE" -le 10 ]; then
+        echo "  PASS: .log-container padding is ${PADDING_VALUE}px (≤ 10px)"
+    else
+        echo "  FAIL: .log-container padding is ${PADDING_VALUE}px (should be ≤ 10px)"
+        exit 1
+    fi
+else
+    echo "  FAIL: Could not find .log-container padding"
+    exit 1
+fi
+
+# Test 2: Check that .log-container has reduced margin (top should be ≤ 50px)
+echo "Test 2: Checking .log-container margin..."
+MARGIN=$(grep -A20 '\.log-container {' "$LOG_VIEWER" | grep 'margin:' | head -1 | sed 's/.*margin:\s*\([^;]*\).*/\1/')
+if [ -n "$MARGIN" ]; then
+    # Extract the first number (top margin)
+    TOP_MARGIN=$(echo "$MARGIN" | grep -oE '[0-9]+' | head -1)
+    if [ "$TOP_MARGIN" -le 50 ]; then
+        echo "  PASS: .log-container top margin is ${TOP_MARGIN}px (≤ 50px)"
+    else
+        echo "  FAIL: .log-container top margin is ${TOP_MARGIN}px (should be ≤ 50px)"
+        exit 1
+    fi
+else
+    echo "  FAIL: Could not find .log-container margin"
+    exit 1
+fi
+
+# Test 3: Check that .log-content has reduced padding (12px or less)
+echo "Test 3: Checking .log-content padding..."
+CONTENT_PADDING=$(grep -A20 '\.log-content {' "$LOG_VIEWER" | grep 'padding:' | head -1 | sed 's/.*padding:\s*\([^;]*\).*/\1/')
+if [ -n "$CONTENT_PADDING" ]; then
+    # Extract the numeric value
+    CONTENT_PADDING_VALUE=$(echo "$CONTENT_PADDING" | grep -oE '[0-9]+' | head -1)
+    if [ "$CONTENT_PADDING_VALUE" -le 12 ]; then
+        echo "  PASS: .log-content padding is ${CONTENT_PADDING_VALUE}px (≤ 12px)"
+    else
+        echo "  FAIL: .log-content padding is ${CONTENT_PADDING_VALUE}px (should be ≤ 12px)"
+        exit 1
+    fi
+else
+    echo "  FAIL: Could not find .log-content padding"
+    exit 1
+fi
+
+# Test 4: Check that line-height is compact (1.3 or less)
+echo "Test 4: Checking .log-content line-height..."
+LINE_HEIGHT=$(grep -A20 '\.log-content {' "$LOG_VIEWER" | grep 'line-height:' | head -1 | sed 's/.*line-height:\s*\([^;]*\).*/\1/')
+if [ -n "$LINE_HEIGHT" ]; then
+    # Compare as integer after multiplying by 10 to handle decimals
+    LINE_HEIGHT_INT=$(echo "$LINE_HEIGHT" | awk '{printf "%.0f", $1 * 10}')
+    if [ "$LINE_HEIGHT_INT" -le 13 ]; then
+        echo "  PASS: .log-content line-height is ${LINE_HEIGHT} (≤ 1.3)"
+    else
+        echo "  FAIL: .log-content line-height is ${LINE_HEIGHT} (should be ≤ 1.3)"
+        exit 1
+    fi
+else
+    echo "  FAIL: Could not find .log-content line-height"
+    exit 1
+fi
+
+# Test 5: Check that .log-header padding is compact (8px or less)
+echo "Test 5: Checking .log-header padding..."
+HEADER_PADDING=$(grep -A20 '\.log-header {' "$LOG_VIEWER" | grep 'padding:' | head -1 | sed 's/.*padding:\s*\([^;]*\).*/\1/')
+if [ -n "$HEADER_PADDING" ]; then
+    # Extract the numeric value (first number)
+    HEADER_PADDING_VALUE=$(echo "$HEADER_PADDING" | grep -oE '[0-9]+' | head -1)
+    if [ "$HEADER_PADDING_VALUE" -le 8 ]; then
+        echo "  PASS: .log-header padding is ${HEADER_PADDING_VALUE}px (≤ 8px)"
+    else
+        echo "  FAIL: .log-header padding is ${HEADER_PADDING_VALUE}px (should be ≤ 8px)"
+        exit 1
+    fi
+else
+    echo "  FAIL: Could not find .log-header padding"
+    exit 1
+fi
+
+# Test 6: Check that side margins are compact (10px or less)
+echo "Test 6: Checking .log-container side margins..."
+# Extract all margin numbers
+MARGIN_VALUES=$(echo "$MARGIN" | grep -oE '[0-9]+')
+# Get the second value (right margin) or first if only one value
+SECOND_MARGIN=$(echo "$MARGIN_VALUES" | sed -n '2p')
+if [ -z "$SECOND_MARGIN" ]; then
+    SECOND_MARGIN=$(echo "$MARGIN_VALUES" | head -1)
+fi
+if [ "$SECOND_MARGIN" -le 10 ]; then
+    echo "  PASS: .log-container side margin is ${SECOND_MARGIN}px (≤ 10px)"
+else
+    echo "  FAIL: .log-container side margin is ${SECOND_MARGIN}px (should be ≤ 10px)"
+    exit 1
+fi
+
+echo ""
+echo "================================================="
+echo "All tests passed!"
+echo ""
+echo "Summary of fix for Issue #18:"
+echo "- Reduced .log-container padding from 20px to 10px or less"
+echo "- Reduced .log-container margins (top from 80px, sides from 20px)"
+echo "- Reduced .log-content padding from 20px to 12px or less"
+echo "- Reduced line-height from 1.4 to 1.3 or less"
+echo "- Reduced .log-header padding for compactness"
+echo "- More log content is now visible without scrolling"


### PR DESCRIPTION
## Summary

Reduced wasted space in the log viewer by optimising CSS padding, margins, and line spacing. This allows more log content to be visible without scrolling, making it easier to review log files.

### Changes Made

| Element | Before | After | Improvement |
|---------|--------|-------|-------------|
| `.log-container` padding | 20px | 0px | Removed unnecessary inner padding |
| `.log-container` top margin | 80px | 45px | 44% reduction |
| `.log-container` side margins | 20px | 8px | 60% reduction |
| `.log-content` padding | 20px | 8px 10px | 60% reduction |
| `.log-content` line-height | 1.4 | 1.25 | 11% reduction |
| `.log-header` padding | 8px 15px | 6px 10px | 33% reduction |
| `.back-button` size | 20px top/left | 8px top/left | 60% reduction |
| Border radius | 8px | 6px | More compact appearance |
| Border-left on highlighted lines | 3px | 2px | More subtle indicators |

### Mobile Responsiveness

The optimisations extend to mobile viewports (≤768px) with further reduced margins and padding to maximise screen real estate on smaller devices.

## Evidence

Unable to generate screenshot: Playwright MCP is not available in this environment. However, the space improvements can be verified by:

1. Opening the log viewer at `/docs/log-viewer.html?file=GRQ-25/node.log`
2. Comparing the visible log content area before and after this change
3. Running the automated tests which verify the CSS values meet the compact thresholds

### CSS Value Verification

The shell test (`tests/test-log-viewer-space.sh`) verifies:
- `.log-container` padding ≤ 10px ✓
- `.log-container` top margin ≤ 50px ✓
- `.log-container` side margins ≤ 10px ✓
- `.log-content` padding ≤ 12px ✓
- `.log-content` line-height ≤ 1.3 ✓
- `.log-header` padding ≤ 8px ✓

## Test Plan

- Added `tests/log-viewer-space.test.html` - Browser-based visual test for space optimisation
- Added `tests/test-log-viewer-space.sh` - Shell script test that verifies CSS values meet compact thresholds
- All existing tests continue to pass

### Test Results

```
Testing Issue #18: Log viewer space optimisation
=================================================

Test 1: Checking .log-container padding...
  PASS: .log-container padding is 0px (≤ 10px)
Test 2: Checking .log-container margin...
  PASS: .log-container top margin is 45px (≤ 50px)
Test 3: Checking .log-content padding...
  PASS: .log-content padding is 6px (≤ 12px)
Test 4: Checking .log-content line-height...
  PASS: .log-content line-height is  1.25 (≤ 1.3)
Test 5: Checking .log-header padding...
  PASS: .log-header padding is 6px (≤ 8px)
Test 6: Checking .log-container side margins...
  PASS: .log-container side margin is 8px (≤ 10px)

=================================================
All tests passed!
```

Fixes #18

---

## Automated Fix Details
This PR addresses issue #18: **We waste a lot of space in the log view**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #18