### PR TITLE
Add weekend grace period to repo commit staleness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ The dashboard calculates status from `last_commit_ts`:
 
 **Per-repo thresholds**: Each repo can optionally specify `warning_days` and `error_days` to customise the thresholds. If not specified, defaults to 1 day (warning) and 2 days (error). For example, the "Listings" repo uses 5 days for warning and 6 days for error.
 
+**Weekend grace period**: Repos using default thresholds automatically exclude weekend days (Saturday and Sunday) from the staleness calculation, so a normal weekend without commits does not trigger false warnings. Repos with explicitly configured `warning_days`/`error_days` continue to use calendar days as before.
+
 The "last updated" timestamp shown in the dashboard is calculated from the most recent `last_commit_ts` among all repos.
 
 ### Enhanced Health Status Classification

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.85";
+const VERSION = "1.0.86";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -35,7 +35,9 @@ const THRESHOLDS = {
     HEARTBEAT_CRITICAL_HOURS: 24, // Hours without heartbeat before marking host critical
     USER_STALE_DEFAULT_HOURS: 24, // Default hours before a user is marked stale (3x the 8h heartbeat threshold)
     MACOS_MIN_VERSION: '14.0',    // macOS versions below this trigger a warning
-    UBUNTU_MIN_VERSION: '22.04'   // Ubuntu versions below this trigger a warning
+    UBUNTU_MIN_VERSION: '22.04',  // Ubuntu versions below this trigger a warning
+    REPO_DEFAULT_WARNING_DAYS: 1, // Default repo staleness warning threshold (business days)
+    REPO_DEFAULT_ERROR_DAYS: 2    // Default repo staleness error threshold (business days)
 };
 
 function formatUptime(seconds) {
@@ -245,24 +247,53 @@ function buildIdleWorkerWarning(data) {
     return idleStatus.reason;
 }
 
-function getRepoStatus(repo) {
+// Count full weekend days (Saturday and Sunday) between two unix timestamps (Issue #47)
+function countWeekendDays(startTs, endTs) {
+    let count = 0;
+    const startDate = new Date(startTs * 1000);
+    // Begin from the calendar day after the start timestamp
+    const current = new Date(startDate);
+    current.setUTCHours(0, 0, 0, 0);
+    current.setUTCDate(current.getUTCDate() + 1);
+
+    const endDate = new Date(endTs * 1000);
+    endDate.setUTCHours(23, 59, 59, 999);
+
+    while (current <= endDate) {
+        const day = current.getUTCDay();
+        if (day === 0 || day === 6) { // Sunday = 0, Saturday = 6
+            count++;
+        }
+        current.setUTCDate(current.getUTCDate() + 1);
+    }
+    return count;
+}
+
+function getRepoStatus(repo, nowTs) {
     // Calculate status based on last_commit_ts
-    // Uses per-repo warning_days and error_days if provided, otherwise defaults to 1 day (warning) and 2 days (error)
+    // Repos with default thresholds get weekend grace — weekend days are subtracted from elapsed time (Issue #47)
+    // Repos with explicitly configured warning_days/error_days use calendar days as before
     if (!repo || !repo.last_commit_ts || repo.last_commit_ts <= 0) {
         return 'error'; // No timestamp or invalid repo means error
     }
-    
-    // Get thresholds (default: 1 day warning, 2 days error)
-    const warningDays = repo.warning_days !== undefined ? repo.warning_days : 1;
-    const errorDays = repo.error_days !== undefined ? repo.error_days : 2;
-    
+
+    const hasExplicitThresholds = repo.warning_days !== undefined || repo.error_days !== undefined;
+    const warningDays = repo.warning_days !== undefined ? repo.warning_days : THRESHOLDS.REPO_DEFAULT_WARNING_DAYS;
+    const errorDays = repo.error_days !== undefined ? repo.error_days : THRESHOLDS.REPO_DEFAULT_ERROR_DAYS;
+
     // Convert days to hours
     const warningHours = warningDays * 24;
     const errorHours = errorDays * 24;
-    
-    const now = Math.floor(Date.now() / 1000);
-    const hoursSinceCommit = (now - repo.last_commit_ts) / 3600;
-    
+
+    const now = nowTs !== undefined ? nowTs : Math.floor(Date.now() / 1000);
+    let hoursSinceCommit = (now - repo.last_commit_ts) / 3600;
+
+    // For repos using default thresholds, subtract weekend days so weekends do not count toward staleness
+    if (!hasExplicitThresholds) {
+        const weekendDays = countWeekendDays(repo.last_commit_ts, now);
+        hoursSinceCommit -= weekendDays * 24;
+    }
+
     if (hoursSinceCommit > errorHours) {
         return 'error';
     } else if (hoursSinceCommit > warningHours) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.85" rel="stylesheet">
+    <link href="./styles.css?v=1.0.86" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.85"></script>
+    <script src="./dashboard.js?v=1.0.86"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.85')
+                navigator.serviceWorker.register('./sw.js?v=1.0.86')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-47.md
+++ b/docs/pr-summary-47.md
@@ -1,0 +1,31 @@
+## Summary
+
+Add weekend grace period to repo commit staleness checks so that repos using default thresholds do not trigger false warnings over a normal weekend. Closes #47.
+
+### Changes
+
+- Added `countWeekendDays(startTs, endTs)` function that counts Saturday and Sunday days between two timestamps
+- Modified `getRepoStatus()` to subtract weekend days from elapsed time when using default thresholds
+- Added optional `nowTs` parameter to `getRepoStatus()` for testability
+- Added `REPO_DEFAULT_WARNING_DAYS` and `REPO_DEFAULT_ERROR_DAYS` to the `THRESHOLDS` object
+- Repos with explicitly configured `warning_days`/`error_days` continue to use calendar days (unaffected)
+- Updated `extract-functions.sh` pure function range (27-693) and `test-xss-prevention.sh` createHostCard range to account for the new function
+
+## Evidence
+
+This is a backend/logic change with no visual UI changes. All 17 quality checks pass, including the 13 new weekend grace period tests.
+
+## Test Plan
+
+- Added `tests/test-weekend-grace-period.sh` with 13 tests:
+  - `countWeekendDays` correctly counts 0, 2, or 4 weekend days for various spans
+  - Default repo: Friday commit is healthy on Monday (weekend grace applied)
+  - Default repo: Friday commit is healthy on Sunday
+  - Default repo: Thursday commit is healthy on Saturday
+  - Default repo: Wednesday commit is NOT healthy on Monday (too many weekdays elapsed)
+  - Default repo: Monday commit triggers error on Wednesday (pure weekday staleness)
+  - Explicit threshold repo: Friday commit uses calendar days (no grace) — triggers error on Monday
+  - Explicit `warning_days` only: still uses calendar days
+  - `getRepoStatus` works without `nowTs` parameter (backwards compatible)
+  - `THRESHOLDS.REPO_DEFAULT_WARNING_DAYS` and `REPO_DEFAULT_ERROR_DAYS` exist
+- All existing tests continue to pass (no tests modified or removed)

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.85
+// Version: 1.0.86
 
-const CACHE_NAME = 'grq-health-v1.0.85';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.85';
+const CACHE_NAME = 'grq-health-v1.0.86';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.86';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.85',
+  './dashboard.js?v=1.0.86',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.85"
+VERSION="1.0.86"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/extract-functions.sh
+++ b/tests/extract-functions.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 # Extract pure functions from dashboard.js for unit testing
-# Pure functions are lines 27-661 (no DOM dependencies)
+# Pure functions are lines 27-693 (no DOM dependencies)
 # Usage: source this file, then call run_js_test 'your JS test code'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DASHBOARD_JS="$SCRIPT_DIR/../docs/dashboard.js"
 DENO="$HOME/.deno/bin/deno"
 
-# Extract pure functions (lines 27-661) from dashboard.js
+# Extract pure functions (lines 27-693) from dashboard.js
 extract_pure_functions() {
-    sed -n '27,661p' "$DASHBOARD_JS"
+    sed -n '27,693p' "$DASHBOARD_JS"
 }
 
 # Run a JS test using deno

--- a/tests/test-weekend-grace-period.sh
+++ b/tests/test-weekend-grace-period.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# Test for Issue #47: Weekend/holiday grace period for repo commit staleness
+# Verifies that repos with default thresholds do not trigger warnings over weekends,
+# while repos with explicitly configured thresholds continue to work as before.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/extract-functions.sh"
+
+echo "Testing Issue #47: Weekend/holiday grace period"
+echo "=============================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+OUTPUT=$(run_js_test '
+// Helper: create a unix timestamp for a specific date/time (UTC)
+function makeTs(year, month, day, hour, minute) {
+    return Math.floor(new Date(Date.UTC(year, month - 1, day, hour, minute, 0)).getTime() / 1000);
+}
+
+// =====================================================
+// Test 1: countWeekendDays counts Saturday and Sunday
+// Friday 2026-01-02 to Monday 2026-01-05 spans one weekend (Sat+Sun)
+// =====================================================
+{
+    const fri = makeTs(2026, 1, 2, 12, 0);
+    const mon = makeTs(2026, 1, 5, 12, 0);
+    const result = countWeekendDays(fri, mon);
+    if (result === 2) {
+        console.log("TEST_RESULT:count-weekend-basic:PASS:counted 2 weekend days (Sat+Sun)");
+    } else {
+        console.log("TEST_RESULT:count-weekend-basic:FAIL:expected 2, got " + result);
+    }
+}
+
+// =====================================================
+// Test 2: countWeekendDays returns 0 for weekday-only span
+// Monday to Wednesday = 0 weekend days
+// =====================================================
+{
+    const mon = makeTs(2026, 1, 5, 12, 0);
+    const wed = makeTs(2026, 1, 7, 12, 0);
+    const result = countWeekendDays(mon, wed);
+    if (result === 0) {
+        console.log("TEST_RESULT:count-weekend-none:PASS:0 weekend days in weekday span");
+    } else {
+        console.log("TEST_RESULT:count-weekend-none:FAIL:expected 0, got " + result);
+    }
+}
+
+// =====================================================
+// Test 3: countWeekendDays counts multiple weekends
+// Friday 2026-01-02 to Monday 2026-01-12 spans two weekends (4 weekend days)
+// =====================================================
+{
+    const fri = makeTs(2026, 1, 2, 12, 0);
+    const mon = makeTs(2026, 1, 12, 12, 0);
+    const result = countWeekendDays(fri, mon);
+    if (result === 4) {
+        console.log("TEST_RESULT:count-weekend-multiple:PASS:counted 4 weekend days across 2 weekends");
+    } else {
+        console.log("TEST_RESULT:count-weekend-multiple:FAIL:expected 4, got " + result);
+    }
+}
+
+// =====================================================
+// Test 4: Default repo - commit on Friday, checked Monday = healthy
+// Last commit Friday 17:00, checked Monday 09:00 = ~62 hours elapsed
+// With 2 weekend days subtracted: ~62 - 48 = ~14 hours effective
+// Should be healthy (under 1-day default warning threshold)
+// =====================================================
+{
+    const fridayCommit = makeTs(2026, 1, 2, 17, 0);
+    const mondayNow = makeTs(2026, 1, 5, 9, 0);
+    const repo = { name: "TestRepo", last_commit_ts: fridayCommit };
+    const status = getRepoStatus(repo, mondayNow);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:default-friday-monday-healthy:PASS:Friday commit healthy on Monday");
+    } else {
+        console.log("TEST_RESULT:default-friday-monday-healthy:FAIL:expected healthy, got " + status);
+    }
+}
+
+// =====================================================
+// Test 5: Default repo - commit on Wednesday, checked Monday = warning/error
+// Last commit Wednesday 17:00, checked Monday 09:00 = ~5 days elapsed
+// With 2 weekend days subtracted: ~3 effective days
+// Should NOT be healthy (over 1-day default warning)
+// =====================================================
+{
+    const wedCommit = makeTs(2025, 12, 31, 17, 0);
+    const mondayNow = makeTs(2026, 1, 5, 9, 0);
+    const repo = { name: "TestRepo", last_commit_ts: wedCommit };
+    const status = getRepoStatus(repo, mondayNow);
+    if (status !== "healthy") {
+        console.log("TEST_RESULT:default-wed-monday-not-healthy:PASS:Wednesday commit not healthy on Monday (got " + status + ")");
+    } else {
+        console.log("TEST_RESULT:default-wed-monday-not-healthy:FAIL:expected warning or error, got healthy");
+    }
+}
+
+// =====================================================
+// Test 6: Explicit thresholds are unaffected by weekend grace
+// Repo with warning_days=1, error_days=2 should use calendar days (no weekend subtraction)
+// Friday commit, checked Monday (~2.7 days) should be error
+// =====================================================
+{
+    const fridayCommit = makeTs(2026, 1, 2, 17, 0);
+    const mondayNow = makeTs(2026, 1, 5, 9, 0);
+    const repo = { name: "ExplicitRepo", last_commit_ts: fridayCommit, warning_days: 1, error_days: 2 };
+    const status = getRepoStatus(repo, mondayNow);
+    if (status === "error") {
+        console.log("TEST_RESULT:explicit-no-grace:PASS:explicit threshold repo uses calendar days");
+    } else {
+        console.log("TEST_RESULT:explicit-no-grace:FAIL:expected error for explicit repo, got " + status);
+    }
+}
+
+// =====================================================
+// Test 7: Default repo - commit on Thursday, checked Saturday = healthy
+// Last commit Thursday 17:00, checked Saturday 09:00 = ~40 hours
+// Saturday is a weekend day but only 1 weekend day passed so far
+// With 1 weekend day subtracted: ~16 hours effective
+// Should be healthy
+// =====================================================
+{
+    const thuCommit = makeTs(2026, 1, 1, 17, 0);
+    const satNow = makeTs(2026, 1, 3, 9, 0);
+    const repo = { name: "TestRepo", last_commit_ts: thuCommit };
+    const status = getRepoStatus(repo, satNow);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:default-thu-sat-healthy:PASS:Thursday commit healthy on Saturday");
+    } else {
+        console.log("TEST_RESULT:default-thu-sat-healthy:FAIL:expected healthy, got " + status);
+    }
+}
+
+// =====================================================
+// Test 8: THRESHOLDS has REPO_DEFAULT_WARNING_DAYS and REPO_DEFAULT_ERROR_DAYS
+// =====================================================
+{
+    const hasWarning = THRESHOLDS.REPO_DEFAULT_WARNING_DAYS !== undefined;
+    const hasError = THRESHOLDS.REPO_DEFAULT_ERROR_DAYS !== undefined;
+    if (hasWarning && hasError) {
+        console.log("TEST_RESULT:thresholds-repo-defaults:PASS:REPO_DEFAULT_WARNING_DAYS=" + THRESHOLDS.REPO_DEFAULT_WARNING_DAYS + " REPO_DEFAULT_ERROR_DAYS=" + THRESHOLDS.REPO_DEFAULT_ERROR_DAYS);
+    } else {
+        console.log("TEST_RESULT:thresholds-repo-defaults:FAIL:missing repo default threshold constants");
+    }
+}
+
+// =====================================================
+// Test 9: Default repo - commit on Monday, checked Wednesday = warning
+// Last commit Monday 09:00, checked Wednesday 12:00 = ~51 hours = ~2.1 days
+// No weekend days in between, so effective days = ~2.1
+// Should be error (over 2-day default error threshold)
+// =====================================================
+{
+    const monCommit = makeTs(2026, 1, 5, 9, 0);
+    const wedNow = makeTs(2026, 1, 7, 12, 0);
+    const repo = { name: "TestRepo", last_commit_ts: monCommit };
+    const status = getRepoStatus(repo, wedNow);
+    if (status === "error") {
+        console.log("TEST_RESULT:default-weekday-error:PASS:2+ days on weekdays triggers error");
+    } else {
+        console.log("TEST_RESULT:default-weekday-error:FAIL:expected error, got " + status);
+    }
+}
+
+// =====================================================
+// Test 10: Default repo - commit on Friday morning, checked Sunday evening
+// Last commit Friday 09:00, checked Sunday 21:00 = ~60 hours
+// With 2 weekend days subtracted: ~60 - 48 = ~12 hours effective
+// Should be healthy
+// =====================================================
+{
+    const friCommit = makeTs(2026, 1, 2, 9, 0);
+    const sunNow = makeTs(2026, 1, 4, 21, 0);
+    const repo = { name: "TestRepo", last_commit_ts: friCommit };
+    const status = getRepoStatus(repo, sunNow);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:default-fri-sun-healthy:PASS:Friday commit healthy on Sunday");
+    } else {
+        console.log("TEST_RESULT:default-fri-sun-healthy:FAIL:expected healthy, got " + status);
+    }
+}
+
+// =====================================================
+// Test 11: getRepoStatus without nowTs uses current time (backwards compat)
+// Recent commit should be healthy regardless
+// =====================================================
+{
+    const now = Math.floor(Date.now() / 1000);
+    const repo = { name: "TestRepo", last_commit_ts: now - 3600 }; // 1 hour ago
+    const status = getRepoStatus(repo);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:no-nowts-param:PASS:getRepoStatus works without nowTs parameter");
+    } else {
+        console.log("TEST_RESULT:no-nowts-param:FAIL:expected healthy, got " + status);
+    }
+}
+
+// =====================================================
+// Test 12: countWeekendDays with same-day (no days between)
+// =====================================================
+{
+    const mon = makeTs(2026, 1, 5, 9, 0);
+    const monLater = makeTs(2026, 1, 5, 17, 0);
+    const result = countWeekendDays(mon, monLater);
+    if (result === 0) {
+        console.log("TEST_RESULT:count-weekend-same-day:PASS:same day returns 0");
+    } else {
+        console.log("TEST_RESULT:count-weekend-same-day:FAIL:expected 0, got " + result);
+    }
+}
+
+// =====================================================
+// Test 13: Explicit warning_days only (no error_days) still uses calendar days
+// =====================================================
+{
+    const fridayCommit = makeTs(2026, 1, 2, 17, 0);
+    const mondayNow = makeTs(2026, 1, 5, 9, 0);
+    const repo = { name: "ExplicitWarning", last_commit_ts: fridayCommit, warning_days: 1.5 };
+    const status = getRepoStatus(repo, mondayNow);
+    // ~2.7 calendar days elapsed, warning_days=1.5 so should be warning or error
+    if (status !== "healthy") {
+        console.log("TEST_RESULT:explicit-warning-only:PASS:explicit warning_days uses calendar days (got " + status + ")");
+    } else {
+        console.log("TEST_RESULT:explicit-warning-only:FAIL:expected non-healthy for explicit warning_days");
+    }
+}
+')
+
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*)
+            local_name="$(echo "$line" | cut -d: -f2)"
+            local_result="$(echo "$line" | cut -d: -f3)"
+            local_detail="$(echo "$line" | cut -d: -f4-)"
+            if [ "$local_result" = "PASS" ]; then
+                pass_test "$local_name — $local_detail"
+            else
+                fail_test "$local_name — $local_detail"
+            fi
+            ;;
+    esac
+done <<< "$OUTPUT"
+
+echo ""
+echo "=============================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test-xss-prevention.sh
+++ b/tests/test-xss-prevention.sh
@@ -29,7 +29,7 @@ fail_test() {
 # but it only generates HTML strings — no real DOM access needed.
 # Extract it separately and provide a minimal DOM mock.
 extract_card_function() {
-    sed -n '663,945p' "$SCRIPT_DIR/../docs/dashboard.js"
+    sed -n '694,976p' "$SCRIPT_DIR/../docs/dashboard.js"
 }
 
 # renderRepoHealth (lines 306-380) uses document.getElementById


### PR DESCRIPTION
## Summary

Add weekend grace period to repo commit staleness checks so that repos using default thresholds do not trigger false warnings over a normal weekend. Closes #47.

### Changes

- Added `countWeekendDays(startTs, endTs)` function that counts Saturday and Sunday days between two timestamps
- Modified `getRepoStatus()` to subtract weekend days from elapsed time when using default thresholds
- Added optional `nowTs` parameter to `getRepoStatus()` for testability
- Added `REPO_DEFAULT_WARNING_DAYS` and `REPO_DEFAULT_ERROR_DAYS` to the `THRESHOLDS` object
- Repos with explicitly configured `warning_days`/`error_days` continue to use calendar days (unaffected)
- Updated `extract-functions.sh` pure function range (27-693) and `test-xss-prevention.sh` createHostCard range to account for the new function

## Evidence

This is a backend/logic change with no visual UI changes. All 17 quality checks pass, including the 13 new weekend grace period tests.

## Test Plan

- Added `tests/test-weekend-grace-period.sh` with 13 tests:
  - `countWeekendDays` correctly counts 0, 2, or 4 weekend days for various spans
  - Default repo: Friday commit is healthy on Monday (weekend grace applied)
  - Default repo: Friday commit is healthy on Sunday
  - Default repo: Thursday commit is healthy on Saturday
  - Default repo: Wednesday commit is NOT healthy on Monday (too many weekdays elapsed)
  - Default repo: Monday commit triggers error on Wednesday (pure weekday staleness)
  - Explicit threshold repo: Friday commit uses calendar days (no grace) — triggers error on Monday
  - Explicit `warning_days` only: still uses calendar days
  - `getRepoStatus` works without `nowTs` parameter (backwards compatible)
  - `THRESHOLDS.REPO_DEFAULT_WARNING_DAYS` and `REPO_DEFAULT_ERROR_DAYS` exist
- All existing tests continue to pass (no tests modified or removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)