### PR TITLE
Fix: Add HTML escaping to prevent XSS in dashboard (#34)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.80";
+const VERSION = "1.0.81";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.80" rel="stylesheet">
+    <link href="./styles.css?v=1.0.81" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.80"></script>
+    <script src="./dashboard.js?v=1.0.81"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.80')
+                navigator.serviceWorker.register('./sw.js?v=1.0.81')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/log-viewer.html
+++ b/docs/log-viewer.html
@@ -164,7 +164,7 @@
                 
                 document.getElementById('logContainer').innerHTML = `
                     <div class="log-header">
-                        <div class="log-title"><i class="bi bi-file-text"></i> ${hostname}/node.log <small class="text-muted">• ${new Date().toLocaleString()}</small></div>
+                        <div class="log-title"><i class="bi bi-file-text"></i> ${escapeHtml(hostname)}/node.log <small class="text-muted">• ${new Date().toLocaleString()}</small></div>
                     </div>
                     <div class="log-content">${processedContent}</div>
                 `;
@@ -181,8 +181,8 @@
                     <div class="error">
                         <i class="bi bi-exclamation-triangle"></i>
                         <h4>Error Loading Log File</h4>
-                        <p>Failed to load log file: ${error.message}</p>
-                        <p>File path: ${filePath}</p>
+                        <p>Failed to load log file: ${escapeHtml(error.message)}</p>
+                        <p>File path: ${escapeHtml(filePath)}</p>
                     </div>
                 `;
             }
@@ -224,10 +224,14 @@
             }).join('');
         }
         
-        function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+        function escapeHtml(str) {
+            if (!str && str !== 0) return '';
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
         }
         
         function scrollToFirstIssue() {

--- a/docs/pr-summary-34.md
+++ b/docs/pr-summary-34.md
@@ -1,0 +1,27 @@
+## Summary
+
+Add HTML escaping to prevent XSS vulnerabilities across the dashboard, log viewer, and simple status page.
+
+**dashboard.js** already had an `escapeHtml()` function and used it consistently across all `innerHTML` assignments — no changes needed there.
+
+**log-viewer.html** had two XSS vulnerabilities:
+- Hostname extracted from URL parameter was interpolated into `innerHTML` without escaping (success path, line 167)
+- `error.message` and `filePath` were interpolated into `innerHTML` without escaping (error path, lines 184-185)
+- Also replaced the DOM-based `escapeHtml` (using `document.createElement`) with the same string-replacement approach used in `dashboard.js` for consistency
+
+**simple.html** had one XSS vulnerability:
+- `updateRepoSummary()` used `innerHTML` with unescaped repo names and error messages from `repos.json` (lines 311-315)
+- Added `escapeHtml()` function and applied it to all user-controlled data before HTML interpolation
+
+## Evidence
+
+This is a security fix with no visual changes. All changes are in JavaScript logic that escapes special characters (`<`, `>`, `&`, `"`, `'`) before interpolating data into HTML. The dashboard renders identically — only malicious payloads are neutralised.
+
+## Test Plan
+
+- `tests/test-escape-html.sh` — 8 tests verifying `escapeHtml()` function (pre-existing, all pass)
+- `tests/test-xss-prevention.sh` — 8 tests verifying `createHostCard()` and `renderRepoHealth()` escape XSS payloads in hostname, os_info, info, location, config_warning, dead host fields, zero handling, and repo names
+- `tests/test-xss-log-viewer.sh` — 2 tests verifying log-viewer escapes hostname in both success path (log header) and error path (error display)
+- `tests/test-xss-simple-html.sh` — 2 tests verifying simple.html escapes repo names and error messages in summary output
+
+All 16 quality checks pass via `./quality.sh`.

--- a/docs/simple.html
+++ b/docs/simple.html
@@ -46,6 +46,17 @@
     <div class="repo-summary" id="repoSummary"></div>
 
     <script>
+        // Escape HTML special characters to prevent XSS when interpolating into innerHTML
+        function escapeHtml(str) {
+            if (!str && str !== 0) return '';
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
         async function checkHealth() {
             try {
                 // Add timestamp to force fresh fetch and bypass cache
@@ -300,18 +311,18 @@
 
             const parts = [`${repoStats.healthy} good`];
             if (repoStats.warning > 0) {
-                const warningNames = repoStats.warningNames.join(', ');
+                const warningNames = repoStats.warningNames.map(escapeHtml).join(', ');
                 parts.push(`${repoStats.warning} warning${warningNames ? ` (${warningNames})` : ''}`);
             }
             if (repoStats.error > 0) {
-                const errorNames = repoStats.errorNames.join(', ');
+                const errorNames = repoStats.errorNames.map(escapeHtml).join(', ');
                 parts.push(`${repoStats.error} error${errorNames ? ` (${errorNames})` : ''}`);
             }
 
             summaryElement.innerHTML = `
-                Market feeds: ${parts.join(' • ')}
+                Market feeds: ${parts.join(' &bull; ')}
                 ${generatedAt ? `<small>Repo data updated ${formatRelativeTime(generatedAt)}</small>` : ''}
-                ${repoStats.errorMessages.length ? `<small>Issues: ${repoStats.errorMessages.join(' • ')}</small>` : ''}
+                ${repoStats.errorMessages.length ? `<small>Issues: ${repoStats.errorMessages.map(escapeHtml).join(' &bull; ')}</small>` : ''}
             `;
         }
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.80
+// Version: 1.0.81
 
-const CACHE_NAME = 'grq-health-v1.0.80';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.80';
+const CACHE_NAME = 'grq-health-v1.0.81';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.81';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.80',
+  './dashboard.js?v=1.0.81',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.80"
+VERSION="1.0.81"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/test-xss-log-viewer.sh
+++ b/tests/test-xss-log-viewer.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Test for Issue #34: XSS prevention in log-viewer.html
+# Verifies that hostname and filePath are escaped in innerHTML
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DENO="$HOME/.deno/bin/deno"
+LOG_VIEWER="$SCRIPT_DIR/../docs/log-viewer.html"
+
+echo "Testing Issue #34: XSS prevention in log-viewer.html"
+echo "===================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Extract the script block from log-viewer.html, stripping the tags
+extract_log_viewer_script() {
+    sed -n '/<script>/,/<\/script>/p' "$LOG_VIEWER" | sed '1d;$d'
+}
+
+# Test 1: Error path — hostname and error.message are escaped
+OUTPUT_ERROR=$(echo '
+const mockElements = {};
+globalThis.document = {
+    getElementById: function(id) {
+        if (!mockElements[id]) {
+            mockElements[id] = { innerHTML: "", textContent: "", className: "", style: { display: "" } };
+        }
+        return mockElements[id];
+    },
+    querySelector: function() { return null; },
+    title: ""
+};
+globalThis.window = { location: { search: "?file=./<script>alert(1)</script>/node.log" } };
+globalThis.navigator = { onLine: true };
+globalThis.setTimeout = function(fn) { fn(); };
+globalThis.fetch = function() {
+    return Promise.reject(new Error("<img src=x onerror=alert(2)>"));
+};
+' "$(extract_log_viewer_script)" '
+await new Promise(r => setTimeout(r, 100));
+const html = mockElements["logContainer"]?.innerHTML || "";
+const hasRawScript = html.includes("<script>alert(1)</script>");
+const hasRawImg = html.includes("<img src=x onerror=alert(2)>");
+if (hasRawScript || hasRawImg) {
+    console.log("TEST_RESULT:error-path-xss:FAIL:raw HTML in error output: " + (hasRawScript ? "script " : "") + (hasRawImg ? "img" : ""));
+} else {
+    console.log("TEST_RESULT:error-path-xss:PASS:error path output properly escaped");
+}
+' | "$DENO" run - 2>&1)
+
+# Test 2: Success path — hostname is escaped in log header
+OUTPUT_SUCCESS=$(echo '
+const mockElements = {};
+globalThis.document = {
+    getElementById: function(id) {
+        if (!mockElements[id]) {
+            mockElements[id] = { innerHTML: "", textContent: "", className: "", style: { display: "" } };
+        }
+        return mockElements[id];
+    },
+    querySelector: function() { return null; },
+    title: ""
+};
+globalThis.window = { location: { search: "?file=./<img>xss/node.log" } };
+globalThis.navigator = { onLine: true };
+const origSetTimeout = globalThis.setTimeout;
+globalThis.setTimeout = function(fn, ms) { origSetTimeout(fn, Math.min(ms || 0, 50)); };
+globalThis.fetch = function() {
+    return Promise.resolve({
+        ok: true,
+        text: function() { return Promise.resolve("Normal log line\nAnother line\n"); }
+    });
+};
+' "$(extract_log_viewer_script)" '
+await new Promise(r => origSetTimeout(r, 500));
+const html = mockElements["logContainer"]?.innerHTML || "";
+// hostname extracted from filePath is "<img>xss"
+const hasRawImg = html.includes("<img>xss");
+if (hasRawImg) {
+    console.log("TEST_RESULT:success-path-xss:FAIL:raw HTML tag in log header hostname");
+} else if (html.includes("&lt;img&gt;xss")) {
+    console.log("TEST_RESULT:success-path-xss:PASS:hostname escaped in log header");
+} else {
+    console.log("TEST_RESULT:success-path-xss:FAIL:escaped hostname not found in output");
+}
+' | "$DENO" run - 2>&1)
+
+# Parse results from both tests
+for OUTPUT in "$OUTPUT_ERROR" "$OUTPUT_SUCCESS"; do
+    while IFS= read -r line; do
+        case "$line" in
+            TEST_RESULT:*)
+                local_name="$(echo "$line" | cut -d: -f2)"
+                local_result="$(echo "$line" | cut -d: -f3)"
+                local_detail="$(echo "$line" | cut -d: -f4-)"
+                if [ "$local_result" = "PASS" ]; then
+                    pass_test "$local_name — $local_detail"
+                else
+                    fail_test "$local_name — $local_detail"
+                fi
+                ;;
+        esac
+    done <<< "$OUTPUT"
+done
+
+echo ""
+echo "===================================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test-xss-prevention.sh
+++ b/tests/test-xss-prevention.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+# Test for Issue #34: XSS prevention in dashboard HTML generation
+# Verifies that createHostCard and other HTML-generating functions
+# properly escape user-controlled data from JSON
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/extract-functions.sh"
+
+echo "Testing Issue #34: XSS prevention in HTML generation"
+echo "===================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# createHostCard (lines 661-943) is outside the default pure-function range
+# but it only generates HTML strings — no real DOM access needed.
+# Extract it separately and provide a minimal DOM mock.
+extract_card_function() {
+    sed -n '661,943p' "$SCRIPT_DIR/../docs/dashboard.js"
+}
+
+# renderRepoHealth (lines 306-380) uses document.getElementById
+# but we mock it. It's already within the pure range.
+
+run_js_test_with_card() {
+    local test_code="$1"
+    local functions
+    functions="$(extract_pure_functions)"
+    local card_fn
+    card_fn="$(extract_card_function)"
+
+    # Provide globals that are declared outside the pure-function range
+    local globals="let repoHealthData = { repos: [] };"
+
+    echo "${globals}
+${functions}
+${card_fn}
+${test_code}" | "$DENO" run -
+}
+
+OUTPUT=$(run_js_test_with_card '
+// Mock allHosts for createHostCard
+var allHosts = [];
+
+// Test 1: createHostCard escapes hostname with XSS payload
+{
+    const xssHostname = "<script>alert(1)</script>";
+    const data = {
+        heart_beat_ts: Math.floor(Date.now() / 1000),
+        os_info: "macOS",
+        os_version: "15.5",
+        uptime: 86400,
+        used_disk_percent: "30",
+        mem_usage_percent: "50",
+        cpu_load: "10%",
+        network_status: "connected",
+        timezone: "AEST"
+    };
+    const html = createHostCard(xssHostname, data);
+    // The raw <script> tag should NOT appear — it should be escaped
+    if (html.includes("<script>alert(1)</script>")) {
+        console.log("TEST_RESULT:hostname-xss:FAIL:raw script tag found in hostname");
+    } else if (html.includes("&lt;script&gt;")) {
+        console.log("TEST_RESULT:hostname-xss:PASS:hostname XSS payload properly escaped");
+    } else {
+        console.log("TEST_RESULT:hostname-xss:FAIL:hostname not found at all in output");
+    }
+}
+
+// Test 2: createHostCard escapes os_info with XSS payload
+{
+    const hostname = "safe-host";
+    const data = {
+        heart_beat_ts: Math.floor(Date.now() / 1000),
+        os_info: "<img src=x onerror=alert(1)>",
+        os_version: "15.5",
+        uptime: 86400,
+        used_disk_percent: "30",
+        mem_usage_percent: "50",
+        cpu_load: "10%",
+        network_status: "connected",
+        timezone: "AEST"
+    };
+    const html = createHostCard(hostname, data);
+    if (html.includes("<img src=x onerror=alert(1)>")) {
+        console.log("TEST_RESULT:osinfo-xss:FAIL:raw img tag found in os_info");
+    } else if (html.includes("&lt;img")) {
+        console.log("TEST_RESULT:osinfo-xss:PASS:os_info XSS payload properly escaped");
+    } else {
+        console.log("TEST_RESULT:osinfo-xss:FAIL:os_info not found at all in output");
+    }
+}
+
+// Test 3: createHostCard escapes info field with XSS payload
+{
+    const hostname = "safe-host";
+    const data = {
+        heart_beat_ts: Math.floor(Date.now() / 1000),
+        os_info: "macOS",
+        os_version: "15.5",
+        uptime: 86400,
+        used_disk_percent: "30",
+        mem_usage_percent: "50",
+        cpu_load: "10%",
+        network_status: "connected",
+        timezone: "AEST",
+        info: "<script>steal(cookies)</script>"
+    };
+    const html = createHostCard(hostname, data);
+    if (html.includes("<script>steal(cookies)</script>")) {
+        console.log("TEST_RESULT:info-xss:FAIL:raw script tag found in info field");
+    } else if (html.includes("&lt;script&gt;steal(cookies)&lt;/script&gt;")) {
+        console.log("TEST_RESULT:info-xss:PASS:info field XSS payload properly escaped");
+    } else {
+        console.log("TEST_RESULT:info-xss:FAIL:info field not found at all in output");
+    }
+}
+
+// Test 4: createHostCard escapes location with XSS payload
+{
+    const hostname = "safe-host";
+    const data = {
+        heart_beat_ts: Math.floor(Date.now() / 1000),
+        os_info: "macOS",
+        os_version: "15.5",
+        uptime: 86400,
+        used_disk_percent: "30",
+        mem_usage_percent: "50",
+        cpu_load: "10%",
+        network_status: "connected",
+        timezone: "AEST",
+        location: "\"onmouseover=\"alert(1)\""
+    };
+    const html = createHostCard(hostname, data);
+    if (html.includes("\"onmouseover=\"alert(1)\"")) {
+        console.log("TEST_RESULT:location-xss:FAIL:raw event handler found in location");
+    } else if (html.includes("&quot;onmouseover=&quot;alert(1)&quot;")) {
+        console.log("TEST_RESULT:location-xss:PASS:location XSS payload properly escaped");
+    } else {
+        console.log("TEST_RESULT:location-xss:FAIL:unexpected escaping: check location handling");
+    }
+}
+
+// Test 5: createHostCard escapes config_warning with XSS payload
+{
+    const hostname = "safe-host";
+    const data = {
+        heart_beat_ts: Math.floor(Date.now() / 1000),
+        os_info: "macOS",
+        os_version: "15.5",
+        uptime: 86400,
+        used_disk_percent: "30",
+        mem_usage_percent: "50",
+        cpu_load: "10%",
+        network_status: "connected",
+        timezone: "AEST",
+        config_warning: "<b onmouseover=alert(1)>hover me</b>"
+    };
+    const html = createHostCard(hostname, data);
+    if (html.includes("<b onmouseover=alert(1)>")) {
+        console.log("TEST_RESULT:config-warning-xss:FAIL:raw HTML found in config_warning");
+    } else if (html.includes("&lt;b onmouseover=alert(1)&gt;")) {
+        console.log("TEST_RESULT:config-warning-xss:PASS:config_warning XSS payload escaped");
+    } else {
+        console.log("TEST_RESULT:config-warning-xss:FAIL:config_warning content not found");
+    }
+}
+
+// Test 6: createHostCard escapes dead host fields
+{
+    const hostname = "<img src=x onerror=alert(1)>";
+    const data = {
+        death_date: "<script>alert(2)</script>",
+        location: "<b>xss</b>",
+        emoji: "💀",
+        os_info: "<iframe>",
+        info: "<script>alert(3)</script>"
+    };
+    const html = createHostCard(hostname, data);
+    const hasRawScript = html.includes("<script>alert");
+    const hasRawImg = html.includes("<img src=x onerror");
+    const hasRawIframe = html.includes("<iframe>");
+    if (hasRawScript || hasRawImg || hasRawIframe) {
+        console.log("TEST_RESULT:dead-host-xss:FAIL:raw HTML tags found in dead host card");
+    } else {
+        console.log("TEST_RESULT:dead-host-xss:PASS:dead host card fields properly escaped");
+    }
+}
+
+// Test 7: escapeHtml handles zero correctly (not treated as falsy)
+{
+    const result = escapeHtml(0);
+    if (result === "0") {
+        console.log("TEST_RESULT:zero-handling:PASS:zero is preserved, not treated as falsy");
+    } else {
+        console.log("TEST_RESULT:zero-handling:FAIL:expected 0, got " + result);
+    }
+}
+
+// Test 8: renderRepoHealth escapes repo name with XSS payload
+{
+    // Mock DOM elements needed by renderRepoHealth
+    const mockElements = {};
+    const origGetById = globalThis.document?.getElementById;
+    globalThis.document = {
+        getElementById: function(id) {
+            if (!mockElements[id]) {
+                mockElements[id] = {
+                    innerHTML: "",
+                    textContent: "",
+                    style: { display: "" }
+                };
+            }
+            return mockElements[id];
+        }
+    };
+
+    // Set up repoHealthData with XSS payload
+    repoHealthData = {
+        repos: [{
+            name: "<script>alert(1)</script>",
+            last_commit_ts: Math.floor(Date.now() / 1000) - 3600,
+            error_message: "<img src=x onerror=alert(2)>"
+        }]
+    };
+
+    renderRepoHealth();
+
+    const listHtml = mockElements["repoHealthList"]?.innerHTML || "";
+    const hasRawScript = listHtml.includes("<script>alert(1)</script>");
+    const hasRawImg = listHtml.includes("<img src=x onerror=alert(2)>");
+    if (hasRawScript || hasRawImg) {
+        console.log("TEST_RESULT:repo-name-xss:FAIL:raw HTML in repo health output");
+    } else if (listHtml.includes("&lt;script&gt;") && listHtml.includes("&lt;img")) {
+        console.log("TEST_RESULT:repo-name-xss:PASS:repo name and error_message escaped");
+    } else {
+        console.log("TEST_RESULT:repo-name-xss:FAIL:escaped content not found in output");
+    }
+}
+')
+
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*)
+            local_name="$(echo "$line" | cut -d: -f2)"
+            local_result="$(echo "$line" | cut -d: -f3)"
+            local_detail="$(echo "$line" | cut -d: -f4-)"
+            if [ "$local_result" = "PASS" ]; then
+                pass_test "$local_name — $local_detail"
+            else
+                fail_test "$local_name — $local_detail"
+            fi
+            ;;
+    esac
+done <<< "$OUTPUT"
+
+echo ""
+echo "===================================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test-xss-simple-html.sh
+++ b/tests/test-xss-simple-html.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Test for Issue #34: XSS prevention in simple.html
+# Verifies that repo summary output escapes user-controlled data
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DENO="$HOME/.deno/bin/deno"
+SIMPLE_HTML="$SCRIPT_DIR/../docs/simple.html"
+
+echo "Testing Issue #34: XSS prevention in simple.html"
+echo "===================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Extract only the function definitions from simple.html (not auto-executing code)
+# We extract all content between <script> and </script>, replacing auto-run calls with empty lines
+extract_simple_functions() {
+    sed -n '/<script>/,/<\/script>/p' "$SIMPLE_HTML" | \
+        sed '1d;$d' | \
+        sed 's/^[[:space:]]*checkHealth();//' | \
+        sed 's/^[[:space:]]*setInterval(checkHealth, 30000);//'
+}
+
+OUTPUT=$(echo "
+// Minimal DOM mock
+const mockElements = {};
+globalThis.document = {
+    getElementById: function(id) {
+        if (!mockElements[id]) {
+            mockElements[id] = {
+                innerHTML: '',
+                textContent: '',
+                className: '',
+                style: { display: '' }
+            };
+        }
+        return mockElements[id];
+    }
+};
+globalThis.window = { location: { search: '' } };
+globalThis.navigator = { onLine: true };
+
+// Extract and run the simple.html functions
+$(extract_simple_functions)
+
+// Test 1: updateRepoSummary escapes repo names with XSS payload
+{
+    const repoStats = {
+        total: 2,
+        healthy: 1,
+        warning: 0,
+        error: 1,
+        warningNames: [],
+        errorNames: ['<script>alert(1)</script>'],
+        errorMessages: ['<script>alert(1)</script>: <img src=x onerror=alert(2)>']
+    };
+    updateRepoSummary(repoStats, null);
+    const html = mockElements['repoSummary']?.innerHTML || '';
+    const hasRawScript = html.includes('<script>alert(1)</script>');
+    const hasRawImg = html.includes('<img src=x onerror=alert(2)>');
+    if (hasRawScript || hasRawImg) {
+        console.log('TEST_RESULT:simple-repo-xss:FAIL:raw HTML found in repo summary: ' + (hasRawScript ? 'script ' : '') + (hasRawImg ? 'img' : ''));
+    } else {
+        console.log('TEST_RESULT:simple-repo-xss:PASS:repo names and error messages properly escaped');
+    }
+}
+
+// Test 2: updateRepoSummary escapes warning names with XSS payload
+{
+    // Reset mock
+    mockElements['repoSummary'] = { innerHTML: '', textContent: '', className: '', style: { display: '' } };
+    const repoStats = {
+        total: 1,
+        healthy: 0,
+        warning: 1,
+        error: 0,
+        warningNames: ['<b onmouseover=alert(1)>xss</b>'],
+        errorNames: [],
+        errorMessages: []
+    };
+    updateRepoSummary(repoStats, Math.floor(Date.now() / 1000));
+    const html = mockElements['repoSummary']?.innerHTML || '';
+    const hasRawHtml = html.includes('<b onmouseover=alert(1)>');
+    if (hasRawHtml) {
+        console.log('TEST_RESULT:simple-warning-xss:FAIL:raw HTML found in warning names');
+    } else {
+        console.log('TEST_RESULT:simple-warning-xss:PASS:warning names properly escaped');
+    }
+}
+" | "$DENO" run - 2>&1)
+
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*)
+            local_name="$(echo "$line" | cut -d: -f2)"
+            local_result="$(echo "$line" | cut -d: -f3)"
+            local_detail="$(echo "$line" | cut -d: -f4-)"
+            if [ "$local_result" = "PASS" ]; then
+                pass_test "$local_name — $local_detail"
+            else
+                fail_test "$local_name — $local_detail"
+            fi
+            ;;
+    esac
+done <<< "$OUTPUT"
+
+echo ""
+echo "===================================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Add HTML escaping to prevent XSS vulnerabilities across the dashboard, log viewer, and simple status page.

**dashboard.js** already had an `escapeHtml()` function and used it consistently across all `innerHTML` assignments — no changes needed there.

**log-viewer.html** had two XSS vulnerabilities:
- Hostname extracted from URL parameter was interpolated into `innerHTML` without escaping (success path, line 167)
- `error.message` and `filePath` were interpolated into `innerHTML` without escaping (error path, lines 184-185)
- Also replaced the DOM-based `escapeHtml` (using `document.createElement`) with the same string-replacement approach used in `dashboard.js` for consistency

**simple.html** had one XSS vulnerability:
- `updateRepoSummary()` used `innerHTML` with unescaped repo names and error messages from `repos.json` (lines 311-315)
- Added `escapeHtml()` function and applied it to all user-controlled data before HTML interpolation

## Evidence

This is a security fix with no visual changes. All changes are in JavaScript logic that escapes special characters (`<`, `>`, `&`, `"`, `'`) before interpolating data into HTML. The dashboard renders identically — only malicious payloads are neutralised.

## Test Plan

- `tests/test-escape-html.sh` — 8 tests verifying `escapeHtml()` function (pre-existing, all pass)
- `tests/test-xss-prevention.sh` — 8 tests verifying `createHostCard()` and `renderRepoHealth()` escape XSS payloads in hostname, os_info, info, location, config_warning, dead host fields, zero handling, and repo names
- `tests/test-xss-log-viewer.sh` — 2 tests verifying log-viewer escapes hostname in both success path (log header) and error path (error display)
- `tests/test-xss-simple-html.sh` — 2 tests verifying simple.html escapes repo names and error messages in summary output

All 16 quality checks pass via `./quality.sh`.

> **Screenshot evidence not provided**: This appears to be a UI-related change but no screenshots were included. For UI changes, use Playwright MCP to capture screenshots as evidence: `browser_navigate` to open a relevant URL, then `browser_take_screenshot` to save to `docs/evidence/`.

---

## Automated Fix Details
This PR addresses issue #34: **Add HTML escaping to prevent XSS in dashboard**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #34