### PR TITLE
Add hysteresis to disk usage warning threshold (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,12 @@ The "last updated" timestamp shown in the dashboard is calculated from the most 
 
 ### Enhanced Health Status Classification
 
-- **Healthy**: 
+- **Healthy**:
   - Heartbeat within 24 hours
-  - Disk usage under 75%
+  - Disk usage under 75% (or below 72% to clear a previous warning)
   - OS version up to date
-- **Warning**: 
-  - Disk usage over 75%
+- **Warning**:
+  - Disk usage over 75% (with hysteresis: must drop below 72% to clear — Issue #49)
   - Outdated OS version
   - Heartbeat within 24 hours
 - **Critical**: 

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.86";
+const VERSION = "1.0.87";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -8,6 +8,10 @@ let currentFilter = 'all';
 let allHosts = [];
 let repoHealthData = { repos: [] };
 let lastRepoRefresh = 0;
+
+// Per-host disk warning state for hysteresis (Issue #49)
+// Tracks whether each host was previously in a disk warning state
+const diskWarningState = {};
 
 // Initialize PWA functionality when DOM is loaded
 document.addEventListener("DOMContentLoaded", () => {
@@ -32,6 +36,7 @@ const THRESHOLDS = {
     IDLE_LOAD_15M: 20,        // 15-minute load average threshold for idle detection (%)
     IDLE_HIGH_LOAD: 50,       // Load above this indicates active work (recently started/stopped)
     DISK_WARNING_PERCENT: 75, // Disk usage above this triggers a warning
+    DISK_CLEAR_PERCENT: 72,   // Disk usage must drop below this to clear a warning (hysteresis, Issue #49)
     HEARTBEAT_CRITICAL_HOURS: 24, // Hours without heartbeat before marking host critical
     USER_STALE_DEFAULT_HOURS: 24, // Default hours before a user is marked stale (3x the 8h heartbeat threshold)
     MACOS_MIN_VERSION: '14.0',    // macOS versions below this trigger a warning
@@ -588,7 +593,7 @@ function redirectToSimpleVersion() {
   }
 }
 
-function getHealthStatus(_hostname, data) {
+function getHealthStatus(_hostname, data, options) {
     // Check if this is a dead machine
     if (data.death_date) {
         return 'dead';
@@ -655,9 +660,24 @@ function getHealthStatus(_hostname, data) {
             }
         }
 
-        // Disk usage warning - applies to all hosts including mobile
-        if (data.used_disk_percent && parseFloat(data.used_disk_percent) > THRESHOLDS.DISK_WARNING_PERCENT) {
-            return 'warning';
+        // Disk usage warning with hysteresis (Issue #49)
+        // To trigger: disk must exceed DISK_WARNING_PERCENT
+        // To clear: disk must drop below DISK_CLEAR_PERCENT
+        // This prevents oscillation when disk hovers around the threshold
+        if (data.used_disk_percent) {
+            const diskPercent = parseFloat(data.used_disk_percent);
+            const previousDiskWarning = options && options.previousDiskWarning;
+            if (previousDiskWarning) {
+                // Already in warning state — stay in warning until disk drops below clear threshold
+                if (diskPercent >= THRESHOLDS.DISK_CLEAR_PERCENT) {
+                    return 'warning';
+                }
+            } else {
+                // Not in warning state — only trigger if disk exceeds warning threshold
+                if (diskPercent > THRESHOLDS.DISK_WARNING_PERCENT) {
+                    return 'warning';
+                }
+            }
         }
         
         // Config warning (missing PRIMARY_READ_URL or TRAINING_WRITE_URL)
@@ -695,12 +715,25 @@ function getHealthStatus(_hostname, data) {
         
         return 'healthy';
     }
-    
+
     return 'healthy';
 }
 
+// Wrapper that calls getHealthStatus with disk hysteresis state tracking (Issue #49)
+function getHealthStatusWithHysteresis(hostname, data) {
+    const previousDiskWarning = diskWarningState[hostname] || false;
+    const status = getHealthStatus(hostname, data, { previousDiskWarning: previousDiskWarning });
+    // Update the tracked state: host is in disk warning if status is warning AND disk is above clear threshold
+    if (status === 'warning' && data.used_disk_percent && parseFloat(data.used_disk_percent) >= THRESHOLDS.DISK_CLEAR_PERCENT) {
+        diskWarningState[hostname] = true;
+    } else if (status !== 'warning' || !data.used_disk_percent || parseFloat(data.used_disk_percent) < THRESHOLDS.DISK_CLEAR_PERCENT) {
+        diskWarningState[hostname] = false;
+    }
+    return status;
+}
+
 function createHostCard(hostname, data) {
-    const healthStatus = getHealthStatus(hostname, data);
+    const healthStatus = getHealthStatusWithHysteresis(hostname, data);
     const statusClass = healthStatus;
     const safeHostname = escapeHtml(hostname);
     const logUrl = `./log-viewer.html?file=./${safeHostname}/node.log`;
@@ -986,10 +1019,10 @@ function createHostCard(hostname, data) {
 function updateStats(hosts) {
     const stats = {
         total: hosts.length,
-        healthy: hosts.filter(([hostname, data]) => getHealthStatus(hostname, data) === 'healthy').length,
-        warning: hosts.filter(([hostname, data]) => getHealthStatus(hostname, data) === 'warning').length,
-        critical: hosts.filter(([hostname, data]) => getHealthStatus(hostname, data) === 'critical').length,
-        mia: hosts.filter(([hostname, data]) => getHealthStatus(hostname, data) === 'mia').length
+        healthy: hosts.filter(([hostname, data]) => getHealthStatusWithHysteresis(hostname, data) === 'healthy').length,
+        warning: hosts.filter(([hostname, data]) => getHealthStatusWithHysteresis(hostname, data) === 'warning').length,
+        critical: hosts.filter(([hostname, data]) => getHealthStatusWithHysteresis(hostname, data) === 'critical').length,
+        mia: hosts.filter(([hostname, data]) => getHealthStatusWithHysteresis(hostname, data) === 'mia').length
     };
     const repoStats = getRepoStats();
     const hasRepoError = repoStats.error > 0;
@@ -1040,7 +1073,7 @@ function updateStats(hosts) {
     const criticalSection = document.getElementById('criticalSection');
     const criticalHostsList = document.getElementById('criticalHostsList');
     if (stats.critical > 0) {
-        const criticalHosts = hosts.filter(([hostname, data]) => getHealthStatus(hostname, data) === 'critical');
+        const criticalHosts = hosts.filter(([hostname, data]) => getHealthStatusWithHysteresis(hostname, data) === 'critical');
         const criticalHtml = criticalHosts.map(([hostname, data]) => {
             if (data.heart_beat_ts) {
                 const hoursSince = Math.floor((Math.floor(Date.now() / 1000) - data.heart_beat_ts) / 3600);
@@ -1064,7 +1097,7 @@ function updateStats(hosts) {
     const miaHostsList = document.getElementById('miaHostsList');
 
     if (stats.mia > 0) {
-        const miaHosts = hosts.filter(([hostname, data]) => getHealthStatus(hostname, data) === 'mia');
+        const miaHosts = hosts.filter(([hostname, data]) => getHealthStatusWithHysteresis(hostname, data) === 'mia');
         const miaHtml = miaHosts.map(([hostname, data]) => {
             if (data.heart_beat_ts) {
                 const hoursSince = Math.floor((Math.floor(Date.now() / 1000) - data.heart_beat_ts) / 3600);
@@ -1087,10 +1120,10 @@ function updateStats(hosts) {
     const warningSection = document.getElementById('warningSection');
     const warningHostsList = document.getElementById('warningHostsList');
     if (stats.warning > 0) {
-        const warningHosts = hosts.filter(([hostname, data]) => getHealthStatus(hostname, data) === 'warning');
+        const warningHosts = hosts.filter(([hostname, data]) => getHealthStatusWithHysteresis(hostname, data) === 'warning');
         const warningHtml = warningHosts.map(([hostname, data]) => {
             let warningReason = '';
-            if (data.used_disk_percent && parseFloat(data.used_disk_percent) > THRESHOLDS.DISK_WARNING_PERCENT) {
+            if (data.used_disk_percent && parseFloat(data.used_disk_percent) >= THRESHOLDS.DISK_CLEAR_PERCENT && diskWarningState[hostname]) {
                 warningReason += `High disk usage: ${data.used_disk_percent}%`;
             }
             if (data.config_warning) {
@@ -1150,13 +1183,13 @@ function filterHosts(filter, event) {
     }
     // Filter hosts
     const filteredHosts = allHosts.filter(([hostname, data]) => {
-        const status = getHealthStatus(hostname, data);
+        const status = getHealthStatusWithHysteresis(hostname, data);
         return filter === 'all' || status === filter;
     });
     // Sort: critical first, then warning, then healthy, then historical, then dead, then by last seen (most recent first)
     filteredHosts.sort(([hostnameA, dataA], [hostnameB, dataB]) => {
-        const statusA = getHealthStatus(hostnameA, dataA);
-        const statusB = getHealthStatus(hostnameB, dataB);
+        const statusA = getHealthStatusWithHysteresis(hostnameA, dataA);
+        const statusB = getHealthStatusWithHysteresis(hostnameB, dataB);
         const priority = { critical: 6, mia: 5, warning: 4, healthy: 3, historical: 2, dead: 1 };
         
         // First sort by health status

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.86" rel="stylesheet">
+    <link href="./styles.css?v=1.0.87" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.86"></script>
+    <script src="./dashboard.js?v=1.0.87"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.86')
+                navigator.serviceWorker.register('./sw.js?v=1.0.87')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-49.md
+++ b/docs/pr-summary-49.md
@@ -1,0 +1,34 @@
+## Summary
+
+Add hysteresis to disk usage warning threshold to prevent oscillation when disk usage hovers around the 75% boundary. Closes #49.
+
+**How it works:**
+- To **trigger** a disk warning: usage must exceed 75% (`DISK_WARNING_PERCENT`)
+- To **clear** a disk warning: usage must drop below 72% (`DISK_CLEAR_PERCENT`)
+- In the hysteresis band (72–75%): the previous state is maintained
+
+This prevents noisy status flapping when disk usage fluctuates around the threshold due to temporary files or log rotation.
+
+**Changes:**
+- Added `DISK_CLEAR_PERCENT: 72` to `THRESHOLDS` in `dashboard.js`
+- Extended `getHealthStatus()` to accept an optional `options.previousDiskWarning` parameter
+- Added `getHealthStatusWithHysteresis()` wrapper that tracks per-host disk warning state
+- Updated all dashboard callers to use the hysteresis-aware wrapper
+- Applied matching hysteresis logic to `simple.html`
+- Updated `extract-functions.sh` line ranges for shifted code
+
+## Evidence
+
+This is a backend/logic change with no visual UI differences. The behaviour is verified by 10 unit tests covering:
+- Threshold existence and relationship
+- Warning trigger above 75%
+- Healthy state below 72%
+- Hysteresis band behaviour with and without previous warning
+- Boundary conditions (exactly at threshold values)
+- Backwards compatibility (no options parameter)
+
+## Test Plan
+
+- Added `tests/test-disk-hysteresis.sh` with 10 tests covering the hysteresis band behaviour
+- All 18 existing quality checks continue to pass
+- Updated `tests/test-xss-prevention.sh` extraction range for shifted line numbers

--- a/docs/simple.html
+++ b/docs/simple.html
@@ -207,6 +207,9 @@
             return result;
         }
 
+        // Per-host disk warning state for hysteresis (Issue #49)
+        const diskWarningState = {};
+
         function getHealthStatus(hostname, data) {
             // Check if this is a dead machine
             if (data.death_date) {
@@ -243,9 +246,23 @@
 
             // Check for warning states
             if (hoursSinceHeartbeat <= 24) {
-                // Disk usage warning (over 75% used)
-                if (data.used_disk_percent && parseFloat(data.used_disk_percent) > 75) {
-                    return 'warning';
+                // Disk usage warning with hysteresis (Issue #49)
+                if (data.used_disk_percent) {
+                    const diskPercent = parseFloat(data.used_disk_percent);
+                    const previousDiskWarning = diskWarningState[hostname] || false;
+                    if (previousDiskWarning) {
+                        if (diskPercent >= 72) {
+                            diskWarningState[hostname] = true;
+                            return 'warning';
+                        } else {
+                            diskWarningState[hostname] = false;
+                        }
+                    } else {
+                        if (diskPercent > 75) {
+                            diskWarningState[hostname] = true;
+                            return 'warning';
+                        }
+                    }
                 }
 
                 // Config warning (missing PRIMARY_READ_URL or TRAINING_WRITE_URL)

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.86
+// Version: 1.0.87
 
-const CACHE_NAME = 'grq-health-v1.0.86';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.86';
+const CACHE_NAME = 'grq-health-v1.0.87';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.87';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.86',
+  './dashboard.js?v=1.0.87',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.86"
+VERSION="1.0.87"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/extract-functions.sh
+++ b/tests/extract-functions.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 # Extract pure functions from dashboard.js for unit testing
-# Pure functions are lines 27-661 (no DOM dependencies)
+# Pure functions are lines 31-720 (no DOM dependencies)
 # Usage: source this file, then call run_js_test 'your JS test code'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DASHBOARD_JS="$SCRIPT_DIR/../docs/dashboard.js"
 DENO="$HOME/.deno/bin/deno"
 
-# Extract pure functions (lines 27-700) from dashboard.js
+# Extract pure functions (lines 31-720) from dashboard.js
 extract_pure_functions() {
-    sed -n '27,700p' "$DASHBOARD_JS"
+    sed -n '31,720p' "$DASHBOARD_JS"
 }
 
 # Run a JS test using deno

--- a/tests/test-disk-hysteresis.sh
+++ b/tests/test-disk-hysteresis.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Test for Issue #49: Disk usage hysteresis
+# Verifies that disk warnings use hysteresis to avoid oscillation
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/extract-functions.sh"
+
+echo "Testing Issue #49: Disk usage hysteresis"
+echo "=============================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+OUTPUT=$(run_js_test '
+const now = Math.floor(Date.now() / 1000);
+
+// Test 1: DISK_CLEAR_PERCENT threshold exists and is below DISK_WARNING_PERCENT
+{
+    if (THRESHOLDS.DISK_CLEAR_PERCENT !== undefined &&
+        typeof THRESHOLDS.DISK_CLEAR_PERCENT === "number" &&
+        THRESHOLDS.DISK_CLEAR_PERCENT < THRESHOLDS.DISK_WARNING_PERCENT) {
+        console.log("TEST_RESULT:clear-threshold-exists:PASS:DISK_CLEAR_PERCENT=" + THRESHOLDS.DISK_CLEAR_PERCENT + " < DISK_WARNING_PERCENT=" + THRESHOLDS.DISK_WARNING_PERCENT);
+    } else {
+        console.log("TEST_RESULT:clear-threshold-exists:FAIL:DISK_CLEAR_PERCENT missing or not below DISK_WARNING_PERCENT");
+    }
+}
+
+// Test 2: Disk clearly above warning threshold triggers warning (no previous state)
+{
+    const data = { heart_beat_ts: now, used_disk_percent: "80" };
+    const status = getHealthStatus("test-host", data);
+    if (status === "warning") {
+        console.log("TEST_RESULT:above-threshold-warns:PASS:80% triggers warning");
+    } else {
+        console.log("TEST_RESULT:above-threshold-warns:FAIL:expected warning for 80%, got " + status);
+    }
+}
+
+// Test 3: Disk clearly below clear threshold is healthy (no previous state)
+{
+    const data = { heart_beat_ts: now, used_disk_percent: "70" };
+    const status = getHealthStatus("test-host", data);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:below-clear-healthy:PASS:70% is healthy");
+    } else {
+        console.log("TEST_RESULT:below-clear-healthy:FAIL:expected healthy for 70%, got " + status);
+    }
+}
+
+// Test 4: Disk in hysteresis band (between clear and warning) with no previous warning is healthy
+{
+    const data = { heart_beat_ts: now, used_disk_percent: "73" };
+    const status = getHealthStatus("test-host", data, {});
+    if (status === "healthy") {
+        console.log("TEST_RESULT:band-no-prev-healthy:PASS:73% with no previous warning is healthy");
+    } else {
+        console.log("TEST_RESULT:band-no-prev-healthy:FAIL:expected healthy for 73% with no prev warning, got " + status);
+    }
+}
+
+// Test 5: Disk in hysteresis band with previous disk warning stays warning
+{
+    const data = { heart_beat_ts: now, used_disk_percent: "73" };
+    const status = getHealthStatus("test-host", data, { previousDiskWarning: true });
+    if (status === "warning") {
+        console.log("TEST_RESULT:band-prev-warn-stays:PASS:73% with previous disk warning stays warning");
+    } else {
+        console.log("TEST_RESULT:band-prev-warn-stays:FAIL:expected warning for 73% with prev disk warning, got " + status);
+    }
+}
+
+// Test 6: Disk drops below clear threshold clears warning even with previous disk warning
+{
+    const data = { heart_beat_ts: now, used_disk_percent: String(THRESHOLDS.DISK_CLEAR_PERCENT - 1) };
+    const status = getHealthStatus("test-host", data, { previousDiskWarning: true });
+    if (status === "healthy") {
+        console.log("TEST_RESULT:below-clear-clears:PASS:below clear threshold clears warning");
+    } else {
+        console.log("TEST_RESULT:below-clear-clears:FAIL:expected healthy below clear threshold with prev warning, got " + status);
+    }
+}
+
+// Test 7: Disk at exactly the warning threshold does NOT trigger (must exceed)
+{
+    const data = { heart_beat_ts: now, used_disk_percent: String(THRESHOLDS.DISK_WARNING_PERCENT) };
+    const status = getHealthStatus("test-host", data);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:at-threshold-healthy:PASS:exactly at " + THRESHOLDS.DISK_WARNING_PERCENT + "% is healthy");
+    } else {
+        console.log("TEST_RESULT:at-threshold-healthy:FAIL:expected healthy at exactly " + THRESHOLDS.DISK_WARNING_PERCENT + "%, got " + status);
+    }
+}
+
+// Test 8: Disk at exactly the clear threshold with previous warning stays warning (must drop below)
+{
+    const data = { heart_beat_ts: now, used_disk_percent: String(THRESHOLDS.DISK_CLEAR_PERCENT) };
+    const status = getHealthStatus("test-host", data, { previousDiskWarning: true });
+    if (status === "warning") {
+        console.log("TEST_RESULT:at-clear-stays-warn:PASS:exactly at clear threshold with prev warning stays warning");
+    } else {
+        console.log("TEST_RESULT:at-clear-stays-warn:FAIL:expected warning at exactly clear threshold with prev warning, got " + status);
+    }
+}
+
+// Test 9: Without options parameter, function still works (backwards compatibility)
+{
+    const data = { heart_beat_ts: now, used_disk_percent: "80" };
+    const status = getHealthStatus("test-host", data);
+    if (status === "warning") {
+        console.log("TEST_RESULT:no-options-compat:PASS:works without options parameter");
+    } else {
+        console.log("TEST_RESULT:no-options-compat:FAIL:expected warning without options param, got " + status);
+    }
+}
+
+// Test 10: Disk at 75.5% (just above threshold) triggers warning from healthy state
+{
+    const data = { heart_beat_ts: now, used_disk_percent: "75.5" };
+    const status = getHealthStatus("test-host", data, { previousDiskWarning: false });
+    if (status === "warning") {
+        console.log("TEST_RESULT:just-above-triggers:PASS:75.5% triggers warning from healthy");
+    } else {
+        console.log("TEST_RESULT:just-above-triggers:FAIL:expected warning for 75.5% from healthy, got " + status);
+    }
+}
+')
+
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*)
+            local_name="$(echo "$line" | cut -d: -f2)"
+            local_result="$(echo "$line" | cut -d: -f3)"
+            local_detail="$(echo "$line" | cut -d: -f4-)"
+            if [ "$local_result" = "PASS" ]; then
+                pass_test "$local_name — $local_detail"
+            else
+                fail_test "$local_name — $local_detail"
+            fi
+            ;;
+    esac
+done <<< "$OUTPUT"
+
+echo ""
+echo "=============================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test-xss-prevention.sh
+++ b/tests/test-xss-prevention.sh
@@ -25,14 +25,14 @@ fail_test() {
     FAIL_COUNT=$((FAIL_COUNT + 1))
 }
 
-# createHostCard (lines 702-984) is outside the default pure-function range
+# createHostCard (lines 723-1018) is outside the default pure-function range
 # but it only generates HTML strings — no real DOM access needed.
-# Extract it separately and provide a minimal DOM mock.
+# Extract it separately (includes getHealthStatusWithHysteresis wrapper).
 extract_card_function() {
-    sed -n '702,984p' "$SCRIPT_DIR/../docs/dashboard.js"
+    sed -n '723,1018p' "$SCRIPT_DIR/../docs/dashboard.js"
 }
 
-# renderRepoHealth (lines 347-420) uses document.getElementById
+# renderRepoHealth (lines 352-428) uses document.getElementById
 # but we mock it. It's already within the pure range.
 
 run_js_test_with_card() {
@@ -43,7 +43,8 @@ run_js_test_with_card() {
     card_fn="$(extract_card_function)"
 
     # Provide globals that are declared outside the pure-function range
-    local globals="let repoHealthData = { repos: [] };"
+    local globals="let repoHealthData = { repos: [] };
+const diskWarningState = {};"
 
     echo "${globals}
 ${functions}


### PR DESCRIPTION
## Summary

Add hysteresis to disk usage warning threshold to prevent oscillation when disk usage hovers around the 75% boundary. Closes #49.

**How it works:**
- To **trigger** a disk warning: usage must exceed 75% (`DISK_WARNING_PERCENT`)
- To **clear** a disk warning: usage must drop below 72% (`DISK_CLEAR_PERCENT`)
- In the hysteresis band (72–75%): the previous state is maintained

This prevents noisy status flapping when disk usage fluctuates around the threshold due to temporary files or log rotation.

**Changes:**
- Added `DISK_CLEAR_PERCENT: 72` to `THRESHOLDS` in `dashboard.js`
- Extended `getHealthStatus()` to accept an optional `options.previousDiskWarning` parameter
- Added `getHealthStatusWithHysteresis()` wrapper that tracks per-host disk warning state
- Updated all dashboard callers to use the hysteresis-aware wrapper
- Applied matching hysteresis logic to `simple.html`
- Updated `extract-functions.sh` line ranges for shifted code

## Evidence

This is a backend/logic change with no visual UI differences. The behaviour is verified by 10 unit tests covering:
- Threshold existence and relationship
- Warning trigger above 75%
- Healthy state below 72%
- Hysteresis band behaviour with and without previous warning
- Boundary conditions (exactly at threshold values)
- Backwards compatibility (no options parameter)

## Test Plan

- Added `tests/test-disk-hysteresis.sh` with 10 tests covering the hysteresis band behaviour
- All 18 existing quality checks continue to pass
- Updated `tests/test-xss-prevention.sh` extraction range for shifted line numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)