### PR TITLE
Exclude [MemoryMonitor] when scanning for WARNING/ERROR

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ A distributed health monitoring system that tracks the status of multiple hosts 
 #### Exception Detection in run.sh:
 - **Stack traces**: Lines with "Exception", "Error", "MEMETIC" followed by stack trace lines
 - **Missing commands**: "No such file or directory" errors
-- **Warning emojis**: Lines containing "⚠️" 
+- **Warning emojis**: Lines containing "⚠️"
 - **Permission errors**: "Permission denied", "access denied", "EACCES"
 - **All exceptions trigger health updates** regardless of heartbeat timing
+- **Excluded**: Lines containing `[MemoryMonitor]` are filtered out before scanning — these are operational cache-clearing messages, not real errors
 
 #### Multi-user Hosts (per-user heartbeats):
 - **Problem**: Some machines run multiple unix users; one user's heartbeat can mask another user's stuck state if we only store a single host heartbeat.

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.88";
+const VERSION = "1.0.89";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.88" rel="stylesheet">
+    <link href="./styles.css?v=1.0.89" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.88"></script>
+    <script src="./dashboard.js?v=1.0.89"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.88')
+                navigator.serviceWorker.register('./sw.js?v=1.0.89')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/log-viewer.html
+++ b/docs/log-viewer.html
@@ -200,8 +200,12 @@
                 const isCStackTraceLine = /^\s+\d+\s+[^\s]+\s+0x[0-9a-fA-F]+/.test(line);
                 
                 // Highlight different types of log messages
+                // Issue #61: Exclude [MemoryMonitor] lines — operational cache clearing noise
+                if (line.includes('[MemoryMonitor]')) {
+                    return `<div data-line-index="${index}">${escapeHtml(line)}</div>`;
+                }
                 // Be specific to avoid false positives from training metrics that mention "Error:"
-                if (line.includes('ERROR') || 
+                if (line.includes('ERROR') ||
                     line.includes('Exception') || 
                     line.startsWith('Error:') ||
                     /Discovery failed for .+ after .+: Error:/.test(line) ||

--- a/docs/pr-summary-61.md
+++ b/docs/pr-summary-61.md
@@ -1,0 +1,21 @@
+## Summary
+Exclude `[MemoryMonitor]` lines when scanning `node.log` for WARNING/ERROR. These lines are operational noise from cache clearing and should not be flagged as errors. Closes #61.
+
+### Changes
+- **`run.sh` `scan_log_errors()`**: Filter out `[MemoryMonitor]` lines before scanning for errors by creating a filtered copy of the log file
+- **`docs/log-viewer.html`**: Skip `[MemoryMonitor]` lines from warning/error classification in the log viewer display
+- **`README.md`**: Document the MemoryMonitor exclusion in the exception detection section
+
+## Evidence
+This is a backend/CLI change with no visual UI changes. The fix was verified through automated tests covering both `run.sh` scanning and log-viewer classification.
+
+Test output confirms:
+- MemoryMonitor-only logs produce zero errors
+- MemoryMonitor lines with ⚠️ and ❌ emojis are excluded
+- Real errors mixed with MemoryMonitor lines are still detected correctly
+- Log-viewer classifies MemoryMonitor lines as normal (not warning/error)
+
+## Test Plan
+- Added `tests/test-memory-monitor-exclusion.sh` with 10 test cases:
+  - **run.sh tests (5)**: MemoryMonitor warning lines excluded, emoji lines excluded, real errors still detected alongside MemoryMonitor lines, failure emoji excluded, actual GRQ-18 log content excluded
+  - **log-viewer.html tests (5)**: MemoryMonitor WARNING/CRITICAL/Warning-response classified as normal, real WARNING and ERROR still flagged correctly

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.88
+// Version: 1.0.89
 
-const CACHE_NAME = 'grq-health-v1.0.88';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.88';
+const CACHE_NAME = 'grq-health-v1.0.89';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.89';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.88',
+  './dashboard.js?v=1.0.89',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.88"
+VERSION="1.0.89"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.
@@ -752,34 +752,43 @@ scan_log_errors() {
     exception_summary=""
     
     if [ -f "$log_file" ]; then
+        # Issue #61: Filter out [MemoryMonitor] lines — these are operational noise
+        # (cache clearing warnings) that should not be flagged as errors.
+        local filtered_log
+        filtered_log=$(mktemp)
+        grep -v '\[MemoryMonitor\]' "$log_file" > "$filtered_log" 2>/dev/null || true
+
         # Count actual exceptions by looking for error messages that precede stack traces
         # Each exception starts with an error message, followed by stack trace lines
-        local stack_trace_exceptions=$(grep -B1 "^[[:space:]]\+at " "$log_file" | grep -v "^[[:space:]]\+at " | grep -v "^--$" | grep -E "Exception|^Error:|MEMETIC" | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
-        
+        local stack_trace_exceptions=$(grep -B1 "^[[:space:]]\+at " "$filtered_log" | grep -v "^[[:space:]]\+at " | grep -v "^--$" | grep -E "Exception|^Error:|MEMETIC" | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
+
         # Count other critical errors that should be flagged
         # Missing commands/tools (excluding aws which is only expected on Macs)
         # Focus on missing script files which indicate configuration issues
         # Exclude .cache/ paths — cache files may not exist after cleanup (normal concurrency)
-        local missing_command_errors=$(grep -E "line [0-9]+: .*: No such file or directory" "$log_file" | grep -v '\.cache/' | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
-        
+        local missing_command_errors=$(grep -E "line [0-9]+: .*: No such file or directory" "$filtered_log" | grep -v '\.cache/' | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
+
         # Count warning emoji issues (⚠️)
-        local warning_emoji_errors=$(grep -c "⚠️" "$log_file" 2>/dev/null | tr -d ' \n' || echo "0")
-        
+        local warning_emoji_errors=$(grep -c "⚠️" "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
+
         # Count failure emoji issues (❌)
-        local failure_emoji_errors=$(grep -c "❌" "$log_file" 2>/dev/null | tr -d ' \n' || echo "0")
-        
-        
+        local failure_emoji_errors=$(grep -c "❌" "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
+
+
         # Lock acquisition failures (removed - these are expected for daily tasks)
         local lock_failures=0
-        
+
         # Permission/access errors
-        local permission_errors=$(grep -E "Permission denied|access denied|EACCES" "$log_file" | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
-        
+        local permission_errors=$(grep -E "Permission denied|access denied|EACCES" "$filtered_log" | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
+
         # Network/connection errors (removed - too unreliable, causing false positives)
         local network_errors=0
-        
+
         # Count all Deno crashes with C stack traces (includes out of memory, segfaults, etc.)
-        local deno_crashes=$(grep -c "==== C stack trace" "$log_file" 2>/dev/null | tr -d ' \n' || echo "0")
+        local deno_crashes=$(grep -c "==== C stack trace" "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
+
+        # Clean up filtered log
+        rm -f "$filtered_log"
         
         # Sum all error types
         exception_count=$((stack_trace_exceptions + missing_command_errors + warning_emoji_errors + failure_emoji_errors + lock_failures + permission_errors + network_errors + deno_crashes))

--- a/tests/test-memory-monitor-exclusion.sh
+++ b/tests/test-memory-monitor-exclusion.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# Test for Issue #61: Exclude [MemoryMonitor] when scanning for WARNING/ERROR
+# MemoryMonitor warnings about cache clearing are operational noise, not real errors.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_SH="$SCRIPT_DIR/../run.sh"
+DENO="$HOME/.deno/bin/deno"
+
+echo "Testing Issue #61: MemoryMonitor exclusion from error scanning"
+echo "==============================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Create a temporary directory for test log files
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Extract the scan_log_errors function from run.sh
+eval "$(sed -n '/^scan_log_errors()/,/^}/p' "$RUN_SH")"
+
+# --- run.sh scan_log_errors tests ---
+
+echo "Part 1: scan_log_errors() in run.sh"
+echo "------------------------------------"
+
+# Test 1: MemoryMonitor warning lines should NOT be counted
+echo "Test 1: MemoryMonitor warning lines are excluded..."
+HOME="$WORK_DIR"
+mkdir -p "$WORK_DIR/logs"
+NODE_PID=""
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+run_core pid=20689 start=Sat Mar  7 21:30:59 AEDT 2026
+[MemoryMonitor] Warning-level response: reduced activation cache cap from 100 to 50, evicted 25 entries
+[MemoryMonitor] Heap: 180 MB / 217 MB (82.7%) [WARNING]
+[MemoryMonitor] Critical-level response: cleared all WASM caches, activation cap reduced to 1, compilation cache cleared
+[MemoryMonitor] Heap: 1581 MB / 1649 MB (95.9%) [CRITICAL]
+Option: IntelligentDesign
+HEAD is now at 8f0cfaf Evolution score 0.4065 -> 0.4066
+EOF
+
+scan_log_errors
+
+if [ "$exception_count" -eq 0 ]; then
+    pass_test "MemoryMonitor-only log has zero errors (count=$exception_count)"
+else
+    fail_test "MemoryMonitor lines were falsely flagged: $exception_summary"
+fi
+
+# Test 2: MemoryMonitor with warning emoji should NOT be counted
+echo "Test 2: MemoryMonitor with warning emoji excluded..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+run_core pid=20689
+[MemoryMonitor] ⚠️ High memory usage detected (85.2%)
+[MemoryMonitor] Heap: 500 MB / 600 MB (83.3%) [WARNING]
+EOF
+
+scan_log_errors
+
+if [ "$exception_count" -eq 0 ]; then
+    pass_test "MemoryMonitor with emoji has zero errors (count=$exception_count)"
+else
+    fail_test "MemoryMonitor emoji lines were falsely flagged: $exception_summary"
+fi
+
+# Test 3: Real errors mixed with MemoryMonitor lines — only real errors counted
+echo "Test 3: Real errors still detected alongside MemoryMonitor lines..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+run_core pid=20689
+[MemoryMonitor] Warning-level response: reduced activation cache cap from 100 to 50
+[MemoryMonitor] Heap: 180 MB / 217 MB (82.7%) [WARNING]
+Error: Something went wrong
+    at Object.runInContext (vm.js:130:16)
+    at main (index.js:52:8)
+⚠️ Disk space running low
+EOF
+
+scan_log_errors
+
+if [ "$exception_count" -eq 2 ]; then
+    pass_test "Real errors counted correctly alongside MemoryMonitor (count=$exception_count)"
+else
+    fail_test "Expected 2 errors, got $exception_count: $exception_summary"
+fi
+
+# Test 4: MemoryMonitor with failure emoji should NOT be counted
+echo "Test 4: MemoryMonitor with failure emoji excluded..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+[MemoryMonitor] ❌ Failed to free enough memory
+EOF
+
+scan_log_errors
+
+if [ "$exception_count" -eq 0 ]; then
+    pass_test "MemoryMonitor with failure emoji has zero errors (count=$exception_count)"
+else
+    fail_test "MemoryMonitor failure emoji was falsely flagged: $exception_summary"
+fi
+
+# Test 5: Real GRQ-18 node-rocket.log MemoryMonitor lines should not be counted
+echo "Test 5: Actual MemoryMonitor log content from GRQ-18..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+Download https://jsr.io/@stsoftware/neat-ai/0.316.31/src/NEAT/MemoryMonitor.ts
+[MemoryMonitor] Critical-level response: cleared all WASM caches, activation cap reduced to 1, compilation cache cleared
+[MemoryMonitor] Heap: 1581 MB / 1649 MB (95.9%) [CRITICAL]
+[MemoryMonitor] Critical-level response: cleared all WASM caches, activation cap reduced to 1, compilation cache cleared
+[MemoryMonitor] Heap: 1334 MB / 1406 MB (94.9%) [CRITICAL]
+EOF
+
+scan_log_errors
+
+if [ "$exception_count" -eq 0 ]; then
+    pass_test "Actual GRQ-18 MemoryMonitor log has zero errors (count=$exception_count)"
+else
+    fail_test "Actual GRQ-18 MemoryMonitor lines falsely flagged: $exception_summary"
+fi
+
+# --- log-viewer.html classification tests ---
+
+echo ""
+echo "Part 2: log-viewer.html classification"
+echo "---------------------------------------"
+
+check_result() {
+    local line="$1"
+    local name result detail
+    name="$(echo "$line" | cut -d: -f2)"
+    result="$(echo "$line" | cut -d: -f3)"
+    detail="$(echo "$line" | cut -d: -f4-)"
+    if [ "$result" = "PASS" ]; then
+        pass_test "$name — $detail"
+    else
+        fail_test "$name — $detail"
+    fi
+}
+
+OUTPUT=$("$DENO" run - <<'DENO_SCRIPT'
+// Extract classification logic matching log-viewer.html processLogContent
+function classifyLine(line) {
+    const isStackTraceLine = /^\s+at /.test(line);
+    const isCStackTraceLine = /^\s+\d+\s+[^\s]+\s+0x[0-9a-fA-F]+/.test(line);
+
+    // Exclude MemoryMonitor lines from warning/error classification
+    if (line.includes('[MemoryMonitor]')) {
+        return 'normal';
+    }
+
+    if (line.includes('ERROR') ||
+        line.includes('Exception') ||
+        line.startsWith('Error:') ||
+        /Discovery failed for .+ after .+: Error:/.test(line) ||
+        /\bfailed\b.*Error:/.test(line) ||
+        /Fatal JavaScript out of memory/.test(line) ||
+        /==== C stack trace/.test(line) ||
+        /Fatal error/.test(line)) {
+        return 'error-line';
+    } else if (line.includes('\u274C')) {  // ❌
+        return 'error-line';
+    } else if (isStackTraceLine || isCStackTraceLine) {
+        return 'stack-trace-line';
+    } else if (line.includes('WARNING') || line.includes('Warning:') || line.includes('\u26A0\uFE0F')) {  // ⚠️
+        return 'warning-line';
+    } else if (line.includes('DEBUG:')) {
+        return 'debug-line';
+    } else {
+        return 'normal';
+    }
+}
+
+// Test: MemoryMonitor WARNING line should be classified as normal
+{
+    const line = "[MemoryMonitor] Heap: 180 MB / 217 MB (82.7%) [WARNING]";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:memmon-warning-normal:PASS:MemoryMonitor WARNING classified as normal");
+    } else {
+        console.log("TEST_RESULT:memmon-warning-normal:FAIL:expected normal, got " + cls);
+    }
+}
+
+// Test: MemoryMonitor CRITICAL line should be classified as normal
+{
+    const line = "[MemoryMonitor] Heap: 1581 MB / 1649 MB (95.9%) [CRITICAL]";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:memmon-critical-normal:PASS:MemoryMonitor CRITICAL classified as normal");
+    } else {
+        console.log("TEST_RESULT:memmon-critical-normal:FAIL:expected normal, got " + cls);
+    }
+}
+
+// Test: MemoryMonitor Warning-level response should be classified as normal
+{
+    const line = "[MemoryMonitor] Warning-level response: reduced activation cache cap from 100 to 50";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:memmon-warning-response:PASS:MemoryMonitor warning response classified as normal");
+    } else {
+        console.log("TEST_RESULT:memmon-warning-response:FAIL:expected normal, got " + cls);
+    }
+}
+
+// Test: Real WARNING line should STILL be classified as warning
+{
+    const line = "WARNING: Disk space running low";
+    const cls = classifyLine(line);
+    if (cls === "warning-line") {
+        console.log("TEST_RESULT:real-warning-still-flagged:PASS:real WARNING still classified as warning");
+    } else {
+        console.log("TEST_RESULT:real-warning-still-flagged:FAIL:expected warning-line, got " + cls);
+    }
+}
+
+// Test: Real ERROR line should STILL be classified as error
+{
+    const line = "ERROR: Something went wrong";
+    const cls = classifyLine(line);
+    if (cls === "error-line") {
+        console.log("TEST_RESULT:real-error-still-flagged:PASS:real ERROR still classified as error");
+    } else {
+        console.log("TEST_RESULT:real-error-still-flagged:FAIL:expected error-line, got " + cls);
+    }
+}
+DENO_SCRIPT
+)
+
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*) check_result "$line" ;;
+    esac
+done <<< "$OUTPUT"
+
+# Summary
+echo ""
+echo "==============================================================="
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Exclude `[MemoryMonitor]` lines when scanning `node.log` for WARNING/ERROR. These lines are operational noise from cache clearing and should not be flagged as errors. Closes #61.

### Changes
- **`run.sh` `scan_log_errors()`**: Filter out `[MemoryMonitor]` lines before scanning for errors by creating a filtered copy of the log file
- **`docs/log-viewer.html`**: Skip `[MemoryMonitor]` lines from warning/error classification in the log viewer display
- **`README.md`**: Document the MemoryMonitor exclusion in the exception detection section

## Evidence
This is a backend/CLI change with no visual UI changes. The fix was verified through automated tests covering both `run.sh` scanning and log-viewer classification.

Test output confirms:
- MemoryMonitor-only logs produce zero errors
- MemoryMonitor lines with ⚠️ and ❌ emojis are excluded
- Real errors mixed with MemoryMonitor lines are still detected correctly
- Log-viewer classifies MemoryMonitor lines as normal (not warning/error)

## Test Plan
- Added `tests/test-memory-monitor-exclusion.sh` with 10 test cases:
  - **run.sh tests (5)**: MemoryMonitor warning lines excluded, emoji lines excluded, real errors still detected alongside MemoryMonitor lines, failure emoji excluded, actual GRQ-18 log content excluded
  - **log-viewer.html tests (5)**: MemoryMonitor WARNING/CRITICAL/Warning-response classified as normal, real WARNING and ERROR still flagged correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)