### PR TITLE
Increase disk warning threshold from 75% to 80%

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.93";
+const VERSION = "1.0.95";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -33,8 +33,8 @@ const THRESHOLDS = {
     IDLE_LOAD_5M: 15,         // 5-minute load average threshold for idle detection (%)
     IDLE_LOAD_15M: 20,        // 15-minute load average threshold for idle detection (%)
     IDLE_HIGH_LOAD: 50,       // Load above this indicates active work (recently started/stopped)
-    DISK_WARNING_PERCENT: 75, // Disk usage at or above this triggers a warning
-    DISK_WARNING_CLEAR_PERCENT: 72, // Disk usage must drop to or below this to clear warning (hysteresis)
+    DISK_WARNING_PERCENT: 80, // Disk usage at or above this triggers a warning (Issue #71)
+    DISK_WARNING_CLEAR_PERCENT: 77, // Disk usage must drop to or below this to clear warning (hysteresis)
     HEARTBEAT_CRITICAL_HOURS: 24, // Hours without heartbeat before marking host critical
     USER_STALE_DEFAULT_HOURS: 24, // Default hours before a user is marked stale (3x the 8h heartbeat threshold)
     MACOS_MIN_VERSION: '14.0',    // macOS versions below this trigger a warning

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.93" rel="stylesheet">
+    <link href="./styles.css?v=1.0.95" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.93"></script>
+    <script src="./dashboard.js?v=1.0.95"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.93')
+                navigator.serviceWorker.register('./sw.js?v=1.0.95')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-71.md
+++ b/docs/pr-summary-71.md
@@ -1,0 +1,16 @@
+## Summary
+Increased the high disk alarm threshold from 75% to 80% as requested. The hysteresis clear threshold was also updated from 72% to 77%, maintaining the 3-point gap to prevent oscillation. Closes #71.
+
+## Changes
+- `docs/dashboard.js`: Updated `DISK_WARNING_PERCENT` from 75 to 80 and `DISK_WARNING_CLEAR_PERCENT` from 72 to 77
+- `tests/test-thresholds-constants.sh`: Added tests 13-14 to verify the new threshold values (80% warning, 77% clear)
+- `tests/test-disk-hysteresis.sh`: Updated test 12 to use threshold-relative values instead of hardcoded numbers, making it resilient to future threshold changes
+
+## Evidence
+This is a backend threshold change with no UI layout changes. All 26 quality checks pass, including the disk hysteresis and threshold constant test suites.
+
+## Test Plan
+- Added test asserting `DISK_WARNING_PERCENT === 80` (test 13 in test-thresholds-constants.sh)
+- Added test asserting `DISK_WARNING_CLEAR_PERCENT === 77` (test 14 in test-thresholds-constants.sh)
+- Refactored hysteresis oscillation test to use `THRESHOLDS` constants instead of hardcoded values
+- All existing tests continue to pass with the updated thresholds

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.93
+// Version: 1.0.95
 
-const CACHE_NAME = 'grq-health-v1.0.93';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.93';
+const CACHE_NAME = 'grq-health-v1.0.95';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.0.95';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.93',
+  './dashboard.js?v=1.0.95',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/tests/test-disk-hysteresis.sh
+++ b/tests/test-disk-hysteresis.sh
@@ -145,16 +145,20 @@ const now = Math.floor(Date.now() / 1000);
     }
 }
 
-// Test 12: Disk at 75% (exactly threshold) does not oscillate — stays warning once triggered
+// Test 12: Disk at threshold does not oscillate — stays warning once triggered
 {
-    // First check: 76% triggers warning
-    const trigger = isDiskWarning(76, false);
-    // Second check: drops to 75% — still in hysteresis band, should stay warning
-    const stays = isDiskWarning(75, true);
-    // Third check: drops to 74% — still in hysteresis band, should stay warning
-    const stays2 = isDiskWarning(74, true);
+    // Use threshold-relative values to avoid hardcoding
+    const above = THRESHOLDS.DISK_WARNING_PERCENT + 1;
+    const atThreshold = THRESHOLDS.DISK_WARNING_PERCENT;
+    const belowThresholdInBand = THRESHOLDS.DISK_WARNING_PERCENT - 1;
+    // First check: above threshold triggers warning
+    const trigger = isDiskWarning(above, false);
+    // Second check: drops to exactly threshold — still in hysteresis band, should stay warning
+    const stays = isDiskWarning(atThreshold, true);
+    // Third check: drops below threshold but still in band — should stay warning
+    const stays2 = isDiskWarning(belowThresholdInBand, true);
     if (trigger && stays && stays2) {
-        console.log("TEST_RESULT:no-oscillation:PASS:76->75->74 does not oscillate");
+        console.log("TEST_RESULT:no-oscillation:PASS:" + above + "->" + atThreshold + "->" + belowThresholdInBand + " does not oscillate");
     } else {
         console.log("TEST_RESULT:no-oscillation:FAIL:expected true,true,true got " + trigger + "," + stays + "," + stays2);
     }

--- a/tests/test-thresholds-constants.sh
+++ b/tests/test-thresholds-constants.sh
@@ -184,7 +184,25 @@ OUTPUT=$(run_js_test '
     }
 }
 
-// Test 13: Ubuntu version below THRESHOLDS.UBUNTU_MIN_VERSION triggers warning
+// Test 13: Issue #71 — Disk warning threshold is 80%
+{
+    if (THRESHOLDS.DISK_WARNING_PERCENT === 80) {
+        console.log("TEST_RESULT:disk-warning-80:PASS:DISK_WARNING_PERCENT is 80%");
+    } else {
+        console.log("TEST_RESULT:disk-warning-80:FAIL:expected 80, got " + THRESHOLDS.DISK_WARNING_PERCENT);
+    }
+}
+
+// Test 14: Issue #71 — Disk warning clear threshold is 77% (3-point hysteresis)
+{
+    if (THRESHOLDS.DISK_WARNING_CLEAR_PERCENT === 77) {
+        console.log("TEST_RESULT:disk-clear-77:PASS:DISK_WARNING_CLEAR_PERCENT is 77%");
+    } else {
+        console.log("TEST_RESULT:disk-clear-77:FAIL:expected 77, got " + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT);
+    }
+}
+
+// Test 15: Ubuntu version below THRESHOLDS.UBUNTU_MIN_VERSION triggers warning
 {
     const now = Math.floor(Date.now() / 1000);
     const data = { heart_beat_ts: now, os_info: "Ubuntu", os_version: "20.04" };


### PR DESCRIPTION
## Summary
Increased the high disk alarm threshold from 75% to 80% as requested. The hysteresis clear threshold was also updated from 72% to 77%, maintaining the 3-point gap to prevent oscillation. Closes #71.

## Changes
- `docs/dashboard.js`: Updated `DISK_WARNING_PERCENT` from 75 to 80 and `DISK_WARNING_CLEAR_PERCENT` from 72 to 77
- `tests/test-thresholds-constants.sh`: Added tests 13-14 to verify the new threshold values (80% warning, 77% clear)
- `tests/test-disk-hysteresis.sh`: Updated test 12 to use threshold-relative values instead of hardcoded numbers, making it resilient to future threshold changes

## Evidence
This is a backend threshold change with no UI layout changes. All 26 quality checks pass, including the disk hysteresis and threshold constant test suites.

## Test Plan
- Added test asserting `DISK_WARNING_PERCENT === 80` (test 13 in test-thresholds-constants.sh)
- Added test asserting `DISK_WARNING_CLEAR_PERCENT === 77` (test 14 in test-thresholds-constants.sh)
- Refactored hysteresis oscillation test to use `THRESHOLDS` constants instead of hardcoded values
- All existing tests continue to pass with the updated thresholds

---

## Automated Fix Details
This PR addresses issue #71: **Increase the high disk alarm threshold to 80%**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #71
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-71 -->