### PR TITLE
Add weekend-aware health checks for FX and similar feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ The system uses a simple structure where each hostname is a key:
   "repos": [
     {
       "name": "FX",
-      "last_commit_ts": 1752806400
+      "last_commit_ts": 1752806400,
+      "warning_days": 1.5,
+      "error_days": 4,
+      "business_days_only": true
     },
     {
       "name": "shareprices2025Q3",
@@ -214,6 +217,8 @@ The dashboard calculates status from `last_commit_ts`:
 **Weekend grace period (Issue #47)**: Repos using default thresholds count only business days (weekdays), so a normal weekend without commits does not trigger false alarms. Repos with explicitly configured `warning_days` and/or `error_days` continue to use calendar days.
 
 **Per-repo thresholds**: Each repo can optionally specify `warning_days` and `error_days` to customise the thresholds (in calendar days). If not specified, defaults to 1 business day (warning) and 2 business days (error). For example, the "Listings" repo uses 5 days for warning and 6 days for error.
+
+**Weekend-aware repos (Issue #67)**: Repos that only receive data on weekdays (e.g., FX market feeds that run Monday–Friday) can set `"business_days_only": true` to skip weekends when calculating staleness, even with explicit thresholds. Without this flag, explicit thresholds count calendar days/hours. With it, only business days are counted, preventing false alarms on Monday mornings.
 
 The "last updated" timestamp shown in the dashboard is calculated from the most recent `last_commit_ts` among all repos.
 

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.91";
+const VERSION = "1.0.92";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -286,20 +286,22 @@ function countBusinessDays(fromTs, toTs) {
 
 function getRepoStatus(repo, nowTs) {
     // Calculate status based on last_commit_ts
-    // Repos with explicit warning_days/error_days use calendar days.
+    // Repos with explicit warning_days/error_days use calendar days by default.
     // Repos using defaults skip weekends (business days only) — Issue #47.
+    // Repos with business_days_only: true skip weekends even with explicit thresholds — Issue #67.
     if (!repo || !repo.last_commit_ts || repo.last_commit_ts <= 0) {
         return 'error'; // No timestamp or invalid repo means error
     }
 
     const hasExplicitThresholds = repo.warning_days !== undefined || repo.error_days !== undefined;
+    const useBusinessDays = repo.business_days_only === true;
     const warningDays = repo.warning_days !== undefined ? repo.warning_days : 1;
     const errorDays = repo.error_days !== undefined ? repo.error_days : 2;
 
     const now = nowTs || Math.floor(Date.now() / 1000);
 
-    if (hasExplicitThresholds) {
-        // Explicit thresholds: use calendar hours as before
+    if (hasExplicitThresholds && !useBusinessDays) {
+        // Explicit thresholds without business_days_only: use calendar hours
         const warningHours = warningDays * 24;
         const errorHours = errorDays * 24;
         const hoursSinceCommit = (now - repo.last_commit_ts) / 3600;
@@ -312,7 +314,7 @@ function getRepoStatus(repo, nowTs) {
             return 'healthy';
         }
     } else {
-        // Default thresholds: count only business days (skip weekends)
+        // Default thresholds or business_days_only: count only business days (skip weekends)
         const businessDays = countBusinessDays(repo.last_commit_ts, now);
 
         if (businessDays > errorDays) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.91" rel="stylesheet">
+    <link href="./styles.css?v=1.0.92" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.91"></script>
+    <script src="./dashboard.js?v=1.0.92"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.91')
+                navigator.serviceWorker.register('./sw.js?v=1.0.92')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-67.md
+++ b/docs/pr-summary-67.md
@@ -1,0 +1,33 @@
+## Summary
+
+Added `business_days_only` flag for weekend-aware health checks on repos with explicit thresholds. This prevents false alarms for feeds like FX that only run Monday–Friday (NY time). Previously, repos with explicit `warning_days`/`error_days` always used calendar days, causing weekend gaps to trigger warnings on Monday mornings. With `"business_days_only": true`, weekends are skipped when counting staleness. Closes #67.
+
+## Changes
+
+- **`docs/dashboard.js`**: Modified `getRepoStatus()` to check for `business_days_only: true` flag. When set, repos with explicit thresholds use `countBusinessDays()` (skipping weekends) instead of calendar hours.
+- **`docs/repos.json`**: Added `"business_days_only": true` to the FX repo entry.
+- **`tests/test-weekend-aware-repos.sh`**: Added 8 new tests covering the FX weekend scenario, threshold behaviour, backward compatibility, partial thresholds, and edge cases.
+- **`tests/extract-functions.sh`**: Updated pure function extraction range (29-736) to account for the 2 added lines.
+- **`tests/test-xss-prevention.sh`**: Updated `createHostCard` extraction range (738-1048) to match the shifted line numbers.
+- **`README.md`**: Documented the new `business_days_only` flag with usage example.
+- **Version**: Bumped from 1.0.91 to 1.0.92.
+
+## Evidence
+
+This is a backend logic change with no visual UI modifications. The fix is verified by 8 new unit tests (all passing) plus all 25 existing quality checks passing.
+
+Key test scenario: FX repo updated Friday noon, checked Monday morning — without `business_days_only` returns "warning" (3 calendar days > 1.5 threshold), with `business_days_only: true` returns "healthy" (1 business day < 1.5 threshold).
+
+## Test Plan
+
+- `tests/test-weekend-aware-repos.sh` — 8 new tests:
+  - FX-like repo stays healthy over weekend (Friday→Monday)
+  - Warns after enough business days (Friday→Wednesday)
+  - Errors after error threshold in business days
+  - Backward compatibility: no flag still uses calendar days
+  - Partial explicit thresholds with business_days_only
+  - `business_days_only: false` treated same as not set
+  - Same-day check is healthy
+  - Saturday check after Friday update is healthy
+- All 14 existing weekend grace tests (`test-weekend-grace.sh`) continue to pass
+- All 25 quality checks pass

--- a/docs/repos.json
+++ b/docs/repos.json
@@ -32,7 +32,8 @@
       "name": "FX",
       "last_commit_ts": 1774093143,
       "warning_days": 1.5,
-      "error_days": 4
+      "error_days": 4,
+      "business_days_only": true
     },
     {
       "name": "Sentiment",

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.91
+// Version: 1.0.92
 
-const CACHE_NAME = 'grq-health-v1.0.91';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.91';
+const CACHE_NAME = 'grq-health-v1.0.92';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.92';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.91',
+  './dashboard.js?v=1.0.92',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.0.91"
+VERSION="1.0.92"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/extract-functions.sh
+++ b/tests/extract-functions.sh
@@ -7,9 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DASHBOARD_JS="$SCRIPT_DIR/../docs/dashboard.js"
 DENO="$HOME/.deno/bin/deno"
 
-# Extract pure functions (lines 29-734) from dashboard.js
+# Extract pure functions (lines 29-736) from dashboard.js
 extract_pure_functions() {
-    sed -n '29,734p' "$DASHBOARD_JS"
+    sed -n '29,736p' "$DASHBOARD_JS"
 }
 
 # Run a JS test using deno

--- a/tests/test-weekend-aware-repos.sh
+++ b/tests/test-weekend-aware-repos.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# Test for Issue #67: Weekend-aware health checks for repos with explicit thresholds
+# Verifies that repos with business_days_only flag skip weekends even with custom thresholds
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/extract-functions.sh"
+
+echo "Testing Issue #67: Weekend-aware repos (business_days_only flag)"
+echo "================================================================"
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Helper: run JS test and check result
+run_and_check() {
+    local test_name="$1"
+    local js_code="$2"
+    local output
+    output=$(run_js_test "$js_code" 2>&1) || true
+    local result
+    result=$(echo "$output" | grep "^TEST_RESULT:${test_name}:" | head -1)
+    if [[ "$result" == *":PASS:"* ]]; then
+        local detail
+        detail=$(echo "$result" | cut -d: -f4-)
+        pass_test "$test_name: $detail"
+    else
+        local detail
+        detail=$(echo "$result" | cut -d: -f4-)
+        if [ -z "$detail" ]; then
+            detail="no output (full: $output)"
+        fi
+        fail_test "$test_name: $detail"
+    fi
+}
+
+# Timestamps (all midnight UTC, verified correct):
+# Mon 2026-03-02 = 1772409600
+# Tue 2026-03-03 = 1772496000
+# Wed 2026-03-04 = 1772582400
+# Thu 2026-03-05 = 1772668800
+# Fri 2026-03-06 = 1772755200
+# Sat 2026-03-07 = 1772841600
+# Sun 2026-03-08 = 1772928000
+# Mon 2026-03-09 = 1773014400
+# Fri 2026-03-13 = 1773360000
+
+# ============================================================
+# Test 1: FX-like repo — Friday update, Monday check should be healthy
+# ============================================================
+echo "Test 1: FX-like repo with business_days_only over weekend..."
+
+# FX: warning_days: 1.5, error_days: 4, business_days_only: true
+# Updated Friday noon, checked Monday morning — only 1 business day elapsed
+# Without business_days_only: 3 calendar days > 1.5 warning = warning/error
+# With business_days_only: 1 business day < 1.5 = healthy
+run_and_check "fx-weekend-healthy" '
+    const fridayNoon = 1772755200 + 43200; // Fri 2026-03-06 12:00 UTC
+    const mondayMorn = 1773014400 + 36000; // Mon 2026-03-09 10:00 UTC
+
+    const repo = {
+        name: "FX",
+        last_commit_ts: fridayNoon,
+        warning_days: 1.5,
+        error_days: 4,
+        business_days_only: true
+    };
+    const status = getRepoStatus(repo, mondayMorn);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:fx-weekend-healthy:PASS:FX healthy on Monday after Friday update");
+    } else {
+        console.log("TEST_RESULT:fx-weekend-healthy:FAIL:expected healthy, got " + status);
+    }
+'
+
+# ============================================================
+# Test 2: business_days_only repo warns after enough business days
+# ============================================================
+echo ""
+echo "Test 2: business_days_only repo warns after threshold business days..."
+
+# FX updated Friday, checked Wednesday — 3 business days (Mon, Tue, Wed) > 1.5 warning
+run_and_check "fx-midweek-warning" '
+    const fridayNoon = 1772755200 + 43200; // Fri 2026-03-06 12:00 UTC
+    const wedNoon = 1772582400 + 43200 + 604800; // Wed 2026-03-11 12:00 UTC
+
+    const repo = {
+        name: "FX",
+        last_commit_ts: fridayNoon,
+        warning_days: 1.5,
+        error_days: 4,
+        business_days_only: true
+    };
+    const status = getRepoStatus(repo, wedNoon);
+    if (status === "warning") {
+        console.log("TEST_RESULT:fx-midweek-warning:PASS:FX warns after 3 business days > 1.5 threshold");
+    } else {
+        console.log("TEST_RESULT:fx-midweek-warning:FAIL:expected warning, got " + status);
+    }
+'
+
+# ============================================================
+# Test 3: business_days_only repo errors after error threshold
+# ============================================================
+echo ""
+echo "Test 3: business_days_only repo errors after error threshold..."
+
+# FX updated Mon Mar 2, checked next Wed Mar 11 — 7 business days > 4 error
+run_and_check "fx-error-threshold" '
+    const monNoon = 1772409600 + 43200; // Mon 2026-03-02 12:00 UTC
+    const wedNoon = 1772582400 + 43200 + 604800; // Wed 2026-03-11 12:00 UTC
+
+    const repo = {
+        name: "FX",
+        last_commit_ts: monNoon,
+        warning_days: 1.5,
+        error_days: 4,
+        business_days_only: true
+    };
+    const status = getRepoStatus(repo, wedNoon);
+    if (status === "error") {
+        console.log("TEST_RESULT:fx-error-threshold:PASS:FX errors after 7 business days > 4 threshold");
+    } else {
+        console.log("TEST_RESULT:fx-error-threshold:FAIL:expected error, got " + status);
+    }
+'
+
+# ============================================================
+# Test 4: Without business_days_only, explicit thresholds still use calendar days
+# ============================================================
+echo ""
+echo "Test 4: Backward compatibility — no flag uses calendar days..."
+
+# Same FX-like thresholds but without business_days_only
+# Friday to Monday = 3 calendar days > 1.5 warning, < 4 error = warning
+run_and_check "no-flag-calendar-days" '
+    const fridayNoon = 1772755200 + 43200; // Fri 2026-03-06 12:00 UTC
+    const mondayMorn = 1773014400 + 36000; // Mon 2026-03-09 10:00 UTC
+
+    const repo = {
+        name: "NoFlag",
+        last_commit_ts: fridayNoon,
+        warning_days: 1.5,
+        error_days: 4
+    };
+    const status = getRepoStatus(repo, mondayMorn);
+    if (status === "warning") {
+        console.log("TEST_RESULT:no-flag-calendar-days:PASS:without flag, calendar days used (warning)");
+    } else {
+        console.log("TEST_RESULT:no-flag-calendar-days:FAIL:expected warning, got " + status);
+    }
+'
+
+# ============================================================
+# Test 5: business_days_only with only warning_days set (error_days defaults to 2)
+# ============================================================
+echo ""
+echo "Test 5: business_days_only with partial explicit thresholds..."
+
+# warning_days: 1.5 set, error_days defaults to 2
+# Friday to Monday = 1 business day < 1.5 warning = healthy
+run_and_check "partial-bdays-healthy" '
+    const fridayNoon = 1772755200 + 43200; // Fri 2026-03-06 12:00 UTC
+    const mondayMorn = 1773014400 + 36000; // Mon 2026-03-09 10:00 UTC
+
+    const repo = {
+        name: "PartialBDays",
+        last_commit_ts: fridayNoon,
+        warning_days: 1.5,
+        business_days_only: true
+    };
+    const status = getRepoStatus(repo, mondayMorn);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:partial-bdays-healthy:PASS:partial explicit with business_days_only stays healthy");
+    } else {
+        console.log("TEST_RESULT:partial-bdays-healthy:FAIL:expected healthy, got " + status);
+    }
+'
+
+# ============================================================
+# Test 6: business_days_only false is same as not set
+# ============================================================
+echo ""
+echo "Test 6: business_days_only: false treated same as not set..."
+
+run_and_check "bdays-false-calendar" '
+    const fridayNoon = 1772755200 + 43200; // Fri 2026-03-06 12:00 UTC
+    const mondayMorn = 1773014400 + 36000; // Mon 2026-03-09 10:00 UTC
+
+    const repo = {
+        name: "BDaysFalse",
+        last_commit_ts: fridayNoon,
+        warning_days: 1.5,
+        error_days: 4,
+        business_days_only: false
+    };
+    const status = getRepoStatus(repo, mondayMorn);
+    if (status === "warning") {
+        console.log("TEST_RESULT:bdays-false-calendar:PASS:business_days_only false uses calendar days");
+    } else {
+        console.log("TEST_RESULT:bdays-false-calendar:FAIL:expected warning, got " + status);
+    }
+'
+
+# ============================================================
+# Test 7: Same-day check should be healthy regardless of flag
+# ============================================================
+echo ""
+echo "Test 7: Same-day check is healthy with business_days_only..."
+
+run_and_check "bdays-same-day" '
+    const morning = 1773014400 + 36000; // Mon 2026-03-09 10:00 UTC
+    const afternoon = 1773014400 + 50400; // Mon 2026-03-09 14:00 UTC
+
+    const repo = {
+        name: "SameDay",
+        last_commit_ts: morning,
+        warning_days: 1.5,
+        error_days: 4,
+        business_days_only: true
+    };
+    const status = getRepoStatus(repo, afternoon);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:bdays-same-day:PASS:same day is healthy");
+    } else {
+        console.log("TEST_RESULT:bdays-same-day:FAIL:expected healthy, got " + status);
+    }
+'
+
+# ============================================================
+# Test 8: Saturday check — last update Friday, should be healthy
+# ============================================================
+echo ""
+echo "Test 8: Weekend check on Saturday after Friday update..."
+
+run_and_check "bdays-saturday-check" '
+    const fridayNoon = 1772755200 + 43200; // Fri 2026-03-06 12:00 UTC
+    const saturdayNoon = 1772841600 + 43200; // Sat 2026-03-07 12:00 UTC
+
+    const repo = {
+        name: "SatCheck",
+        last_commit_ts: fridayNoon,
+        warning_days: 1.5,
+        error_days: 4,
+        business_days_only: true
+    };
+    const status = getRepoStatus(repo, saturdayNoon);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:bdays-saturday-check:PASS:Saturday check after Friday update is healthy");
+    } else {
+        console.log("TEST_RESULT:bdays-saturday-check:FAIL:expected healthy, got " + status);
+    }
+'
+
+echo ""
+echo "================================================================"
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test-xss-prevention.sh
+++ b/tests/test-xss-prevention.sh
@@ -29,7 +29,7 @@ fail_test() {
 # but it only generates HTML strings — no real DOM access needed.
 # Extract it separately and provide a minimal DOM mock.
 extract_card_function() {
-    sed -n '736,1046p' "$SCRIPT_DIR/../docs/dashboard.js"
+    sed -n '738,1048p' "$SCRIPT_DIR/../docs/dashboard.js"
 }
 
 # renderRepoHealth (lines 347-420) uses document.getElementById


### PR DESCRIPTION
## Summary

Added `business_days_only` flag for weekend-aware health checks on repos with explicit thresholds. This prevents false alarms for feeds like FX that only run Monday–Friday (NY time). Previously, repos with explicit `warning_days`/`error_days` always used calendar days, causing weekend gaps to trigger warnings on Monday mornings. With `"business_days_only": true`, weekends are skipped when counting staleness. Closes #67.

## Changes

- **`docs/dashboard.js`**: Modified `getRepoStatus()` to check for `business_days_only: true` flag. When set, repos with explicit thresholds use `countBusinessDays()` (skipping weekends) instead of calendar hours.
- **`docs/repos.json`**: Added `"business_days_only": true` to the FX repo entry.
- **`tests/test-weekend-aware-repos.sh`**: Added 8 new tests covering the FX weekend scenario, threshold behaviour, backward compatibility, partial thresholds, and edge cases.
- **`tests/extract-functions.sh`**: Updated pure function extraction range (29-736) to account for the 2 added lines.
- **`tests/test-xss-prevention.sh`**: Updated `createHostCard` extraction range (738-1048) to match the shifted line numbers.
- **`README.md`**: Documented the new `business_days_only` flag with usage example.
- **Version**: Bumped from 1.0.91 to 1.0.92.

## Evidence

This is a backend logic change with no visual UI modifications. The fix is verified by 8 new unit tests (all passing) plus all 25 existing quality checks passing.

Key test scenario: FX repo updated Friday noon, checked Monday morning — without `business_days_only` returns "warning" (3 calendar days > 1.5 threshold), with `business_days_only: true` returns "healthy" (1 business day < 1.5 threshold).

## Test Plan

- `tests/test-weekend-aware-repos.sh` — 8 new tests:
  - FX-like repo stays healthy over weekend (Friday→Monday)
  - Warns after enough business days (Friday→Wednesday)
  - Errors after error threshold in business days
  - Backward compatibility: no flag still uses calendar days
  - Partial explicit thresholds with business_days_only
  - `business_days_only: false` treated same as not set
  - Same-day check is healthy
  - Saturday check after Friday update is healthy
- All 14 existing weekend grace tests (`test-weekend-grace.sh`) continue to pass
- All 25 quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)