### PR TITLE
Fix: Extract magic numbers into named constants in dashboard.js (#35)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.81";
+const VERSION = "1.0.82";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -30,8 +30,10 @@ const THRESHOLDS = {
     IDLE_LOAD_1M: 15,         // 1-minute load average threshold for idle detection (%)
     IDLE_LOAD_5M: 15,         // 5-minute load average threshold for idle detection (%)
     IDLE_LOAD_15M: 20,        // 15-minute load average threshold for idle detection (%)
+    IDLE_HIGH_LOAD: 50,       // Load above this indicates active work (recently started/stopped)
     DISK_WARNING_PERCENT: 75, // Disk usage above this triggers a warning
     HEARTBEAT_CRITICAL_HOURS: 24, // Hours without heartbeat before marking host critical
+    USER_STALE_DEFAULT_HOURS: 24, // Default hours before a user is marked stale (3x the 8h heartbeat threshold)
     MACOS_MIN_VERSION: '14.0',    // macOS versions below this trigger a warning
     UBUNTU_MIN_VERSION: '22.04'   // Ubuntu versions below this trigger a warning
 };
@@ -114,7 +116,7 @@ function getUserHeartbeatWarningHours(data) {
     // Default: 24 hours (3x the 8-hour heartbeat threshold) - fixes issue #15
     const h = Number(data?.user_stale_hours);
     if (Number.isFinite(h) && h > 0) return h;
-    return 24;
+    return THRESHOLDS.USER_STALE_DEFAULT_HOURS;
 }
 
 // Get list of stale users with their heartbeat information - Issue #22
@@ -219,14 +221,14 @@ function getIdleWorkerStatus(data) {
 
     // Check for recently stopped work - 15m is higher than current (1m/5m)
     // This is informational, not a warning - work may have just finished
-    if (load15m > 50 && load1m < 15 && load5m < 20) {
+    if (load15m > THRESHOLDS.IDLE_HIGH_LOAD && load1m < THRESHOLDS.IDLE_LOAD_1M && load5m < THRESHOLDS.IDLE_LOAD_15M) {
         // Work appears to have finished recently - not idle, just completed work
         return result;
     }
 
     // Check for recently started work - 1m/5m are higher than 15m
     // This is informational - work may have just started
-    if (load1m > 50 && load15m < 20) {
+    if (load1m > THRESHOLDS.IDLE_HIGH_LOAD && load15m < THRESHOLDS.IDLE_LOAD_15M) {
         // Work appears to have just started - not idle
         return result;
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.81" rel="stylesheet">
+    <link href="./styles.css?v=1.0.82" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.81"></script>
+    <script src="./dashboard.js?v=1.0.82"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.81')
+                navigator.serviceWorker.register('./sw.js?v=1.0.82')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-35.md
+++ b/docs/pr-summary-35.md
@@ -1,0 +1,26 @@
+## Summary
+
+Extract remaining magic numbers into the `THRESHOLDS` named constants object in `dashboard.js` (Issue #35).
+
+The `THRESHOLDS` object already existed with 8 keys but several hardcoded values remained scattered through the code. This PR:
+
+- Added `USER_STALE_DEFAULT_HOURS: 24` — replaces the hardcoded `24` in `getUserHeartbeatWarningHours()` (the default hours before a user is marked stale)
+- Added `IDLE_HIGH_LOAD: 50` — replaces the hardcoded `50` in `getIdleWorkerStatus()` (load above which indicates active work for recently-started/stopped detection)
+- Replaced hardcoded `15` and `20` in the "recently stopped/started work" checks with `THRESHOLDS.IDLE_LOAD_1M` and `THRESHOLDS.IDLE_LOAD_15M`
+- Updated `extract-functions.sh` line range from 27-659 to 27-661 and `test-xss-prevention.sh` line range from 661-943 to 663-945 to account for the 2 new lines in THRESHOLDS
+- Bumped version from 1.0.81 to 1.0.82
+
+## Evidence
+
+This is a backend/logic-only change with no visual impact. All 16 quality gate tests pass, including 13 threshold-specific tests.
+
+## Test Plan
+
+- Extended `tests/test-thresholds-constants.sh` with 5 new tests (Tests 9-13):
+  - **new-keys-exist**: Verifies `USER_STALE_DEFAULT_HOURS` and `IDLE_HIGH_LOAD` are present in THRESHOLDS
+  - **sensible-values**: Updated to validate all 10 threshold keys (was 8)
+  - **user-stale-default**: Verifies `getUserHeartbeatWarningHours({})` returns `THRESHOLDS.USER_STALE_DEFAULT_HOURS`
+  - **recently-stopped-work**: Verifies high 15m load with low 1m/5m is not flagged idle (uses IDLE_HIGH_LOAD)
+  - **recently-started-work**: Verifies high 1m load with low 15m is not flagged idle (uses IDLE_HIGH_LOAD)
+  - **ubuntu-min-version**: Verifies Ubuntu below `THRESHOLDS.UBUNTU_MIN_VERSION` triggers warning
+- All existing tests continue to pass unchanged

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.81
+// Version: 1.0.82
 
-const CACHE_NAME = 'grq-health-v1.0.81';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.81';
+const CACHE_NAME = 'grq-health-v1.0.82';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.82';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.81',
+  './dashboard.js?v=1.0.82',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.81"
+VERSION="1.0.82"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/extract-functions.sh
+++ b/tests/extract-functions.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 # Extract pure functions from dashboard.js for unit testing
-# Pure functions are lines 27-659 (no DOM dependencies)
+# Pure functions are lines 27-661 (no DOM dependencies)
 # Usage: source this file, then call run_js_test 'your JS test code'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DASHBOARD_JS="$SCRIPT_DIR/../docs/dashboard.js"
 DENO="$HOME/.deno/bin/deno"
 
-# Extract pure functions (lines 27-659) from dashboard.js
+# Extract pure functions (lines 27-661) from dashboard.js
 extract_pure_functions() {
-    sed -n '27,659p' "$DASHBOARD_JS"
+    sed -n '27,661p' "$DASHBOARD_JS"
 }
 
 # Run a JS test using deno

--- a/tests/test-thresholds-constants.sh
+++ b/tests/test-thresholds-constants.sh
@@ -120,7 +120,8 @@ OUTPUT=$(run_js_test '
 // Test 8: THRESHOLDS values are sensible numbers/strings
 {
     const numericKeys = ["IDLE_MIN_CORES", "IDLE_LOAD_1M", "IDLE_LOAD_5M", "IDLE_LOAD_15M",
-                         "DISK_WARNING_PERCENT", "HEARTBEAT_CRITICAL_HOURS"];
+                         "DISK_WARNING_PERCENT", "HEARTBEAT_CRITICAL_HOURS",
+                         "USER_STALE_DEFAULT_HOURS", "IDLE_HIGH_LOAD"];
     const badValues = numericKeys.filter(k => typeof THRESHOLDS[k] !== "number" || THRESHOLDS[k] <= 0);
     const stringKeys = ["MACOS_MIN_VERSION", "UBUNTU_MIN_VERSION"];
     const badStrings = stringKeys.filter(k => typeof THRESHOLDS[k] !== "string" || THRESHOLDS[k].length === 0);
@@ -129,6 +130,69 @@ OUTPUT=$(run_js_test '
         console.log("TEST_RESULT:sensible-values:PASS:all threshold values are sensible");
     } else {
         console.log("TEST_RESULT:sensible-values:FAIL:bad threshold values: " + allBad.join(", "));
+    }
+}
+
+// Test 9: USER_STALE_DEFAULT_HOURS and IDLE_HIGH_LOAD exist
+{
+    const newKeys = ["USER_STALE_DEFAULT_HOURS", "IDLE_HIGH_LOAD"];
+    const missing = newKeys.filter(k => THRESHOLDS[k] === undefined);
+    if (missing.length === 0) {
+        console.log("TEST_RESULT:new-keys-exist:PASS:USER_STALE_DEFAULT_HOURS and IDLE_HIGH_LOAD present");
+    } else {
+        console.log("TEST_RESULT:new-keys-exist:FAIL:missing keys: " + missing.join(", "));
+    }
+}
+
+// Test 10: getUserHeartbeatWarningHours returns THRESHOLDS.USER_STALE_DEFAULT_HOURS when no per-host value
+{
+    const result = getUserHeartbeatWarningHours({});
+    if (result === THRESHOLDS.USER_STALE_DEFAULT_HOURS) {
+        console.log("TEST_RESULT:user-stale-default:PASS:default stale hours matches THRESHOLDS constant (" + result + ")");
+    } else {
+        console.log("TEST_RESULT:user-stale-default:FAIL:expected " + THRESHOLDS.USER_STALE_DEFAULT_HOURS + ", got " + result);
+    }
+}
+
+// Test 11: getIdleWorkerStatus uses IDLE_HIGH_LOAD for recently-stopped-work detection
+// When 15m load is above IDLE_HIGH_LOAD and 1m/5m are low, machine is NOT flagged idle
+{
+    const data = {
+        load_averages: (THRESHOLDS.IDLE_LOAD_1M - 2) + "% (1m), " + (THRESHOLDS.IDLE_LOAD_15M - 2) + "% (5m), " + (THRESHOLDS.IDLE_HIGH_LOAD + 5) + "% (15m)",
+        cpu_cores: String(THRESHOLDS.IDLE_MIN_CORES + 4)
+    };
+    const result = getIdleWorkerStatus(data);
+    if (!result.isIdle) {
+        console.log("TEST_RESULT:recently-stopped-work:PASS:high 15m with low 1m/5m not flagged idle");
+    } else {
+        console.log("TEST_RESULT:recently-stopped-work:FAIL:should not flag idle when work recently stopped");
+    }
+}
+
+// Test 12: getIdleWorkerStatus uses IDLE_HIGH_LOAD for recently-started-work detection
+// When 1m load is above IDLE_HIGH_LOAD and 15m is low, machine is NOT flagged idle
+{
+    const data = {
+        load_averages: (THRESHOLDS.IDLE_HIGH_LOAD + 5) + "% (1m), " + (THRESHOLDS.IDLE_LOAD_5M - 2) + "% (5m), " + (THRESHOLDS.IDLE_LOAD_15M - 2) + "% (15m)",
+        cpu_cores: String(THRESHOLDS.IDLE_MIN_CORES + 4)
+    };
+    const result = getIdleWorkerStatus(data);
+    if (!result.isIdle) {
+        console.log("TEST_RESULT:recently-started-work:PASS:high 1m with low 15m not flagged idle");
+    } else {
+        console.log("TEST_RESULT:recently-started-work:FAIL:should not flag idle when work recently started");
+    }
+}
+
+// Test 13: Ubuntu version below THRESHOLDS.UBUNTU_MIN_VERSION triggers warning
+{
+    const now = Math.floor(Date.now() / 1000);
+    const data = { heart_beat_ts: now, os_info: "Ubuntu", os_version: "20.04" };
+    const status = getHealthStatus("test-ubuntu", data);
+    if (status === "warning") {
+        console.log("TEST_RESULT:ubuntu-min-version:PASS:Ubuntu below min version triggers warning");
+    } else {
+        console.log("TEST_RESULT:ubuntu-min-version:FAIL:expected warning, got " + status);
     }
 }
 ')

--- a/tests/test-xss-prevention.sh
+++ b/tests/test-xss-prevention.sh
@@ -25,11 +25,11 @@ fail_test() {
     FAIL_COUNT=$((FAIL_COUNT + 1))
 }
 
-# createHostCard (lines 661-943) is outside the default pure-function range
+# createHostCard (lines 663-945) is outside the default pure-function range
 # but it only generates HTML strings — no real DOM access needed.
 # Extract it separately and provide a minimal DOM mock.
 extract_card_function() {
-    sed -n '661,943p' "$SCRIPT_DIR/../docs/dashboard.js"
+    sed -n '663,945p' "$SCRIPT_DIR/../docs/dashboard.js"
 }
 
 # renderRepoHealth (lines 306-380) uses document.getElementById


### PR DESCRIPTION
## Summary

Extract remaining magic numbers into the `THRESHOLDS` named constants object in `dashboard.js` (Issue #35).

The `THRESHOLDS` object already existed with 8 keys but several hardcoded values remained scattered through the code. This PR:

- Added `USER_STALE_DEFAULT_HOURS: 24` — replaces the hardcoded `24` in `getUserHeartbeatWarningHours()` (the default hours before a user is marked stale)
- Added `IDLE_HIGH_LOAD: 50` — replaces the hardcoded `50` in `getIdleWorkerStatus()` (load above which indicates active work for recently-started/stopped detection)
- Replaced hardcoded `15` and `20` in the "recently stopped/started work" checks with `THRESHOLDS.IDLE_LOAD_1M` and `THRESHOLDS.IDLE_LOAD_15M`
- Updated `extract-functions.sh` line range from 27-659 to 27-661 and `test-xss-prevention.sh` line range from 661-943 to 663-945 to account for the 2 new lines in THRESHOLDS
- Bumped version from 1.0.81 to 1.0.82

## Evidence

This is a backend/logic-only change with no visual impact. All 16 quality gate tests pass, including 13 threshold-specific tests.

## Test Plan

- Extended `tests/test-thresholds-constants.sh` with 5 new tests (Tests 9-13):
  - **new-keys-exist**: Verifies `USER_STALE_DEFAULT_HOURS` and `IDLE_HIGH_LOAD` are present in THRESHOLDS
  - **sensible-values**: Updated to validate all 10 threshold keys (was 8)
  - **user-stale-default**: Verifies `getUserHeartbeatWarningHours({})` returns `THRESHOLDS.USER_STALE_DEFAULT_HOURS`
  - **recently-stopped-work**: Verifies high 15m load with low 1m/5m is not flagged idle (uses IDLE_HIGH_LOAD)
  - **recently-started-work**: Verifies high 1m load with low 15m is not flagged idle (uses IDLE_HIGH_LOAD)
  - **ubuntu-min-version**: Verifies Ubuntu below `THRESHOLDS.UBUNTU_MIN_VERSION` triggers warning
- All existing tests continue to pass unchanged

> **Screenshot evidence not provided**: This appears to be a UI-related change but no screenshots were included. For UI changes, use Playwright MCP to capture screenshots as evidence: `browser_navigate` to open a relevant URL, then `browser_take_screenshot` to save to `docs/evidence/`.

---

## Automated Fix Details
This PR addresses issue #35: **Extract magic numbers into named constants in dashboard.js**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #35