### PR TITLE
Clarify high-disk warning message when caused by hysteresis (#84)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.9";
+const VERSION = "1.1.10";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -748,6 +748,20 @@ function isDiskWarning(diskPercent, wasPreviouslyWarning) {
     return !!wasPreviouslyWarning;
 }
 
+// Issue #84: Build a descriptive disk warning message that clarifies
+// whether the warning is from exceeding the threshold or from hysteresis.
+// Returns an empty string when the disk is not in a warning state.
+function buildDiskWarningMessage(diskPercent, wasPreviouslyWarning) {
+    if (!isDiskWarning(diskPercent, wasPreviouslyWarning)) {
+        return '';
+    }
+    if (diskPercent >= THRESHOLDS.DISK_WARNING_PERCENT) {
+        return `High disk usage: ${diskPercent}% (>= ${THRESHOLDS.DISK_WARNING_PERCENT}%)`;
+    }
+    // In the hysteresis band — explain the behaviour
+    return `High disk usage: ${diskPercent}% (in hysteresis band, will clear at or below ${THRESHOLDS.DISK_WARNING_CLEAR_PERCENT}%)`;
+}
+
 function getHealthStatus(_hostname, data, options) {
     // Check if this is a dead machine
     if (data.death_date) {
@@ -1301,7 +1315,10 @@ function updateStats(hosts) {
         const warningHtml = warningHosts.map(([hostname, data]) => {
             let warningReason = '';
             if (data.used_disk_percent && diskWarningState[hostname]) {
-                warningReason += `High disk usage: ${data.used_disk_percent}%`;
+                warningReason += buildDiskWarningMessage(
+                    parseFloat(data.used_disk_percent),
+                    true
+                );
             }
             if (data.config_warning) {
                 if (warningReason) warningReason += ', ';

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -748,17 +748,13 @@ function isDiskWarning(diskPercent, wasPreviouslyWarning) {
     return !!wasPreviouslyWarning;
 }
 
-// Issue #84: Build a descriptive disk warning message that clarifies
-// whether the warning is from exceeding the threshold or from hysteresis.
-// Returns an empty string when the disk is not in a warning state.
-function buildDiskWarningMessage(diskPercent, wasPreviouslyWarning) {
-    if (!isDiskWarning(diskPercent, wasPreviouslyWarning)) {
-        return '';
-    }
+// Issue #84: Build a descriptive disk warning message that distinguishes
+// above-threshold from hysteresis-band cases.
+function buildDiskWarningMessage(diskPercent) {
     if (diskPercent >= THRESHOLDS.DISK_WARNING_PERCENT) {
         return `High disk usage: ${diskPercent}% (>= ${THRESHOLDS.DISK_WARNING_PERCENT}%)`;
     }
-    // In the hysteresis band — explain the behaviour
+    // In hysteresis band (below warning threshold but above clear threshold)
     return `High disk usage: ${diskPercent}% (in hysteresis band, will clear at or below ${THRESHOLDS.DISK_WARNING_CLEAR_PERCENT}%)`;
 }
 
@@ -1315,10 +1311,7 @@ function updateStats(hosts) {
         const warningHtml = warningHosts.map(([hostname, data]) => {
             let warningReason = '';
             if (data.used_disk_percent && diskWarningState[hostname]) {
-                warningReason += buildDiskWarningMessage(
-                    parseFloat(data.used_disk_percent),
-                    true
-                );
+                warningReason += buildDiskWarningMessage(parseFloat(data.used_disk_percent));
             }
             if (data.config_warning) {
                 if (warningReason) warningReason += ', ';

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.9" rel="stylesheet">
+    <link href="./styles.css?v=1.1.10" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -107,14 +107,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.9"></script>
+    <script src="./dashboard.js?v=1.1.10"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.9')
+                navigator.serviceWorker.register('./sw.js?v=1.1.10')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-84.md
+++ b/docs/pr-summary-84.md
@@ -1,29 +1,26 @@
 ## Summary
-Clarify the "High disk usage" warning message so that when a host is flagged due to hysteresis (current usage below 80% but previously above it), the message makes the reason explicit. Closes #84.
+Clarify the "High disk usage" warning message so it distinguishes between above-threshold and hysteresis-band cases. When disk usage is >= 80%, the message reads `High disk usage: X% (>= 80%)`. When in the hysteresis band (77–80%), it reads `High disk usage: X% (in hysteresis band, will clear at or below 77%)`. Threshold values are read from `THRESHOLDS` constants, not hardcoded. Closes #84.
 
-Added `buildDiskWarningMessage(diskPercent, wasPreviouslyWarning)` which returns:
-- **At or above threshold**: `High disk usage: X% (>= 80%)`
-- **In hysteresis band**: `High disk usage: X% (in hysteresis band, will clear at or below 77%)`
-- **Not in warning**: empty string
-
-Threshold values are read from `THRESHOLDS.DISK_WARNING_PERCENT` and `THRESHOLDS.DISK_WARNING_CLEAR_PERCENT` — nothing is hardcoded.
+## Changes
+- Added `buildDiskWarningMessage(diskPercent)` pure function in `docs/dashboard.js` (after `isDiskWarning`)
+- Updated the warning section renderer to call `buildDiskWarningMessage` instead of inline string
+- Bumped VERSION to 1.1.10 and ran `update_version.sh`
 
 ## Evidence
-This is a backend/dashboard logic change with no visual layout changes. The warning text is generated in JavaScript and rendered in the warning hosts section. Verified via 11 new unit tests covering both message branches, edge cases, and threshold usage.
+This is a backend/JS logic change with no new UI layout. The message text is verified by unit tests:
+- `High disk usage: 85.2% (>= 80%)` — above threshold
+- `High disk usage: 78.4% (in hysteresis band, will clear at or below 77%)` — in band
 
-All 30 quality checks pass (including the 11 new tests in `test-disk-warning-message.sh`).
+All 30 quality checks pass including 8 new tests.
 
 ## Test Plan
-- Added `tests/test-disk-warning-message.sh` with 11 tests:
+- Added `tests/test-disk-warning-message.sh` with 8 tests covering:
   - `function-exists` — `buildDiskWarningMessage` is defined
-  - `above-threshold-msg` — message includes disk% and trigger threshold
-  - `above-threshold-gte` — message contains `>=` symbol
-  - `hysteresis-msg` — hysteresis band message mentions "hysteresis"
-  - `hysteresis-clear-threshold` — hysteresis message includes the clear threshold
-  - `at-threshold-msg` — at exactly the threshold uses the above-threshold message
-  - `uses-thresholds` — messages reference THRESHOLDS constants, not hardcoded values
-  - `prefix-above` — above-threshold message starts with "High disk usage:"
-  - `prefix-band` — hysteresis message starts with "High disk usage:"
-  - `no-warning-empty` — returns empty string when not in warning state
-  - `band-no-prev-warning` — returns empty when in band but not previously warning
+  - `above-threshold-msg` — above-threshold message includes usage and trigger threshold
+  - `at-threshold-msg` — at exactly the threshold uses `>=` notation
+  - `hysteresis-band-msg` — hysteresis message explains hysteresis and includes clear threshold
+  - `hysteresis-shows-usage` — hysteresis message includes actual usage percentage
+  - `above-no-hysteresis` — above-threshold message does not mention hysteresis
+  - `dynamic-thresholds` — threshold values come from `THRESHOLDS` constants
+  - `prefix-consistent` — both message variants share consistent prefix
 - All existing tests continue to pass (`./quality.sh` — 30/30)

--- a/docs/pr-summary-84.md
+++ b/docs/pr-summary-84.md
@@ -1,0 +1,29 @@
+## Summary
+Clarify the "High disk usage" warning message so that when a host is flagged due to hysteresis (current usage below 80% but previously above it), the message makes the reason explicit. Closes #84.
+
+Added `buildDiskWarningMessage(diskPercent, wasPreviouslyWarning)` which returns:
+- **At or above threshold**: `High disk usage: X% (>= 80%)`
+- **In hysteresis band**: `High disk usage: X% (in hysteresis band, will clear at or below 77%)`
+- **Not in warning**: empty string
+
+Threshold values are read from `THRESHOLDS.DISK_WARNING_PERCENT` and `THRESHOLDS.DISK_WARNING_CLEAR_PERCENT` — nothing is hardcoded.
+
+## Evidence
+This is a backend/dashboard logic change with no visual layout changes. The warning text is generated in JavaScript and rendered in the warning hosts section. Verified via 11 new unit tests covering both message branches, edge cases, and threshold usage.
+
+All 30 quality checks pass (including the 11 new tests in `test-disk-warning-message.sh`).
+
+## Test Plan
+- Added `tests/test-disk-warning-message.sh` with 11 tests:
+  - `function-exists` — `buildDiskWarningMessage` is defined
+  - `above-threshold-msg` — message includes disk% and trigger threshold
+  - `above-threshold-gte` — message contains `>=` symbol
+  - `hysteresis-msg` — hysteresis band message mentions "hysteresis"
+  - `hysteresis-clear-threshold` — hysteresis message includes the clear threshold
+  - `at-threshold-msg` — at exactly the threshold uses the above-threshold message
+  - `uses-thresholds` — messages reference THRESHOLDS constants, not hardcoded values
+  - `prefix-above` — above-threshold message starts with "High disk usage:"
+  - `prefix-band` — hysteresis message starts with "High disk usage:"
+  - `no-warning-empty` — returns empty string when not in warning state
+  - `band-no-prev-warning` — returns empty when in band but not previously warning
+- All existing tests continue to pass (`./quality.sh` — 30/30)

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.9
+// Version: 1.1.10
 
-const CACHE_NAME = 'grq-health-v1.1.9';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.9';
+const CACHE_NAME = 'grq-health-v1.1.10';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.10';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.9',
+  './dashboard.js?v=1.1.10',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.9"
+VERSION="1.1.10"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/test-disk-warning-message.sh
+++ b/tests/test-disk-warning-message.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# Test for Issue #84: Clarify high-disk warning message when caused by hysteresis
-# Verifies that the disk warning message distinguishes between above-threshold
-# and hysteresis-band cases.
+# Test for Issue #84: Disk warning message clarifies hysteresis
+# Verifies that the warning message distinguishes between above-threshold
+# and hysteresis-band cases, using dynamic threshold values.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/extract-functions.sh"
 
-echo "Testing Issue #84: Disk warning message clarity"
-echo "================================================="
+echo "Testing Issue #84: Disk warning message clarifies hysteresis"
+echo "============================================================="
 echo ""
 
 PASS_COUNT=0
@@ -26,126 +26,93 @@ fail_test() {
 }
 
 OUTPUT=$(run_js_test '
-// Test 1: buildDiskWarningMessage exists
+// Test 1: buildDiskWarningMessage function exists
 {
     if (typeof buildDiskWarningMessage === "function") {
-        console.log("TEST_RESULT:function-exists:PASS:buildDiskWarningMessage exists");
+        console.log("TEST_RESULT:function-exists:PASS:buildDiskWarningMessage function exists");
     } else {
-        console.log("TEST_RESULT:function-exists:FAIL:buildDiskWarningMessage not found");
+        console.log("TEST_RESULT:function-exists:FAIL:buildDiskWarningMessage function not found");
     }
 }
 
 // Test 2: Above threshold — message references the trigger threshold
 {
-    const msg = buildDiskWarningMessage(85, true);
+    const msg = buildDiskWarningMessage(85.2);
     const expected = THRESHOLDS.DISK_WARNING_PERCENT;
-    if (msg.includes(String(expected)) && msg.includes("85")) {
-        console.log("TEST_RESULT:above-threshold-msg:PASS:message includes disk% and threshold: " + msg);
+    if (msg.includes("85.2%") && msg.includes(String(expected) + "%")) {
+        console.log("TEST_RESULT:above-threshold-msg:PASS:message includes usage and threshold: " + msg);
     } else {
-        console.log("TEST_RESULT:above-threshold-msg:FAIL:expected threshold " + expected + " and 85 in message, got: " + msg);
+        console.log("TEST_RESULT:above-threshold-msg:FAIL:expected usage 85.2% and threshold " + expected + "% in message, got: " + msg);
     }
 }
 
-// Test 3: Above threshold — message contains >= symbol
+// Test 3: At exactly the threshold — message references the trigger threshold
 {
-    const msg = buildDiskWarningMessage(85, true);
-    if (msg.includes(">=")) {
-        console.log("TEST_RESULT:above-threshold-gte:PASS:message contains >= for above-threshold case");
+    const atThreshold = THRESHOLDS.DISK_WARNING_PERCENT;
+    const msg = buildDiskWarningMessage(atThreshold);
+    if (msg.includes(String(atThreshold) + "%") && msg.includes(">=" )) {
+        console.log("TEST_RESULT:at-threshold-msg:PASS:message at threshold: " + msg);
     } else {
-        console.log("TEST_RESULT:above-threshold-gte:FAIL:expected >= in message, got: " + msg);
+        console.log("TEST_RESULT:at-threshold-msg:FAIL:expected >= and threshold in message, got: " + msg);
     }
 }
 
-// Test 4: In hysteresis band — message mentions hysteresis
+// Test 4: In hysteresis band — message mentions hysteresis and clear threshold
 {
-    const midPoint = (THRESHOLDS.DISK_WARNING_PERCENT + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT) / 2;
-    const msg = buildDiskWarningMessage(midPoint, true);
-    if (msg.toLowerCase().includes("hysteresis")) {
-        console.log("TEST_RESULT:hysteresis-msg:PASS:hysteresis band message mentions hysteresis: " + msg);
-    } else {
-        console.log("TEST_RESULT:hysteresis-msg:FAIL:expected hysteresis in message, got: " + msg);
-    }
-}
-
-// Test 5: In hysteresis band — message references the clear threshold
-{
-    const midPoint = (THRESHOLDS.DISK_WARNING_PERCENT + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT) / 2;
-    const msg = buildDiskWarningMessage(midPoint, true);
+    const inBand = THRESHOLDS.DISK_WARNING_PERCENT - 1;
+    const msg = buildDiskWarningMessage(inBand);
     const clearThreshold = THRESHOLDS.DISK_WARNING_CLEAR_PERCENT;
-    if (msg.includes(String(clearThreshold))) {
-        console.log("TEST_RESULT:hysteresis-clear-threshold:PASS:hysteresis message includes clear threshold " + clearThreshold);
+    if (msg.includes("hysteresis") && msg.includes(String(clearThreshold) + "%")) {
+        console.log("TEST_RESULT:hysteresis-band-msg:PASS:message explains hysteresis: " + msg);
     } else {
-        console.log("TEST_RESULT:hysteresis-clear-threshold:FAIL:expected clear threshold " + clearThreshold + " in message, got: " + msg);
+        console.log("TEST_RESULT:hysteresis-band-msg:FAIL:expected hysteresis and clear threshold " + clearThreshold + "% in message, got: " + msg);
     }
 }
 
-// Test 6: At exactly the warning threshold — uses above-threshold message
+// Test 5: In hysteresis band — message includes actual usage percentage
 {
-    const msg = buildDiskWarningMessage(THRESHOLDS.DISK_WARNING_PERCENT, true);
-    if (msg.includes(">=") && !msg.toLowerCase().includes("hysteresis")) {
-        console.log("TEST_RESULT:at-threshold-msg:PASS:at threshold uses above-threshold message: " + msg);
+    const inBand = 78.4;
+    const msg = buildDiskWarningMessage(inBand);
+    if (msg.includes("78.4%")) {
+        console.log("TEST_RESULT:hysteresis-shows-usage:PASS:hysteresis message includes usage: " + msg);
     } else {
-        console.log("TEST_RESULT:at-threshold-msg:FAIL:at threshold should use above-threshold message, got: " + msg);
+        console.log("TEST_RESULT:hysteresis-shows-usage:FAIL:expected 78.4% in message, got: " + msg);
     }
 }
 
-// Test 7: Threshold values come from THRESHOLDS constants, not hardcoded
+// Test 6: Above threshold — message does NOT mention hysteresis
 {
-    const msg85 = buildDiskWarningMessage(85, true);
+    const msg = buildDiskWarningMessage(85);
+    if (!msg.includes("hysteresis")) {
+        console.log("TEST_RESULT:above-no-hysteresis:PASS:above-threshold message does not mention hysteresis");
+    } else {
+        console.log("TEST_RESULT:above-no-hysteresis:FAIL:above-threshold message should not mention hysteresis, got: " + msg);
+    }
+}
+
+// Test 7: Threshold values are dynamic (not hardcoded 80/77)
+{
+    const aboveMsg = buildDiskWarningMessage(90);
+    const bandMsg = buildDiskWarningMessage(THRESHOLDS.DISK_WARNING_PERCENT - 1);
     const warnPct = THRESHOLDS.DISK_WARNING_PERCENT;
     const clearPct = THRESHOLDS.DISK_WARNING_CLEAR_PERCENT;
-    const midPoint = (warnPct + clearPct) / 2;
-    const msgBand = buildDiskWarningMessage(midPoint, true);
-    // Verify the above-threshold message contains the warning threshold
-    const aboveOk = msg85.includes(String(warnPct));
-    // Verify the hysteresis message contains the clear threshold
-    const bandOk = msgBand.includes(String(clearPct));
+    const aboveOk = aboveMsg.includes(String(warnPct) + "%");
+    const bandOk = bandMsg.includes(String(clearPct) + "%");
     if (aboveOk && bandOk) {
-        console.log("TEST_RESULT:uses-thresholds:PASS:messages use THRESHOLDS constants (warn=" + warnPct + ", clear=" + clearPct + ")");
+        console.log("TEST_RESULT:dynamic-thresholds:PASS:messages use THRESHOLDS values " + warnPct + " and " + clearPct);
     } else {
-        console.log("TEST_RESULT:uses-thresholds:FAIL:messages should reference THRESHOLDS constants, above:" + msg85 + " band:" + msgBand);
+        console.log("TEST_RESULT:dynamic-thresholds:FAIL:messages should use dynamic thresholds, aboveOk=" + aboveOk + " bandOk=" + bandOk);
     }
 }
 
-// Test 8: Message starts with "High disk usage:" prefix
+// Test 8: Message always starts with "High disk usage:"
 {
-    const msg = buildDiskWarningMessage(85, true);
-    if (msg.startsWith("High disk usage:")) {
-        console.log("TEST_RESULT:prefix-above:PASS:above-threshold message starts with correct prefix");
+    const msg1 = buildDiskWarningMessage(85);
+    const msg2 = buildDiskWarningMessage(78);
+    if (msg1.startsWith("High disk usage:") && msg2.startsWith("High disk usage:")) {
+        console.log("TEST_RESULT:prefix-consistent:PASS:both messages start with High disk usage:");
     } else {
-        console.log("TEST_RESULT:prefix-above:FAIL:expected prefix High disk usage:, got: " + msg);
-    }
-}
-
-// Test 9: Hysteresis message also starts with "High disk usage:" prefix
-{
-    const midPoint = (THRESHOLDS.DISK_WARNING_PERCENT + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT) / 2;
-    const msg = buildDiskWarningMessage(midPoint, true);
-    if (msg.startsWith("High disk usage:")) {
-        console.log("TEST_RESULT:prefix-band:PASS:hysteresis message starts with correct prefix");
-    } else {
-        console.log("TEST_RESULT:prefix-band:FAIL:expected prefix High disk usage:, got: " + msg);
-    }
-}
-
-// Test 10: Not in warning — returns empty string
-{
-    const msg = buildDiskWarningMessage(50, false);
-    if (msg === "") {
-        console.log("TEST_RESULT:no-warning-empty:PASS:returns empty when not in warning");
-    } else {
-        console.log("TEST_RESULT:no-warning-empty:FAIL:expected empty string, got: " + msg);
-    }
-}
-
-// Test 11: In hysteresis band but not previously warning — returns empty string
-{
-    const midPoint = (THRESHOLDS.DISK_WARNING_PERCENT + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT) / 2;
-    const msg = buildDiskWarningMessage(midPoint, false);
-    if (msg === "") {
-        console.log("TEST_RESULT:band-no-prev-warning:PASS:returns empty when in band but not previously warning");
-    } else {
-        console.log("TEST_RESULT:band-no-prev-warning:FAIL:expected empty string for band without prev warning, got: " + msg);
+        console.log("TEST_RESULT:prefix-consistent:FAIL:messages should start with High disk usage:, got: [" + msg1 + "] and [" + msg2 + "]");
     }
 }
 ')
@@ -166,7 +133,7 @@ while IFS= read -r line; do
 done <<< "$OUTPUT"
 
 echo ""
-echo "================================================="
+echo "============================================================="
 echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
 
 if [ "$FAIL_COUNT" -gt 0 ]; then

--- a/tests/test-disk-warning-message.sh
+++ b/tests/test-disk-warning-message.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Test for Issue #84: Clarify high-disk warning message when caused by hysteresis
+# Verifies that the disk warning message distinguishes between above-threshold
+# and hysteresis-band cases.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/extract-functions.sh"
+
+echo "Testing Issue #84: Disk warning message clarity"
+echo "================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+OUTPUT=$(run_js_test '
+// Test 1: buildDiskWarningMessage exists
+{
+    if (typeof buildDiskWarningMessage === "function") {
+        console.log("TEST_RESULT:function-exists:PASS:buildDiskWarningMessage exists");
+    } else {
+        console.log("TEST_RESULT:function-exists:FAIL:buildDiskWarningMessage not found");
+    }
+}
+
+// Test 2: Above threshold — message references the trigger threshold
+{
+    const msg = buildDiskWarningMessage(85, true);
+    const expected = THRESHOLDS.DISK_WARNING_PERCENT;
+    if (msg.includes(String(expected)) && msg.includes("85")) {
+        console.log("TEST_RESULT:above-threshold-msg:PASS:message includes disk% and threshold: " + msg);
+    } else {
+        console.log("TEST_RESULT:above-threshold-msg:FAIL:expected threshold " + expected + " and 85 in message, got: " + msg);
+    }
+}
+
+// Test 3: Above threshold — message contains >= symbol
+{
+    const msg = buildDiskWarningMessage(85, true);
+    if (msg.includes(">=")) {
+        console.log("TEST_RESULT:above-threshold-gte:PASS:message contains >= for above-threshold case");
+    } else {
+        console.log("TEST_RESULT:above-threshold-gte:FAIL:expected >= in message, got: " + msg);
+    }
+}
+
+// Test 4: In hysteresis band — message mentions hysteresis
+{
+    const midPoint = (THRESHOLDS.DISK_WARNING_PERCENT + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT) / 2;
+    const msg = buildDiskWarningMessage(midPoint, true);
+    if (msg.toLowerCase().includes("hysteresis")) {
+        console.log("TEST_RESULT:hysteresis-msg:PASS:hysteresis band message mentions hysteresis: " + msg);
+    } else {
+        console.log("TEST_RESULT:hysteresis-msg:FAIL:expected hysteresis in message, got: " + msg);
+    }
+}
+
+// Test 5: In hysteresis band — message references the clear threshold
+{
+    const midPoint = (THRESHOLDS.DISK_WARNING_PERCENT + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT) / 2;
+    const msg = buildDiskWarningMessage(midPoint, true);
+    const clearThreshold = THRESHOLDS.DISK_WARNING_CLEAR_PERCENT;
+    if (msg.includes(String(clearThreshold))) {
+        console.log("TEST_RESULT:hysteresis-clear-threshold:PASS:hysteresis message includes clear threshold " + clearThreshold);
+    } else {
+        console.log("TEST_RESULT:hysteresis-clear-threshold:FAIL:expected clear threshold " + clearThreshold + " in message, got: " + msg);
+    }
+}
+
+// Test 6: At exactly the warning threshold — uses above-threshold message
+{
+    const msg = buildDiskWarningMessage(THRESHOLDS.DISK_WARNING_PERCENT, true);
+    if (msg.includes(">=") && !msg.toLowerCase().includes("hysteresis")) {
+        console.log("TEST_RESULT:at-threshold-msg:PASS:at threshold uses above-threshold message: " + msg);
+    } else {
+        console.log("TEST_RESULT:at-threshold-msg:FAIL:at threshold should use above-threshold message, got: " + msg);
+    }
+}
+
+// Test 7: Threshold values come from THRESHOLDS constants, not hardcoded
+{
+    const msg85 = buildDiskWarningMessage(85, true);
+    const warnPct = THRESHOLDS.DISK_WARNING_PERCENT;
+    const clearPct = THRESHOLDS.DISK_WARNING_CLEAR_PERCENT;
+    const midPoint = (warnPct + clearPct) / 2;
+    const msgBand = buildDiskWarningMessage(midPoint, true);
+    // Verify the above-threshold message contains the warning threshold
+    const aboveOk = msg85.includes(String(warnPct));
+    // Verify the hysteresis message contains the clear threshold
+    const bandOk = msgBand.includes(String(clearPct));
+    if (aboveOk && bandOk) {
+        console.log("TEST_RESULT:uses-thresholds:PASS:messages use THRESHOLDS constants (warn=" + warnPct + ", clear=" + clearPct + ")");
+    } else {
+        console.log("TEST_RESULT:uses-thresholds:FAIL:messages should reference THRESHOLDS constants, above:" + msg85 + " band:" + msgBand);
+    }
+}
+
+// Test 8: Message starts with "High disk usage:" prefix
+{
+    const msg = buildDiskWarningMessage(85, true);
+    if (msg.startsWith("High disk usage:")) {
+        console.log("TEST_RESULT:prefix-above:PASS:above-threshold message starts with correct prefix");
+    } else {
+        console.log("TEST_RESULT:prefix-above:FAIL:expected prefix High disk usage:, got: " + msg);
+    }
+}
+
+// Test 9: Hysteresis message also starts with "High disk usage:" prefix
+{
+    const midPoint = (THRESHOLDS.DISK_WARNING_PERCENT + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT) / 2;
+    const msg = buildDiskWarningMessage(midPoint, true);
+    if (msg.startsWith("High disk usage:")) {
+        console.log("TEST_RESULT:prefix-band:PASS:hysteresis message starts with correct prefix");
+    } else {
+        console.log("TEST_RESULT:prefix-band:FAIL:expected prefix High disk usage:, got: " + msg);
+    }
+}
+
+// Test 10: Not in warning — returns empty string
+{
+    const msg = buildDiskWarningMessage(50, false);
+    if (msg === "") {
+        console.log("TEST_RESULT:no-warning-empty:PASS:returns empty when not in warning");
+    } else {
+        console.log("TEST_RESULT:no-warning-empty:FAIL:expected empty string, got: " + msg);
+    }
+}
+
+// Test 11: In hysteresis band but not previously warning — returns empty string
+{
+    const midPoint = (THRESHOLDS.DISK_WARNING_PERCENT + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT) / 2;
+    const msg = buildDiskWarningMessage(midPoint, false);
+    if (msg === "") {
+        console.log("TEST_RESULT:band-no-prev-warning:PASS:returns empty when in band but not previously warning");
+    } else {
+        console.log("TEST_RESULT:band-no-prev-warning:FAIL:expected empty string for band without prev warning, got: " + msg);
+    }
+}
+')
+
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*)
+            local_name="$(echo "$line" | cut -d: -f2)"
+            local_result="$(echo "$line" | cut -d: -f3)"
+            local_detail="$(echo "$line" | cut -d: -f4-)"
+            if [ "$local_result" = "PASS" ]; then
+                pass_test "$local_name — $local_detail"
+            else
+                fail_test "$local_name — $local_detail"
+            fi
+            ;;
+    esac
+done <<< "$OUTPUT"
+
+echo ""
+echo "================================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Clarify the "High disk usage" warning message so it distinguishes between above-threshold and hysteresis-band cases. When disk usage is >= 80%, the message reads `High disk usage: X% (>= 80%)`. When in the hysteresis band (77–80%), it reads `High disk usage: X% (in hysteresis band, will clear at or below 77%)`. Threshold values are read from `THRESHOLDS` constants, not hardcoded. Closes #84.

## Changes
- Added `buildDiskWarningMessage(diskPercent)` pure function in `docs/dashboard.js` (after `isDiskWarning`)
- Updated the warning section renderer to call `buildDiskWarningMessage` instead of inline string
- Bumped VERSION to 1.1.10 and ran `update_version.sh`

## Evidence
This is a backend/JS logic change with no new UI layout. The message text is verified by unit tests:
- `High disk usage: 85.2% (>= 80%)` — above threshold
- `High disk usage: 78.4% (in hysteresis band, will clear at or below 77%)` — in band

All 30 quality checks pass including 8 new tests.

## Test Plan
- Added `tests/test-disk-warning-message.sh` with 8 tests covering:
  - `function-exists` — `buildDiskWarningMessage` is defined
  - `above-threshold-msg` — above-threshold message includes usage and trigger threshold
  - `at-threshold-msg` — at exactly the threshold uses `>=` notation
  - `hysteresis-band-msg` — hysteresis message explains hysteresis and includes clear threshold
  - `hysteresis-shows-usage` — hysteresis message includes actual usage percentage
  - `above-no-hysteresis` — above-threshold message does not mention hysteresis
  - `dynamic-thresholds` — threshold values come from `THRESHOLDS` constants
  - `prefix-consistent` — both message variants share consistent prefix
- All existing tests continue to pass (`./quality.sh` — 30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)