### PR TITLE
Pin GitHub Actions in workflows to 40-character commit SHAs (Issue #93)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,11 @@
 name: Deploy to GitHub Pages
 
+# Supply-chain policy: every third-party action below is pinned to a 40-char
+# commit SHA, with the human-readable version recorded as a trailing comment.
+# Do not replace the SHA with a moving tag (e.g. @v4) when bumping versions —
+# resolve the new tag to its commit SHA and update both the SHA and the
+# trailing # vX.Y.Z comment in lock-step. See issue #93 / VibeCoding #1613.
+
 on:
   push:
     branches: [ Develop ]
@@ -21,16 +27,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
       - name: Setup Pages
-        uses: actions/configure-pages@v4
-        
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: './docs'
-          
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/docs/pr-summary-93.md
+++ b/docs/pr-summary-93.md
@@ -1,0 +1,37 @@
+## Summary
+Pinned every `uses:` reference in `.github/workflows/deploy.yml` to a 40-character commit SHA, with a trailing `# vX.Y.Z` comment recording the human-readable version. Added a header comment block documenting the supply-chain pin convention so future contributors keep the format. The four other workflow files (`dependency-review.yml`, `gitleaks.yml`, `semgrep.yml`, `shellcheck.yml`) were already SHA-pinned and required no changes.
+
+This is the security baseline required by VibeCoding #1613 ("Pin GitHub Actions to commit SHAs") and a prerequisite for the auto-bump work in #88. Closes #93.
+
+Resolved SHAs (pinned at the version currently in use — no version bumps):
+
+| Action | Tag | SHA |
+| --- | --- | --- |
+| `actions/checkout` | `v4.3.1` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
+| `actions/configure-pages` | `v4.0.0` | `1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d` |
+| `actions/upload-pages-artifact` | `v3.0.1` | `56afc609e74202658d3ffba0e8f6dda462b719fa` |
+| `actions/deploy-pages` | `v4.0.5` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |
+
+## Evidence
+Backend / CI-only change; no UI to screenshot. Verified by:
+
+- `tests/test-deploy-workflow-pinned.sh` — new test, fails against the unpinned `deploy.yml` and passes after the change.
+- `./quality.sh` — full suite: 37 passed, 0 failed.
+
+```mermaid
+flowchart LR
+    A[deploy.yml uses: @v4 tag] --> B[Resolve tag → 40-char SHA via gh api]
+    B --> C[Rewrite uses: @SHA  # vX.Y.Z]
+    C --> D[New test asserts SHA + version comment]
+    D --> E[quality.sh green]
+```
+
+## Test Plan
+- Added `tests/test-deploy-workflow-pinned.sh` covering:
+  - workflow file exists and is valid YAML
+  - every `uses:` reference is pinned to a 40-character commit SHA
+  - every pinned line carries a trailing `# vX.Y.Z` comment
+  - no third-party action references a moving tag (`@main`, `@master`, `@vN`)
+  - the pin convention is documented via comments in `deploy.yml`
+- Confirmed the existing `test-{dependency-review,gitleaks,semgrep,shellcheck}-workflow.sh` tests still pass — those workflows were already pinned and were not modified.
+- Ran `./quality.sh < /dev/null` end-to-end: 37 passed, 0 failed.

--- a/tests/test-deploy-workflow-pinned.sh
+++ b/tests/test-deploy-workflow-pinned.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Test for Issue #93: Pin GitHub Actions in deploy.yml to 40-char commit SHAs.
+# Verifies the deploy workflow file pins every `uses:` reference to a
+# 40-character commit SHA and carries a trailing `# vX.Y.Z` version comment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_FILE="$SCRIPT_DIR/../.github/workflows/deploy.yml"
+
+echo "Testing Issue #93: deploy.yml SHA pinning"
+echo "========================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail_test() { echo "  FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# Test 1: workflow file exists
+if [ -f "$WORKFLOW_FILE" ]; then
+    pass_test "deploy.yml exists at .github/workflows/deploy.yml"
+else
+    fail_test "deploy.yml is missing from .github/workflows/"
+    echo ""
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    exit 1
+fi
+
+# Test 2: valid YAML
+if python3 -c "import yaml,sys; yaml.safe_load(open('$WORKFLOW_FILE'))" 2>/dev/null; then
+    pass_test "deploy.yml is valid YAML"
+else
+    fail_test "deploy.yml has YAML syntax errors"
+fi
+
+# Test 3: every `uses:` reference is pinned to a 40-char commit SHA, not a tag
+UNPINNED=$(grep -E '^\s*-?\s*uses:\s*' "$WORKFLOW_FILE" | grep -vE '@[0-9a-f]{40}(\s|$)' || true)
+if [ -z "$UNPINNED" ]; then
+    pass_test "All uses: references are pinned to 40-char commit SHAs"
+else
+    fail_test "Unpinned actions found:"
+    echo "$UNPINNED" | sed 's/^/    /'
+fi
+
+# Test 4: every pinned `uses:` line carries a trailing `# vX.Y.Z` version comment
+USES_LINES=$(grep -E '^\s*-?\s*uses:\s*\S+@[0-9a-f]{40}' "$WORKFLOW_FILE" || true)
+MISSING_VERSION=""
+if [ -n "$USES_LINES" ]; then
+    while IFS= read -r line; do
+        # Require a `# vX.Y[.Z]` style trailing comment after the SHA
+        if ! echo "$line" | grep -qE '@[0-9a-f]{40}\s+#\s*v[0-9]+(\.[0-9]+){1,2}'; then
+            MISSING_VERSION+="$line"$'\n'
+        fi
+    done <<< "$USES_LINES"
+fi
+if [ -z "$MISSING_VERSION" ]; then
+    pass_test "Every pinned uses: line carries a trailing # vX.Y.Z comment"
+else
+    fail_test "Pinned uses: lines missing # vX.Y.Z trailing comment:"
+    echo "$MISSING_VERSION" | sed 's/^/    /'
+fi
+
+# Test 5: no third-party action uses a moving tag (e.g. @main, @master, @vN)
+MOVING_TAG=$(grep -E '^\s*-?\s*uses:\s*\S+@(main|master|v[0-9]+)\s*$' "$WORKFLOW_FILE" || true)
+if [ -z "$MOVING_TAG" ]; then
+    pass_test "No actions reference moving tags (@main, @master, @vN)"
+else
+    fail_test "Actions referenced via moving tags found:"
+    echo "$MOVING_TAG" | sed 's/^/    /'
+fi
+
+# Test 6: a comment block in deploy.yml documents the SHA pin convention
+COMMENT_LINES=$(grep -E '^\s*#' "$WORKFLOW_FILE" || true)
+if echo "$COMMENT_LINES" | grep -qiE 'pin' && echo "$COMMENT_LINES" | grep -qiE 'sha'; then
+    pass_test "Pin convention is documented via comments in deploy.yml"
+else
+    fail_test "deploy.yml does not document the SHA pin convention via comments"
+fi
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Pinned every `uses:` reference in `.github/workflows/deploy.yml` to a 40-character commit SHA, with a trailing `# vX.Y.Z` comment recording the human-readable version. Added a header comment block documenting the supply-chain pin convention so future contributors keep the format. The four other workflow files (`dependency-review.yml`, `gitleaks.yml`, `semgrep.yml`, `shellcheck.yml`) were already SHA-pinned and required no changes.

This is the security baseline required by VibeCoding #1613 ("Pin GitHub Actions to commit SHAs") and a prerequisite for the auto-bump work in #88. Closes #93.

Resolved SHAs (pinned at the version currently in use — no version bumps):

| Action | Tag | SHA |
| --- | --- | --- |
| `actions/checkout` | `v4.3.1` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/configure-pages` | `v4.0.0` | `1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d` |
| `actions/upload-pages-artifact` | `v3.0.1` | `56afc609e74202658d3ffba0e8f6dda462b719fa` |
| `actions/deploy-pages` | `v4.0.5` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |

## Evidence
Backend / CI-only change; no UI to screenshot. Verified by:

- `tests/test-deploy-workflow-pinned.sh` — new test, fails against the unpinned `deploy.yml` and passes after the change.
- `./quality.sh` — full suite: 37 passed, 0 failed.

```mermaid
flowchart LR
    A[deploy.yml uses: @v4 tag] --> B[Resolve tag → 40-char SHA via gh api]
    B --> C[Rewrite uses: @SHA  # vX.Y.Z]
    C --> D[New test asserts SHA + version comment]
    D --> E[quality.sh green]
```

## Test Plan
- Added `tests/test-deploy-workflow-pinned.sh` covering:
  - workflow file exists and is valid YAML
  - every `uses:` reference is pinned to a 40-character commit SHA
  - every pinned line carries a trailing `# vX.Y.Z` comment
  - no third-party action references a moving tag (`@main`, `@master`, `@vN`)
  - the pin convention is documented via comments in `deploy.yml`
- Confirmed the existing `test-{dependency-review,gitleaks,semgrep,shellcheck}-workflow.sh` tests still pass — those workflows were already pinned and were not modified.
- Ran `./quality.sh < /dev/null` end-to-end: 37 passed, 0 failed.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-93 -->