### PR TITLE
Update README disk threshold docs to match code (80%/77%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,11 @@ External task runners (e.g. a Quality gate in a worker repo) should follow the c
 
 - **Healthy**: 
   - Heartbeat within 24 hours
-  - Disk usage under 75%
+  - Disk usage under 80%
   - OS version up to date
 - **Warning**:
-  - Disk usage at or above 75% (with hysteresis: clears only when dropping to or below 72%)
+  - Disk usage at or above 80% (with hysteresis: clears only when dropping to or below 77%)
+  - A host can remain in warning state between 77% and 80% until it drops below the clear threshold — this hysteresis band prevents status oscillation when disk usage hovers near the boundary
   - Outdated OS version
   - Heartbeat within 24 hours
 - **Critical**: 

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,11 +99,11 @@ Mobile machines that are expected to be offline:
 
 ### Healthy
 - Heartbeat within 24 hours
-- Disk usage under 75%
+- Disk usage under 80%
 - OS version up to date
 
 ### Warning
-- Disk usage over 75%
+- Disk usage at or above 80% (with hysteresis: clears at or below 77%)
 - Outdated OS version
 - Heartbeat within 24 hours
 

--- a/docs/pr-summary-83.md
+++ b/docs/pr-summary-83.md
@@ -1,0 +1,21 @@
+## Summary
+Updated README.md and docs/README.md disk threshold documentation to match the actual code constants in `docs/dashboard.js` (80% warning / 77% hysteresis clear) instead of the stale 75% / 72% figures. Added a plain-English explanation of the hysteresis band (77–80%). Closes #83.
+
+## Changes
+- `README.md`: Updated "Disk usage under 75%" to "under 80%", "at or above 75%" to "at or above 80%", "dropping to or below 72%" to "dropping to or below 77%". Added sentence explaining hysteresis behaviour.
+- `docs/README.md`: Updated matching stale thresholds (75% to 80%, "over 75%" to "at or above 80% with hysteresis").
+- `tests/test-readme-disk-thresholds.sh`: New test that extracts DISK_WARNING_PERCENT and DISK_WARNING_CLEAR_PERCENT from dashboard.js and verifies README.md documents the correct values.
+
+## Evidence
+Documentation-only change — no UI or performance impact. Verified by:
+- New test `test-readme-disk-thresholds.sh` (6 assertions) confirms README values match code constants
+- All 30 quality checks pass including the new test
+
+## Test Plan
+- Added `tests/test-readme-disk-thresholds.sh` with 6 test cases:
+  - README healthy threshold matches code (under 80%)
+  - README warning trigger matches code (at or above 80%)
+  - README clear threshold matches code (dropping to or below 77%)
+  - No stale 75% value remains in README
+  - Hysteresis behaviour is explained
+  - Both 77% and 80% thresholds are referenced

--- a/tests/test-readme-disk-thresholds.sh
+++ b/tests/test-readme-disk-thresholds.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Test for Issue #83: README disk threshold documentation matches code
+# Verifies that README.md documents the correct disk warning/clear percentages
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Testing Issue #83: README disk threshold documentation"
+echo "======================================================"
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Extract the actual code constants from dashboard.js using awk to get only the value
+DISK_WARNING=$(awk '/DISK_WARNING_PERCENT:/ && !/CLEAR/' "$REPO_ROOT/docs/dashboard.js" | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | tr -d ' ')
+DISK_CLEAR=$(awk '/DISK_WARNING_CLEAR_PERCENT:/' "$REPO_ROOT/docs/dashboard.js" | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | tr -d ' ')
+
+echo "Code constants: warning=${DISK_WARNING}%, clear=${DISK_CLEAR}%"
+echo ""
+
+# Test 1: README.md mentions the correct warning threshold
+if grep -q "Disk usage under ${DISK_WARNING}%" "$REPO_ROOT/README.md"; then
+    pass_test "README.md healthy threshold matches code (under ${DISK_WARNING}%)"
+else
+    fail_test "README.md healthy threshold does not mention 'under ${DISK_WARNING}%'"
+fi
+
+# Test 2: README.md mentions the correct warning trigger
+if grep -q "Disk usage at or above ${DISK_WARNING}%" "$REPO_ROOT/README.md"; then
+    pass_test "README.md warning trigger matches code (at or above ${DISK_WARNING}%)"
+else
+    fail_test "README.md warning trigger does not mention 'at or above ${DISK_WARNING}%'"
+fi
+
+# Test 3: README.md mentions the correct clear threshold
+if grep -q "dropping to or below ${DISK_CLEAR}%" "$REPO_ROOT/README.md"; then
+    pass_test "README.md clear threshold matches code (dropping to or below ${DISK_CLEAR}%)"
+else
+    fail_test "README.md clear threshold does not mention 'dropping to or below ${DISK_CLEAR}%'"
+fi
+
+# Test 4: README.md does NOT contain the old stale thresholds in the health classification section
+if grep -q "Disk usage under 75%" "$REPO_ROOT/README.md"; then
+    fail_test "README.md still contains stale 'Disk usage under 75%'"
+else
+    pass_test "README.md does not contain stale 75% healthy threshold"
+fi
+
+# Test 5: README.md mentions hysteresis behaviour between clear and warning thresholds
+if grep -qi "hysteresis" "$REPO_ROOT/README.md"; then
+    pass_test "README.md explains hysteresis behaviour"
+else
+    fail_test "README.md does not mention hysteresis behaviour"
+fi
+
+# Test 6: README.md explains the hysteresis band
+if grep -q "${DISK_CLEAR}%" "$REPO_ROOT/README.md" && grep -q "${DISK_WARNING}%" "$REPO_ROOT/README.md"; then
+    pass_test "README.md references both ${DISK_CLEAR}% and ${DISK_WARNING}% thresholds"
+else
+    fail_test "README.md missing one or both threshold values (${DISK_CLEAR}%/${DISK_WARNING}%)"
+fi
+
+echo ""
+echo "======================================================"
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Updated README.md and docs/README.md disk threshold documentation to match the actual code constants in `docs/dashboard.js` (80% warning / 77% hysteresis clear) instead of the stale 75% / 72% figures. Added a plain-English explanation of the hysteresis band (77–80%). Closes #83.

## Changes
- `README.md`: Updated "Disk usage under 75%" to "under 80%", "at or above 75%" to "at or above 80%", "dropping to or below 72%" to "dropping to or below 77%". Added sentence explaining hysteresis behaviour.
- `docs/README.md`: Updated matching stale thresholds (75% to 80%, "over 75%" to "at or above 80% with hysteresis").
- `tests/test-readme-disk-thresholds.sh`: New test that extracts DISK_WARNING_PERCENT and DISK_WARNING_CLEAR_PERCENT from dashboard.js and verifies README.md documents the correct values.

## Evidence
Documentation-only change — no UI or performance impact. Verified by:
- New test `test-readme-disk-thresholds.sh` (6 assertions) confirms README values match code constants
- All 30 quality checks pass including the new test

## Test Plan
- Added `tests/test-readme-disk-thresholds.sh` with 6 test cases:
  - README healthy threshold matches code (under 80%)
  - README warning trigger matches code (at or above 80%)
  - README clear threshold matches code (dropping to or below 77%)
  - No stale 75% value remains in README
  - Hysteresis behaviour is explained
  - Both 77% and 80% thresholds are referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)