### PR TITLE
Add heartbeat push retry on failure (#51)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.87";
+const VERSION = "1.0.88";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.87" rel="stylesheet">
+    <link href="./styles.css?v=1.0.88" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.87"></script>
+    <script src="./dashboard.js?v=1.0.88"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.87')
+                navigator.serviceWorker.register('./sw.js?v=1.0.88')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-51.md
+++ b/docs/pr-summary-51.md
@@ -1,0 +1,20 @@
+## Summary
+
+Add retry logic to `commit_and_push()` in `run.sh` so that a transient `git push` failure no longer causes a false critical alert lasting up to 8 hours. The push is now retried up to 3 times with a `git pull --rebase` between attempts, handling git conflicts and network blips gracefully. Closes #51.
+
+## Changes
+
+- **`run.sh`**: Replaced the single `git push` attempt with a retry loop (3 attempts). On failure, it pulls with rebase before retrying, logging each attempt.
+- **`tests/test-push-retry.sh`**: New test file with 3 test scenarios using a mock `git` binary:
+  1. Push succeeds on first try — no retry needed
+  2. Push fails once then succeeds on retry — verifies retry behaviour
+  3. Push fails all retries — verifies all attempts are made and failure is logged
+
+## Evidence
+
+This is a backend/CLI change with no web interface impact. The retry logic is verified by the test suite which uses mock git binaries to simulate push failures and confirm retry behaviour.
+
+## Test Plan
+
+- Added `tests/test-push-retry.sh` with 5 assertions across 3 scenarios
+- All 19 quality checks pass including the new test

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.87
+// Version: 1.0.88
 
-const CACHE_NAME = 'grq-health-v1.0.87';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.87';
+const CACHE_NAME = 'grq-health-v1.0.88';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.88';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.87',
+  './dashboard.js?v=1.0.88',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.87"
+VERSION="1.0.88"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.
@@ -968,11 +968,25 @@ commit_and_push() {
         fi
         git commit -m "Update health status for $HOSTNAME at $commit_date" 2>/dev/null || true
         
-        # Try to push (might fail if no remote or no changes)
-        if git push 2>/dev/null; then
-            echo "Changes pushed to remote repository"
-        else
-            echo "No changes to push or push failed"
+        # Try to push with retry logic (Issue #51)
+        # Retries up to 3 times with a brief delay to handle transient failures
+        # (git conflicts, network blips) that would otherwise cause false critical alerts
+        local max_retries=3
+        local push_succeeded=false
+        for attempt in $(seq 1 "$max_retries"); do
+            if git push 2>/dev/null; then
+                echo "Changes pushed to remote repository"
+                push_succeeded=true
+                break
+            fi
+            if [ "$attempt" -lt "$max_retries" ]; then
+                echo "Push failed (attempt $attempt/$max_retries), retrying after pull --rebase..."
+                sleep 2
+                git pull --rebase 2>/dev/null || true
+            fi
+        done
+        if [ "$push_succeeded" = false ]; then
+            echo "Push failed after $max_retries attempts"
         fi
     else
         echo "Not a git repository, skipping commit/push"

--- a/tests/test-push-retry.sh
+++ b/tests/test-push-retry.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# Test for Issue #51: Add heartbeat update retry on push failure
+# Verifies that commit_and_push retries on git push failure
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_SH="$SCRIPT_DIR/../run.sh"
+
+echo "Testing Issue #51: Heartbeat push retry on failure"
+echo "==================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Create a temporary directory to work in
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Set up a fake git repo with a remote so commit_and_push runs
+setup_fake_repo() {
+    local dir="$1"
+    # Create a bare "remote" repo
+    local remote_dir="${dir}/remote.git"
+    git init --bare "$remote_dir" >/dev/null 2>&1
+
+    # Create the working repo
+    local work_dir="${dir}/work"
+    mkdir -p "$work_dir/docs"
+    cd "$work_dir"
+    git init >/dev/null 2>&1
+    git remote add origin "$remote_dir" >/dev/null 2>&1
+    # Initial commit
+    echo '{}' > docs/index.json
+    git add docs/ >/dev/null 2>&1
+    git commit -m "initial" >/dev/null 2>&1
+    git push -u origin HEAD >/dev/null 2>&1
+    # Make a change for commit_and_push to find
+    echo '{"test": true}' > docs/index.json
+    echo "$work_dir"
+}
+
+# Test 1: Push succeeds on first try — no retry needed
+echo "Test 1: Push succeeds on first try..."
+TEST1_DIR="${WORK_DIR}/test1"
+mkdir -p "$TEST1_DIR"
+REPO_DIR=$(setup_fake_repo "$TEST1_DIR")
+cd "$REPO_DIR"
+
+# Source run.sh functions but don't execute main
+HOSTNAME="TEST-HOST"
+CURRENT_TS=$(date +%s)
+NO_GIT=false
+# Source just the commit_and_push function
+eval "$(sed -n '/^commit_and_push()/,/^}/p' "$RUN_SH")"
+
+OUTPUT=$(commit_and_push 2>&1)
+if echo "$OUTPUT" | grep -q "Changes pushed to remote repository"; then
+    pass_test "Push succeeds on first try"
+else
+    fail_test "Expected successful push message, got: $OUTPUT"
+fi
+
+# Test 2: Push fails then succeeds on retry
+echo "Test 2: Push fails once then succeeds on retry..."
+TEST2_DIR="${WORK_DIR}/test2"
+mkdir -p "$TEST2_DIR"
+REPO_DIR=$(setup_fake_repo "$TEST2_DIR")
+cd "$REPO_DIR"
+
+# Make another change
+echo '{"test": "retry"}' > docs/index.json
+
+# Create a mock git that fails on first push, succeeds on second
+MOCK_BIN="${TEST2_DIR}/mock_bin"
+mkdir -p "$MOCK_BIN"
+PUSH_COUNT_FILE="${TEST2_DIR}/push_count"
+echo "0" > "$PUSH_COUNT_FILE"
+
+cat > "${MOCK_BIN}/git" << 'MOCKEOF'
+#!/bin/bash
+PUSH_COUNT_FILE="PLACEHOLDER_COUNT_FILE"
+if [ "$1" = "push" ]; then
+    count=$(cat "$PUSH_COUNT_FILE")
+    count=$((count + 1))
+    echo "$count" > "$PUSH_COUNT_FILE"
+    if [ "$count" -le 1 ]; then
+        echo "error: failed to push" >&2
+        exit 1
+    fi
+    exit 0
+fi
+# For all other git commands, use the real git
+REAL_GIT="PLACEHOLDER_REAL_GIT"
+"$REAL_GIT" "$@"
+MOCKEOF
+
+REAL_GIT=$(which git)
+sed -i.bak "s|PLACEHOLDER_COUNT_FILE|${PUSH_COUNT_FILE}|g" "${MOCK_BIN}/git"
+sed -i.bak "s|PLACEHOLDER_REAL_GIT|${REAL_GIT}|g" "${MOCK_BIN}/git"
+chmod +x "${MOCK_BIN}/git"
+
+CURRENT_TS=$(date +%s)
+eval "$(sed -n '/^commit_and_push()/,/^}/p' "$RUN_SH")"
+
+PATH="${MOCK_BIN}:${PATH}" OUTPUT=$(commit_and_push 2>&1)
+FINAL_PUSH_COUNT=$(cat "$PUSH_COUNT_FILE")
+
+if [ "$FINAL_PUSH_COUNT" -ge 2 ]; then
+    pass_test "Push was retried after initial failure (push count: $FINAL_PUSH_COUNT)"
+else
+    fail_test "Expected at least 2 push attempts, got: $FINAL_PUSH_COUNT"
+fi
+
+if echo "$OUTPUT" | grep -qi "retry\|retrying"; then
+    pass_test "Retry message was logged"
+else
+    fail_test "Expected retry message in output, got: $OUTPUT"
+fi
+
+# Test 3: Push fails all retries
+echo "Test 3: Push fails all retries..."
+TEST3_DIR="${WORK_DIR}/test3"
+mkdir -p "$TEST3_DIR"
+REPO_DIR=$(setup_fake_repo "$TEST3_DIR")
+cd "$REPO_DIR"
+
+echo '{"test": "all-fail"}' > docs/index.json
+
+MOCK_BIN3="${TEST3_DIR}/mock_bin"
+mkdir -p "$MOCK_BIN3"
+PUSH_COUNT_FILE3="${TEST3_DIR}/push_count"
+echo "0" > "$PUSH_COUNT_FILE3"
+
+cat > "${MOCK_BIN3}/git" << 'MOCKEOF'
+#!/bin/bash
+PUSH_COUNT_FILE="PLACEHOLDER_COUNT_FILE"
+if [ "$1" = "push" ]; then
+    count=$(cat "$PUSH_COUNT_FILE")
+    count=$((count + 1))
+    echo "$count" > "$PUSH_COUNT_FILE"
+    echo "error: failed to push" >&2
+    exit 1
+fi
+REAL_GIT="PLACEHOLDER_REAL_GIT"
+"$REAL_GIT" "$@"
+MOCKEOF
+
+REAL_GIT=$(which git)
+sed -i.bak "s|PLACEHOLDER_COUNT_FILE|${PUSH_COUNT_FILE3}|g" "${MOCK_BIN3}/git"
+sed -i.bak "s|PLACEHOLDER_REAL_GIT|${REAL_GIT}|g" "${MOCK_BIN3}/git"
+chmod +x "${MOCK_BIN3}/git"
+
+CURRENT_TS=$(date +%s)
+eval "$(sed -n '/^commit_and_push()/,/^}/p' "$RUN_SH")"
+
+PATH="${MOCK_BIN3}:${PATH}" OUTPUT=$(commit_and_push 2>&1)
+FINAL_PUSH_COUNT3=$(cat "$PUSH_COUNT_FILE3")
+
+if [ "$FINAL_PUSH_COUNT3" -ge 3 ]; then
+    pass_test "All retry attempts were made (push count: $FINAL_PUSH_COUNT3)"
+else
+    fail_test "Expected at least 3 push attempts, got: $FINAL_PUSH_COUNT3"
+fi
+
+if echo "$OUTPUT" | grep -qi "failed\|push failed"; then
+    pass_test "Failure message logged after all retries exhausted"
+else
+    fail_test "Expected failure message, got: $OUTPUT"
+fi
+
+# Summary
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Add retry logic to `commit_and_push()` in `run.sh` so that a transient `git push` failure no longer causes a false critical alert lasting up to 8 hours. The push is now retried up to 3 times with a `git pull --rebase` between attempts, handling git conflicts and network blips gracefully. Closes #51.

## Changes

- **`run.sh`**: Replaced the single `git push` attempt with a retry loop (3 attempts). On failure, it pulls with rebase before retrying, logging each attempt.
- **`tests/test-push-retry.sh`**: New test file with 3 test scenarios using a mock `git` binary:
  1. Push succeeds on first try — no retry needed
  2. Push fails once then succeeds on retry — verifies retry behaviour
  3. Push fails all retries — verifies all attempts are made and failure is logged

## Evidence

This is a backend/CLI change with no web interface impact. The retry logic is verified by the test suite which uses mock git binaries to simulate push failures and confirm retry behaviour.

## Test Plan

- Added `tests/test-push-retry.sh` with 5 assertions across 3 scenarios
- All 19 quality checks pass including the new test

---

## Automated Fix Details
This PR addresses issue #51: **Add heartbeat update retry on push failure to prevent false critical alerts**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #51