### PR TITLE
Document failure reporting contract + add report_repo_health helper (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ The "last updated" timestamp shown in the dashboard is calculated from the most 
 ./helpers/repos.sh "Quality" --failed --log /path/to/run.log --exit-code 1 --message "3 shellcheck errors"
 ```
 
+External task runners (e.g. a Quality gate in a worker repo) should follow the copy-paste patterns in [`helpers/REPO_HEALTH_SNIPPET.md`](helpers/REPO_HEALTH_SNIPPET.md), which documents both the inline if/else form and a sourceable `report_repo_health` helper that picks success vs. failure automatically from `$?`. See [Reporting failures with a log file](helpers/REPO_HEALTH_SNIPPET.md#reporting-failures-with-a-log-file) for the full caller contract (flags, public-log warning, retention).
+
 ### Enhanced Health Status Classification
 
 - **Healthy**: 

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.7";
+const VERSION = "1.1.8";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.7" rel="stylesheet">
+    <link href="./styles.css?v=1.1.8" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -105,14 +105,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.7"></script>
+    <script src="./dashboard.js?v=1.1.8"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.7')
+                navigator.serviceWorker.register('./sw.js?v=1.1.8')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-78.md
+++ b/docs/pr-summary-78.md
@@ -1,0 +1,72 @@
+## Summary
+
+Documented and implemented the caller integration path for reporting task
+failures through `helpers/repos.sh`, so external task runners can adopt the
+`--failed --log` contract introduced in #76. Closes #78.
+
+Changes:
+
+- **`helpers/REPO_HEALTH_SNIPPET.md`** — added a "Reporting failures with a
+  log file" section with:
+  - The exact inline `if/else` copy-paste pattern from the issue.
+  - A simpler sourceable-helper alternative (`report_repo_health`).
+  - A flag reference table (`--failed`, `--log`, `--exit-code`, `--message`).
+  - An explicit security warning that log contents are published publicly on
+    GitHub Pages and that callers must redact secrets before handing over a
+    log file.
+  - A log-retention note (last 5 per task, slugged directory naming).
+  - A backwards-compatibility statement for existing success-only callers.
+- **`helpers/repo-health-snippet.sh`** — refactored from a standalone
+  copy-paste script into a sourceable library that exposes a single
+  `report_repo_health <task> <log_file>` function. The function:
+  - Captures `$?` on entry and chooses success vs. failure automatically.
+  - Calls `repos.sh "<task>"` on success.
+  - Calls `repos.sh "<task>" --failed --log "<log>" --exit-code "<N>"` on
+    failure.
+  - Preserves the original exit code so the caller can propagate it.
+  - Honours `GRQ_HEALTH_DIR` / `GRQ_HEALTH_REPO` env overrides.
+  - Clones the GRQ-health checkout if missing, and prints a usage message
+    when executed directly rather than sourced.
+- **`README.md`** — added a cross-link from the "Repo Freshness JSON" /
+  "Recording failures" section to the new failure-reporting documentation so
+  operators land in the right place.
+- Bumped `VERSION` from 1.1.7 → 1.1.8 and synced via `update_version.sh`.
+
+## Evidence
+
+This change is backend/CLI documentation plus a sourceable bash helper — there
+is no web UI surface to screenshot. Verification is via the new unit tests
+(see Test Plan) and the existing `test-repos-failure.sh` / `test-repos-validation.sh`
+which continue to pass.
+
+`./quality.sh` result:
+
+```
+Total tests: 28
+Passed: 28
+Failed: 0
+QUALITY CHECK PASSED
+```
+
+## Test Plan
+
+- **Added** `tests/test-report-repo-health.sh` with 8 assertions that source
+  the refactored `repo-health-snippet.sh` and drive `report_repo_health`
+  against a stub `repos.sh`:
+  1. `report_repo_health` is defined after sourcing.
+  2. Success path (`$? == 0`) invokes `repos.sh` with only the task name.
+  3. Failure path (`$? != 0`) invokes `repos.sh` with `--failed --log`.
+  4. Failure path also records `--exit-code <N>`.
+  5. The function returns the original non-zero exit code on failure (`7`).
+  6. The function returns `0` on success.
+  7. `GRQ_HEALTH_DIR` override is honoured.
+  8. An empty task name is rejected with a non-zero return.
+- **Existing tests kept passing**:
+  - `tests/test-repos-failure.sh` — failure-mode contract in `repos.sh`.
+  - `tests/test-repos-validation.sh` — repo-name validation, including
+    command-injection guards.
+  - All 28 tests in `./quality.sh` pass cleanly.
+- **No regressions for success-only callers**: the default
+  `repos.sh "<task>"` invocation is unchanged. The `REPO_HEALTH_SNIPPET.md`
+  copy-paste template for the original success-only pattern is retained in
+  the same file.

--- a/docs/repos.json
+++ b/docs/repos.json
@@ -2,7 +2,7 @@
   "repos": [
     {
       "name": "Dividends",
-      "last_commit_ts": 1776391585,
+      "last_commit_ts": 1776396216,
       "warning_days": 3,
       "error_days": 5
     },

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.7
+// Version: 1.1.8
 
-const CACHE_NAME = 'grq-health-v1.1.7';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.7';
+const CACHE_NAME = 'grq-health-v1.1.8';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.8';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.7',
+  './dashboard.js?v=1.1.8',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/helpers/REPO_HEALTH_SNIPPET.md
+++ b/helpers/REPO_HEALTH_SNIPPET.md
@@ -4,7 +4,7 @@ Add this snippet to the end of your market load scripts (after git commit/push) 
 
 ## Simple Version (Copy-Paste Ready)
 
-Add this to your script after a successful `git push`, customizing the repo name:
+Add this to your script after a successful `git push`, customising the repo name:
 
 ```bash
 if [ $? -eq 0 ]; then
@@ -46,6 +46,89 @@ if [ $? -eq 0 ]; then
 fi
 ```
 
+## Reporting failures with a log file
+
+External task runners (for example, a Quality gate in a worker repo) often want
+to report **both** successful and failed runs. When a task fails, capture its
+output to a log file and hand that log to `repos.sh` with the `--failed` and
+`--log` flags. The dashboard will then show the most recent failure alongside
+its log, and operators can inspect what went wrong without digging into the
+host.
+
+### Copy-paste pattern (inline if/else)
+
+```bash
+# Example: wrapping a quality check
+LOG_FILE="$HOME/logs/quality.log"
+
+if ./quality.sh >"$LOG_FILE" 2>&1; then
+    ./helpers/repos.sh "Quality"
+else
+    EXIT=$?
+    ./helpers/repos.sh "Quality" --failed --log "$LOG_FILE" --exit-code "$EXIT"
+    exit "$EXIT"
+fi
+```
+
+### Single-function helper
+
+If you prefer not to hand-roll the if/else, `source` the helper library and
+call `report_repo_health` right after the task. The function inspects `$?` of
+the previous command and picks the success or failure path automatically:
+
+```bash
+# Source the helper library once
+source "../GRQ-health/helpers/repo-health-snippet.sh"
+
+LOG_FILE="$HOME/logs/quality.log"
+./quality.sh >"$LOG_FILE" 2>&1
+report_repo_health "Quality" "$LOG_FILE" || exit $?
+```
+
+The helper honours the `GRQ_HEALTH_DIR` and `GRQ_HEALTH_REPO` environment
+variables if you need to point at a different checkout or remote. It preserves
+the original exit code so the caller can propagate a non-zero status.
+
+### What the failure flags do
+
+| Flag | Required? | Purpose |
+|------|-----------|---------|
+| `--failed` | Yes (for a failure report) | Marks the call as a failure report. `last_commit_ts` is left untouched. |
+| `--log <path>` | Yes (with `--failed`) | Path to the log file to store alongside the failure entry. Use `-` to read from stdin. |
+| `--exit-code <N>` | Optional | Records the non-zero exit status in `last_failure_exit_code`. |
+| `--message <text>` | Optional | Records a short one-line summary in `last_failure_message`. |
+
+Only invoke `--failed` when the task actually failed. A successful run should
+still use the plain `repos.sh "<task>"` form so that `last_commit_ts` is
+updated.
+
+### ⚠️ Security: logs are published publicly
+
+Log files handed to `repos.sh` are copied into `docs/logs/<task-slug>/` inside
+the GRQ-health repository and **committed to the public GitHub Pages site**.
+
+- Before calling `repos.sh --failed --log`, the caller MUST redact any
+  secrets, credentials, tokens, internal hostnames, customer data, or anything
+  else that should not be published.
+- Never pass a raw log that may include environment dumps, `set -x` traces of
+  commands that contain secrets, or authentication headers.
+- If in doubt, redact aggressively or capture a summary log instead of the
+  full transcript.
+
+### Log retention
+
+`repos.sh` keeps the **last 5 log files per task**. Older logs are deleted
+automatically when a new failure is recorded. Task names are converted to safe
+directory slugs (alphanumeric, hyphens, underscores) before being used as a
+directory name, so `ScoreClient:luke` becomes `docs/logs/ScoreClient-luke/`.
+
+### Backwards compatibility
+
+Existing callers that only report successes continue to work without changes.
+The failure-reporting flags are additive: the default invocation
+(`repos.sh "<task>"`) is unchanged and records a successful run exactly as
+before.
+
 ## How It Works
 
 1. The snippet only runs if `git push` succeeds (`$? -eq 0`)
@@ -61,10 +144,10 @@ fi
 
 The dashboard (`dashboard.js`) automatically calculates status based on `last_commit_ts`:
 - **ERROR** (red): Last commit more than 48 hours ago
-- **WARNING** (yellow): Last commit more than 24 hours ago  
+- **WARNING** (yellow): Last commit more than 24 hours ago
 - **OK** (green): Last commit within 24 hours
 
-## Customization
+## Customisation
 
 - **Repo Name**: Change `"Dividends"` in the last line to your repo's display name (e.g., "FX", "Commodities", "SharePrices")
 - **GRQ_HEALTH_DIR**: Adjust path if GRQ-health is in a different location relative to your script
@@ -72,7 +155,9 @@ The dashboard (`dashboard.js`) automatically calculates status based on `last_co
 
 ## Notes
 
-- The snippet only runs if `git push` succeeds, so failed pushes won't update health tracking
+- The success-only snippet only runs if `git push` succeeds, so failed pushes won't update health tracking
 - `repos.sh` handles all git operations (pull, commit, push) internally with conflict recovery
 - The script uses `--depth=1` for cloning to save time and disk space
-
+- For callers that also want to report **failures**, see the
+  [Reporting failures with a log file](#reporting-failures-with-a-log-file)
+  section above

--- a/helpers/repo-health-snippet.sh
+++ b/helpers/repo-health-snippet.sh
@@ -1,22 +1,109 @@
 #!/bin/bash
 # Repo Health Tracking Snippet
-# Add this to the end of your market load scripts (after git commit/push)
 #
-# Usage: Add this after a successful git push, customizing REPO_NAME
+# This file can be used in two ways:
+#
+#   1. As a sourceable library that exposes report_repo_health().
+#      Example:
+#           LOG_FILE="$HOME/logs/quality.log"
+#           source /path/to/GRQ-health/helpers/repo-health-snippet.sh
+#           ./quality.sh >"$LOG_FILE" 2>&1
+#           report_repo_health "Quality" "$LOG_FILE" || exit $?
+#
+#   2. As a copy-paste template. See helpers/REPO_HEALTH_SNIPPET.md for the
+#      canonical copy-paste patterns (success-only and success-plus-failure).
+#
+# IMPORTANT: log contents are committed publicly to the GRQ-health repo.
+# Callers MUST redact any secrets before passing a log file to this helper.
 
-if [ $? -eq 0 ]; then
-  ## Update health tracking
-  GRQ_HEALTH_DIR="../GRQ-health"
-  GRQ_HEALTH_REPO="git@github.com:stSoftwareAU/GRQ-health.git"
+# Default location of the GRQ-health checkout relative to the caller's CWD.
+# Override either variable from the caller's environment before sourcing or
+# before invoking report_repo_health().
+: "${GRQ_HEALTH_DIR:=../GRQ-health}"
+: "${GRQ_HEALTH_REPO:=git@github.com:stSoftwareAU/GRQ-health.git}"
 
-  # If GRQ-health doesn't exist, clone it; otherwise pull latest
-  if [ ! -d "$GRQ_HEALTH_DIR" ]; then
-      git clone --depth=1 "$GRQ_HEALTH_REPO" "$GRQ_HEALTH_DIR"
-  else
-      git -C "$GRQ_HEALTH_DIR" pull
-  fi
+# Ensure the GRQ-health checkout exists, cloning it if necessary.
+_grq_health_ensure_checkout() {
+    local dir="$1"
+    local repo="$2"
+    if [ ! -d "$dir" ]; then
+        git clone --depth=1 "$repo" "$dir" >/dev/null 2>&1 || {
+            echo "Warning: failed to clone GRQ-health from $repo" >&2
+            return 1
+        }
+    fi
+    return 0
+}
 
-  # Update repo health
-  "${GRQ_HEALTH_DIR}/helpers/repos.sh" "Dividends"  # CHANGE THIS to your repo name
+# report_repo_health <task_name> <log_file>
+#
+# Call this immediately after the task whose outcome you want to report. The
+# function inspects $? (the exit status of the previous command) and invokes
+# helpers/repos.sh with the matching success or failure flags:
+#
+#   - exit 0  -> repos.sh "<task_name>"
+#   - exit N  -> repos.sh "<task_name>" --failed --log "<log_file>" --exit-code "N"
+#
+# The function returns the original exit code so callers can continue to
+# propagate it (e.g. `report_repo_health "Quality" "$LOG_FILE" || exit $?`).
+#
+# Log files passed to this helper are copied into the GRQ-health repo under
+# docs/logs/<task-slug>/ and committed publicly. Only the last 5 log files per
+# task are retained (retention is handled by repos.sh).
+report_repo_health() {
+    local exit_code=$?
+    local task_name="$1"
+    local log_file="$2"
+
+    if [ -z "$task_name" ]; then
+        echo "Error: report_repo_health requires a task name." >&2
+        return 2
+    fi
+
+    local dir="${GRQ_HEALTH_DIR:-../GRQ-health}"
+    local repo="${GRQ_HEALTH_REPO:-git@github.com:stSoftwareAU/GRQ-health.git}"
+
+    if ! _grq_health_ensure_checkout "$dir" "$repo"; then
+        return "$exit_code"
+    fi
+
+    local repos_script="${dir}/helpers/repos.sh"
+    if [ ! -x "$repos_script" ]; then
+        echo "Warning: ${repos_script} is not executable or missing." >&2
+        return "$exit_code"
+    fi
+
+    if [ "$exit_code" -eq 0 ]; then
+        "$repos_script" "$task_name"
+    else
+        if [ -z "$log_file" ]; then
+            echo "Error: report_repo_health requires a log file path on failure." >&2
+            return "$exit_code"
+        fi
+        if [ ! -f "$log_file" ]; then
+            echo "Warning: log file not found at $log_file — skipping failure report." >&2
+            return "$exit_code"
+        fi
+        "$repos_script" "$task_name" --failed --log "$log_file" --exit-code "$exit_code"
+    fi
+
+    return "$exit_code"
+}
+
+# When the file is executed directly (rather than sourced) print a short
+# usage message. The copy-paste templates live in REPO_HEALTH_SNIPPET.md.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    cat <<'USAGE'
+repo-health-snippet.sh is a sourceable library, not a runnable script.
+
+Usage:
+    source /path/to/GRQ-health/helpers/repo-health-snippet.sh
+
+    LOG_FILE="$HOME/logs/quality.log"
+    ./quality.sh >"$LOG_FILE" 2>&1
+    report_repo_health "Quality" "$LOG_FILE" || exit $?
+
+See helpers/REPO_HEALTH_SNIPPET.md for copy-paste patterns.
+USAGE
+    exit 0
 fi
-

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.7"
+VERSION="1.1.8"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/test-report-repo-health.sh
+++ b/tests/test-report-repo-health.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+# Test for Issue #78: report_repo_health helper function in repo-health-snippet.sh
+# Verifies that callers can source the helper and use a single function call to
+# report both success and failure paths to repos.sh.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNIPPET_SCRIPT="$SCRIPT_DIR/../helpers/repo-health-snippet.sh"
+
+echo "Testing Issue #78: report_repo_health helper"
+echo "============================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Create a test environment with a stub repos.sh that records invocations
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+setup_test_env() {
+    local test_dir="$TMPDIR_BASE/test_$$_$RANDOM"
+    mkdir -p "$test_dir/helpers"
+
+    # Create a stub repos.sh that records its invocation arguments
+    cat > "$test_dir/helpers/repos.sh" <<'STUB'
+#!/bin/bash
+# Stub repos.sh — records arguments to a file for test assertions
+INVOCATIONS_FILE="${INVOCATIONS_FILE:-/tmp/invocations.txt}"
+printf '%s\n' "$*" >> "$INVOCATIONS_FILE"
+exit 0
+STUB
+    chmod +x "$test_dir/helpers/repos.sh"
+
+    echo "$test_dir"
+}
+
+# --------------------------------------------------------------------------
+# Test 1: report_repo_health is defined as a function after sourcing
+# --------------------------------------------------------------------------
+echo "Test 1: sourcing the snippet defines report_repo_health..."
+
+# Run in a subshell to avoid polluting the parent shell
+RESULT=$(
+    # shellcheck disable=SC1090
+    source "$SNIPPET_SCRIPT" 2>/dev/null
+    if declare -f report_repo_health >/dev/null 2>&1; then
+        echo "DEFINED"
+    else
+        echo "MISSING"
+    fi
+)
+
+if [ "$RESULT" = "DEFINED" ]; then
+    pass_test "report_repo_health is defined after sourcing"
+else
+    fail_test "report_repo_health is not defined after sourcing"
+fi
+
+# --------------------------------------------------------------------------
+# Test 2: Success path — repos.sh called with just the task name
+# --------------------------------------------------------------------------
+echo "Test 2: success path invokes repos.sh with task name only..."
+TEST_DIR=$(setup_test_env)
+INVOCATIONS_FILE="$TEST_DIR/invocations.txt"
+: > "$INVOCATIONS_FILE"
+export INVOCATIONS_FILE
+
+LOG_FILE="$TEST_DIR/task.log"
+echo "some log output" > "$LOG_FILE"
+
+(
+    export GRQ_HEALTH_DIR="$TEST_DIR"
+    # shellcheck disable=SC1090
+    source "$SNIPPET_SCRIPT"
+
+    # Simulate a successful command by setting $? to 0
+    true
+    report_repo_health "Quality" "$LOG_FILE"
+) 2>/dev/null
+
+if [ -f "$INVOCATIONS_FILE" ]; then
+    INVOCATION=$(cat "$INVOCATIONS_FILE")
+    if [ "$INVOCATION" = "Quality" ]; then
+        pass_test "success call invokes repos.sh with task name"
+    else
+        fail_test "unexpected invocation (got: '$INVOCATION', expected: 'Quality')"
+    fi
+else
+    fail_test "repos.sh was not invoked"
+fi
+
+# --------------------------------------------------------------------------
+# Test 3: Failure path — repos.sh called with --failed --log --exit-code
+# --------------------------------------------------------------------------
+echo "Test 3: failure path invokes repos.sh with --failed --log..."
+TEST_DIR=$(setup_test_env)
+INVOCATIONS_FILE="$TEST_DIR/invocations.txt"
+: > "$INVOCATIONS_FILE"
+export INVOCATIONS_FILE
+
+LOG_FILE="$TEST_DIR/task.log"
+echo "error details" > "$LOG_FILE"
+
+(
+    export GRQ_HEALTH_DIR="$TEST_DIR"
+    # shellcheck disable=SC1090
+    source "$SNIPPET_SCRIPT"
+
+    # Simulate a failing command by setting $? to 3
+    (exit 3)
+    report_repo_health "Quality" "$LOG_FILE"
+) 2>/dev/null || true
+
+if [ -f "$INVOCATIONS_FILE" ]; then
+    INVOCATION=$(cat "$INVOCATIONS_FILE")
+    if [[ "$INVOCATION" == *"Quality"* ]] \
+       && [[ "$INVOCATION" == *"--failed"* ]] \
+       && [[ "$INVOCATION" == *"--log"* ]] \
+       && [[ "$INVOCATION" == *"$LOG_FILE"* ]]; then
+        pass_test "failure call invokes repos.sh with --failed and --log"
+    else
+        fail_test "unexpected failure invocation (got: '$INVOCATION')"
+    fi
+
+    if [[ "$INVOCATION" == *"--exit-code 3"* ]]; then
+        pass_test "failure call records the exit code"
+    else
+        fail_test "failure call did not record exit code 3 (got: '$INVOCATION')"
+    fi
+else
+    fail_test "repos.sh was not invoked on failure"
+fi
+
+# --------------------------------------------------------------------------
+# Test 4: Exit code is preserved so caller can propagate it
+# --------------------------------------------------------------------------
+echo "Test 4: report_repo_health returns the original exit code..."
+TEST_DIR=$(setup_test_env)
+INVOCATIONS_FILE="$TEST_DIR/invocations.txt"
+: > "$INVOCATIONS_FILE"
+export INVOCATIONS_FILE
+
+LOG_FILE="$TEST_DIR/task.log"
+echo "log" > "$LOG_FILE"
+
+SUBSHELL_EXIT=$(
+    (
+        export GRQ_HEALTH_DIR="$TEST_DIR"
+        # shellcheck disable=SC1090
+        source "$SNIPPET_SCRIPT"
+        (exit 7)
+        report_repo_health "Quality" "$LOG_FILE"
+        echo "$?"
+    ) 2>/dev/null
+)
+
+if [ "$SUBSHELL_EXIT" = "7" ]; then
+    pass_test "report_repo_health preserves exit code 7"
+else
+    fail_test "exit code not preserved (got: '$SUBSHELL_EXIT', expected: 7)"
+fi
+
+# --------------------------------------------------------------------------
+# Test 5: Success path returns zero
+# --------------------------------------------------------------------------
+echo "Test 5: success returns zero..."
+TEST_DIR=$(setup_test_env)
+INVOCATIONS_FILE="$TEST_DIR/invocations.txt"
+: > "$INVOCATIONS_FILE"
+export INVOCATIONS_FILE
+
+LOG_FILE="$TEST_DIR/task.log"
+echo "log" > "$LOG_FILE"
+
+SUBSHELL_EXIT=$(
+    (
+        export GRQ_HEALTH_DIR="$TEST_DIR"
+        # shellcheck disable=SC1090
+        source "$SNIPPET_SCRIPT"
+        true
+        report_repo_health "Quality" "$LOG_FILE"
+        echo "$?"
+    ) 2>/dev/null
+)
+
+if [ "$SUBSHELL_EXIT" = "0" ]; then
+    pass_test "report_repo_health returns zero on success"
+else
+    fail_test "success did not return zero (got: '$SUBSHELL_EXIT')"
+fi
+
+# --------------------------------------------------------------------------
+# Test 6: GRQ_HEALTH_DIR environment variable is respected
+# --------------------------------------------------------------------------
+echo "Test 6: GRQ_HEALTH_DIR override is respected..."
+TEST_DIR=$(setup_test_env)
+INVOCATIONS_FILE="$TEST_DIR/invocations.txt"
+: > "$INVOCATIONS_FILE"
+export INVOCATIONS_FILE
+
+LOG_FILE="$TEST_DIR/task.log"
+echo "log" > "$LOG_FILE"
+
+# Put a unique marker in the stub so we know this particular stub ran
+cat > "$TEST_DIR/helpers/repos.sh" <<STUB
+#!/bin/bash
+echo "CUSTOM_DIR_MARKER \$*" >> "$INVOCATIONS_FILE"
+exit 0
+STUB
+chmod +x "$TEST_DIR/helpers/repos.sh"
+
+(
+    export GRQ_HEALTH_DIR="$TEST_DIR"
+    # shellcheck disable=SC1090
+    source "$SNIPPET_SCRIPT"
+    true
+    report_repo_health "Quality" "$LOG_FILE"
+) 2>/dev/null
+
+if grep -q "CUSTOM_DIR_MARKER Quality" "$INVOCATIONS_FILE"; then
+    pass_test "GRQ_HEALTH_DIR override is used"
+else
+    fail_test "GRQ_HEALTH_DIR override was not used"
+fi
+
+# --------------------------------------------------------------------------
+# Test 7: Missing arguments are rejected clearly
+# --------------------------------------------------------------------------
+echo "Test 7: missing arguments rejected..."
+
+SUBSHELL_EXIT=$(
+    (
+        export GRQ_HEALTH_DIR="$TMPDIR_BASE/does-not-matter"
+        # shellcheck disable=SC1090
+        source "$SNIPPET_SCRIPT"
+        report_repo_health "" ""
+        echo "$?"
+    ) 2>/dev/null
+)
+
+if [ "$SUBSHELL_EXIT" != "0" ]; then
+    pass_test "report_repo_health rejects empty task name"
+else
+    fail_test "report_repo_health accepted empty task name"
+fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "============================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Refactored `helpers/repo-health-snippet.sh` from a copy-paste template into a sourceable library that exposes `report_repo_health <task> <log_file>`. The function reads `$?` of the preceding command and calls `repos.sh` with either the success form or `--failed --log --exit-code` on failure, preserving the original exit code.
- Updated `helpers/REPO_HEALTH_SNIPPET.md` with a worked failure-reporting example, a flag reference table, a public-log security warning, and the 5-files-per-task retention note.
- Added a cross-link from `README.md` (Repo Freshness JSON section) to the new failure-reporting documentation.
- Bumped `VERSION` to 1.1.8 and synced via `update_version.sh`.

Closes #78. Part of #75. Depends on #76 (already merged).

## Test plan

- [x] `./quality.sh` — 28/28 tests pass, including the new `test-report-repo-health.sh`
- [x] New test exercises: function definition, success path, failure path (`--failed`, `--log`, `--exit-code`), exit-code propagation, `GRQ_HEALTH_DIR` override, and empty-task-name rejection
- [x] Existing `test-repos-failure.sh` and `test-repos-validation.sh` still pass — no regression in `repos.sh`
- [x] `REPO_HEALTH_SNIPPET.md` retains the original success-only copy-paste template, so existing callers need no changes

See `docs/pr-summary-78.md` for the full summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)