### PR TITLE
Fix false positive error highlighting for directory listing filenames

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.0.95";
+const VERSION = "1.1.5";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.0.95" rel="stylesheet">
+    <link href="./styles.css?v=1.1.5" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.0.95"></script>
+    <script src="./dashboard.js?v=1.1.5"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.0.95')
+                navigator.serviceWorker.register('./sw.js?v=1.1.5')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/log-viewer.html
+++ b/docs/log-viewer.html
@@ -204,6 +204,12 @@
                 if (line.includes('[MemoryMonitor]')) {
                     return `<div data-line-index="${index}">${escapeHtml(line)}</div>`;
                 }
+                // Issue #73: Skip directory listing lines (ls -la output) — filenames
+                // may contain keywords like ERROR or Exception that are not real errors
+                const isDirListingLine = /^[dlcbps-][rwxsStT-]{9}/.test(line);
+                if (isDirListingLine) {
+                    return `<div data-line-index="${index}">${escapeHtml(line)}</div>`;
+                }
                 // Be specific to avoid false positives from training metrics that mention "Error:"
                 if (line.includes('ERROR') ||
                     line.includes('Exception') || 

--- a/docs/pr-summary-73.md
+++ b/docs/pr-summary-73.md
@@ -1,0 +1,34 @@
+## Summary
+
+Directory listing lines (from `ls -la` output) containing filenames with keywords like
+"ERROR" or "Exception" were being incorrectly highlighted as error lines in the log viewer.
+For example, files named `.CRISPR-ERROR-Industry 5th percentile.json` were flagged as errors
+even though they are just data filenames, not actual errors.
+
+Added a check to detect directory listing lines by their file permission prefix pattern
+(e.g., `-rw-r--r--`, `drwxr-xr-x`) and skip error/warning classification for those lines.
+This ensures filenames containing error-related keywords are not falsely flagged.
+
+Closes #73.
+
+## Evidence
+
+This is a log viewer classification fix (no visual UI to screenshot). The fix is verified
+by 7 new unit tests that confirm:
+- Directory listing lines with "ERROR" in filenames are classified as normal
+- Directory listing lines with "Exception" in filenames are classified as normal
+- Directory listing lines with "WARNING" in filenames are classified as normal
+- Real ERROR lines are still correctly flagged as errors
+
+All 26 quality checks pass, including the 19 log viewer classification tests.
+
+## Test Plan
+
+- Added 7 new test cases to `tests/test-log-viewer-classification.sh` (tests 13–19):
+  - Test 13: `ls -la` line with `.CRISPR-ERROR-Industry` filename → normal
+  - Test 14: `ls -la` line with `.CRISPR-ERROR-Industry 95th percentile V2` filename → normal
+  - Test 15: Directory entry with `.CRISPR-ERROR-Insider-Bullish-7-v1` filename → normal
+  - Test 16: File entry with `ExceptionReport-2026.txt` filename → normal
+  - Test 17: File entry with `WARNING-old-report.csv` filename → normal
+  - Test 18: Real `ERROR:` line still correctly flagged as error-line
+  - Test 19: `total 47056` line (ls output) still classified as normal

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.0.95
+// Version: 1.1.5
 
-const CACHE_NAME = 'grq-health-v1.0.95';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.0.95';
+const CACHE_NAME = 'grq-health-v1.1.5';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.5';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.0.95',
+  './dashboard.js?v=1.1.5',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/tests/test-log-viewer-classification.sh
+++ b/tests/test-log-viewer-classification.sh
@@ -41,6 +41,13 @@ function classifyLine(line) {
     const isStackTraceLine = /^\s+at /.test(line);
     const isCStackTraceLine = /^\s+\d+\s+[^\s]+\s+0x[0-9a-fA-F]+/.test(line);
 
+    // Issue #73: Skip directory listing lines (ls -la output) — filenames
+    // may contain keywords like ERROR or Exception that are not real errors
+    const isDirListingLine = /^[dlcbps-][rwxsStT-]{9}/.test(line);
+    if (isDirListingLine) {
+        return 'normal';
+    }
+
     if (line.includes('ERROR') ||
         line.includes('Exception') ||
         line.startsWith('Error:') ||
@@ -192,6 +199,84 @@ function classifyLine(line) {
         console.log("TEST_RESULT:c-stack-trace:PASS:C stack trace flagged correctly");
     } else {
         console.log("TEST_RESULT:c-stack-trace:FAIL:expected stack-trace-line, got " + cls);
+    }
+}
+
+// Issue #73: Directory listing lines with ERROR in filenames should NOT be flagged
+// Test 13: ls -la output with CRISPR-ERROR filename should be normal
+{
+    const line = "-rw-r--r--  1 rocket staff  2003073 Oct 17 05:22 .CRISPR-ERROR-Industry 5th percentile.json";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:dir-listing-error-filename:PASS:directory listing with ERROR filename not flagged");
+    } else {
+        console.log("TEST_RESULT:dir-listing-error-filename:FAIL:expected normal, got " + cls);
+    }
+}
+
+// Test 14: ls -la output with another CRISPR-ERROR filename
+{
+    const line = "-rw-r--r--  1 rocket staff  2003134 Oct 17 05:22 .CRISPR-ERROR-Industry 95th percentile V2.json";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:dir-listing-error-filename-2:PASS:directory listing with ERROR filename not flagged");
+    } else {
+        console.log("TEST_RESULT:dir-listing-error-filename-2:FAIL:expected normal, got " + cls);
+    }
+}
+
+// Test 15: ls -la directory line with ERROR in name should be normal
+{
+    const line = "drwxr-xr-x  46 rocket staff  1472 Apr 16 05:29 .CRISPR-ERROR-Insider-Bullish-7-v1.json";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:dir-listing-error-dirname:PASS:directory listing with ERROR dirname not flagged");
+    } else {
+        console.log("TEST_RESULT:dir-listing-error-dirname:FAIL:expected normal, got " + cls);
+    }
+}
+
+// Test 16: ls -la output with Exception in filename should be normal
+{
+    const line = "-rw-r--r--  1 user staff  1024 Jan 10 12:00 ExceptionReport-2026.txt";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:dir-listing-exception-filename:PASS:directory listing with Exception filename not flagged");
+    } else {
+        console.log("TEST_RESULT:dir-listing-exception-filename:FAIL:expected normal, got " + cls);
+    }
+}
+
+// Test 17: ls -la output with WARNING in filename should be normal
+{
+    const line = "-rw-r--r--  1 user staff  512 Mar 05 09:30 WARNING-old-report.csv";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:dir-listing-warning-filename:PASS:directory listing with WARNING filename not flagged");
+    } else {
+        console.log("TEST_RESULT:dir-listing-warning-filename:FAIL:expected normal, got " + cls);
+    }
+}
+
+// Test 18: Real ERROR line should still be flagged (not a directory listing)
+{
+    const line = "ERROR: Disk space critically low";
+    const cls = classifyLine(line);
+    if (cls === "error-line") {
+        console.log("TEST_RESULT:real-error-still-flagged:PASS:real ERROR still flagged after dir listing fix");
+    } else {
+        console.log("TEST_RESULT:real-error-still-flagged:FAIL:expected error-line, got " + cls);
+    }
+}
+
+// Test 19: ls total line should be normal (not a directory listing but also not an error)
+{
+    const line = "total 47056";
+    const cls = classifyLine(line);
+    if (cls === "normal") {
+        console.log("TEST_RESULT:ls-total-line:PASS:ls total line is normal");
+    } else {
+        console.log("TEST_RESULT:ls-total-line:FAIL:expected normal, got " + cls);
     }
 }
 DENO_SCRIPT


### PR DESCRIPTION
## Summary

Directory listing lines (from `ls -la` output) containing filenames with keywords like
"ERROR" or "Exception" were being incorrectly highlighted as error lines in the log viewer.
For example, files named `.CRISPR-ERROR-Industry 5th percentile.json` were flagged as errors
even though they are just data filenames, not actual errors.

Added a check to detect directory listing lines by their file permission prefix pattern
(e.g., `-rw-r--r--`, `drwxr-xr-x`) and skip error/warning classification for those lines.
This ensures filenames containing error-related keywords are not falsely flagged.

Closes #73.

## Evidence

This is a log viewer classification fix (no visual UI to screenshot). The fix is verified
by 7 new unit tests that confirm:
- Directory listing lines with "ERROR" in filenames are classified as normal
- Directory listing lines with "Exception" in filenames are classified as normal
- Directory listing lines with "WARNING" in filenames are classified as normal
- Real ERROR lines are still correctly flagged as errors

All 26 quality checks pass, including the 19 log viewer classification tests.

## Test Plan

- Added 7 new test cases to `tests/test-log-viewer-classification.sh` (tests 13–19):
  - Test 13: `ls -la` line with `.CRISPR-ERROR-Industry` filename → normal
  - Test 14: `ls -la` line with `.CRISPR-ERROR-Industry 95th percentile V2` filename → normal
  - Test 15: Directory entry with `.CRISPR-ERROR-Insider-Bullish-7-v1` filename → normal
  - Test 16: File entry with `ExceptionReport-2026.txt` filename → normal
  - Test 17: File entry with `WARNING-old-report.csv` filename → normal
  - Test 18: Real `ERROR:` line still correctly flagged as error-line
  - Test 19: `total 47056` line (ls output) still classified as normal