### PR TITLE
docs: document the auto-bump dependency workflow (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,101 @@ When making code changes, you must:
 2. Run `./update_version.sh` to automatically update version numbers in all HTML and JavaScript files
 3. This ensures version consistency across the entire project
 
+## Dependency Maintenance
+
+Third-party GitHub Actions are pinned to commit SHAs and refreshed by an
+automated weekly job. The flow looks like:
+
+```mermaid
+flowchart LR
+    A[Cron: Mon 06:00 UTC] --> B[bump-deps.sh]
+    B --> C{Audit gate<br/>./quality.sh}
+    C -- pass --> D[PR on chore/bump-deps]
+    C -- fail --> E[Worker reverts]
+```
+
+### SHA pinning convention
+
+Every `uses:` line in `.github/workflows/*.yml` is pinned to a 40-char
+commit SHA, with the human-readable version recorded as a trailing
+comment. Never replace the SHA with a moving tag (e.g. `@v4`) — pinning
+to a SHA defends against supply-chain attacks where a release tag is
+re-pointed at malicious code. When the SHA is bumped, update the `# vX.Y.Z`
+comment in lock-step so reviewers can see the version change at a glance.
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+```
+
+### `bump-deps.sh`
+
+`./bump-deps.sh` walks every `uses:` line in `.github/workflows/*.yml`,
+resolves each action's latest release tag to its commit SHA, and rewrites
+the SHA + version comment in place. After applying bumps it runs
+`./quality.sh` as the audit gate; any failure exits non-zero so the
+worker can revert the change.
+
+Flags:
+
+- `--dry-run` — print the planned bumps without writing files; the audit
+  gate is skipped.
+- `--quarantine-hours <H>` — override `VIBE_BUMP_QUARANTINE_HOURS` for
+  this run. Must be a non-negative integer.
+- `--help`, `-h` — print full usage and exit.
+
+Run a manual bump locally:
+
+```bash
+# Preview the bumps without touching files
+./bump-deps.sh --dry-run
+
+# Apply bumps and run the audit gate
+./bump-deps.sh
+
+# Use a longer quarantine window (e.g. 72h)
+./bump-deps.sh --quarantine-hours 72
+```
+
+### Scheduled workflow
+
+`.github/workflows/bump-deps.yml` runs `./bump-deps.sh` on a weekly
+schedule at **06:00 UTC every Monday** — outside Australian business
+hours so any resulting PR is ready at the start of the week. It can also
+be triggered on demand via `workflow_dispatch` from the Actions tab.
+
+The workflow opens (or updates) a PR titled `chore: bump GitHub Action
+SHAs` on branch `chore/bump-deps`. It does not run on `pull_request` so
+the PR does not retrigger itself.
+
+### Quarantine policy
+
+External actions are quarantined to dodge fast-flagged supply-chain
+attacks: a release is only eligible to be bumped once it is at least
+`VIBE_BUMP_QUARANTINE_HOURS` old (default 24 hours). Internal actions
+under `stSoftwareAU/*` skip the quarantine and bump immediately, since
+we control the upstream.
+
+### Audit gate
+
+After applying bumps, `bump-deps.sh` invokes `./quality.sh` as the audit
+gate. If quality checks fail, the script exits non-zero and prints the
+offending bump diff so the worker can revert the change per the
+VibeCoding #1613 contract. The scheduled workflow only opens a PR when
+the audit gate passes.
+
+### Reviewer responsibilities
+
+Before merging an auto-generated `chore: bump GitHub Action SHAs` PR:
+
+- Confirm each new 40-char SHA matches the release tag listed in the
+  trailing `# vX.Y.Z` comment (spot-check on GitHub).
+- Confirm only `.github/workflows/*.yml` files changed — no unrelated
+  edits should appear.
+- Confirm CI is green; the audit gate has already run, but a fresh CI
+  run on the PR branch catches any flakiness.
+- For any new external action, confirm the upstream repository looks
+  legitimate (recent activity, real maintainer, not a typosquat).
+
 ## License
 
 This project is open source. Feel free to modify and distribute as needed.

--- a/docs/pr-summary-96.md
+++ b/docs/pr-summary-96.md
@@ -1,0 +1,48 @@
+## Summary
+
+Documented the auto-bump dependency workflow in `README.md` so future
+contributors and operators understand the SHA-pinning convention,
+`bump-deps.sh`, the scheduled workflow, the quarantine policy, the audit
+gate, and reviewer responsibilities. Closes #96.
+
+## Evidence
+
+CLI/documentation change — no UI to screenshot. The new section was
+verified by a TDD test (`tests/test-readme-bump-deps.sh`) that asserts
+each behavioural point is present in the README. Quality gate output:
+
+```
+Total tests: 40
+Passed: 40
+Failed: 0
+QUALITY CHECK PASSED
+```
+
+The new section embeds a Mermaid flow diagram so reviewers can see the
+end-to-end pipeline at a glance:
+
+```mermaid
+flowchart LR
+    A[Cron: Mon 06:00 UTC] --> B[bump-deps.sh]
+    B --> C{Audit gate<br/>./quality.sh}
+    C -- pass --> D[PR on chore/bump-deps]
+    C -- fail --> E[Worker reverts]
+```
+
+## Test Plan
+
+- Added `tests/test-readme-bump-deps.sh` — 11 assertions covering:
+  - `## Dependency Maintenance` heading present
+  - SHA pinning convention described (40-char SHAs)
+  - Example pinned `uses:` line with `# vX.Y.Z` comment
+  - `bump-deps.sh` documented with `--dry-run`, `--quarantine-hours`,
+    `--help` flags
+  - Local-usage example `./bump-deps.sh --dry-run` shown
+  - Schedule documented (Mondays 06:00 UTC)
+  - PR branch `chore/bump-deps` and `workflow_dispatch` referenced
+  - Quarantine policy (`VIBE_BUMP_QUARANTINE_HOURS=24`,
+    `stSoftwareAU/*` exemption) covered
+  - Audit gate (`./quality.sh`) documented
+  - Reviewer responsibilities listed
+  - Australian English spelling enforced for the new section
+- All 40 tests in `./quality.sh` pass.

--- a/tests/test-readme-bump-deps.sh
+++ b/tests/test-readme-bump-deps.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Test for Issue #96: README documents the auto-bump dependency workflow
+# Verifies that README.md contains the Dependency Maintenance section
+# covering SHA pinning, bump-deps.sh, the scheduled workflow, and
+# quarantine policy.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+README="$REPO_ROOT/README.md"
+
+echo "Testing Issue #96: README auto-bump documentation"
+echo "================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Test 1: README has the Dependency Maintenance section
+if grep -q "^## Dependency Maintenance" "$README"; then
+    pass_test "README contains '## Dependency Maintenance' section"
+else
+    fail_test "README missing '## Dependency Maintenance' section"
+fi
+
+# Test 2: SHA pinning convention is described
+if grep -qi "SHA pinning" "$README" && grep -q "40-char" "$README"; then
+    pass_test "README explains SHA pinning convention"
+else
+    fail_test "README missing SHA pinning convention details"
+fi
+
+# Test 3: Example uses: line is shown with a 40-char SHA and # vX.Y.Z comment
+if grep -qE "uses: [A-Za-z0-9_./-]+@[0-9a-f]{40} +# +v[0-9]+(\.[0-9]+){0,2}" "$README"; then
+    pass_test "README shows an example pinned 'uses:' line"
+else
+    fail_test "README missing example pinned 'uses:' line"
+fi
+
+# Test 4: bump-deps.sh script is described with its three flags
+if grep -q "bump-deps.sh" "$README" \
+   && grep -q -- "--dry-run" "$README" \
+   && grep -q -- "--quarantine-hours" "$README" \
+   && grep -q -- "--help" "$README"; then
+    pass_test "README documents bump-deps.sh and its flags"
+else
+    fail_test "README missing bump-deps.sh flag documentation"
+fi
+
+# Test 5: Local-usage example is present
+if grep -q '\./bump-deps.sh --dry-run' "$README"; then
+    pass_test "README shows './bump-deps.sh --dry-run' example"
+else
+    fail_test "README missing './bump-deps.sh --dry-run' usage example"
+fi
+
+# Test 6: Scheduled workflow timing is documented
+if grep -q "06:00 UTC" "$README" && grep -qi "Monday" "$README"; then
+    pass_test "README documents the schedule (Monday 06:00 UTC)"
+else
+    fail_test "README missing schedule details (Monday 06:00 UTC)"
+fi
+
+# Test 7: PR branch and workflow_dispatch are mentioned
+if grep -q "chore/bump-deps" "$README" && grep -q "workflow_dispatch" "$README"; then
+    pass_test "README documents PR branch and workflow_dispatch"
+else
+    fail_test "README missing PR branch or workflow_dispatch reference"
+fi
+
+# Test 8: Quarantine policy is documented
+if grep -q "VIBE_BUMP_QUARANTINE_HOURS" "$README" \
+   && grep -q "24" "$README" \
+   && grep -q "stSoftwareAU" "$README"; then
+    pass_test "README documents the quarantine policy"
+else
+    fail_test "README missing quarantine policy details"
+fi
+
+# Test 9: Audit gate is documented
+if grep -qi "audit gate" "$README" && grep -q "quality.sh" "$README"; then
+    pass_test "README documents the audit gate"
+else
+    fail_test "README missing audit gate documentation"
+fi
+
+# Test 10: Reviewer responsibilities are listed
+if grep -qi "reviewer" "$README"; then
+    pass_test "README mentions reviewer responsibilities"
+else
+    fail_test "README missing reviewer responsibilities section"
+fi
+
+# Test 11: Australian English — check only the new Dependency Maintenance
+# section to avoid touching unrelated content elsewhere in the README.
+SECTION=$(awk '/^## Dependency Maintenance/{flag=1; next} /^## /{flag=0} flag' "$README")
+if echo "$SECTION" | grep -qE '\b(behavior|color|favor|organization|center|honor|defense)\b'; then
+    fail_test "Dependency Maintenance section uses American spelling"
+else
+    pass_test "Dependency Maintenance section uses Australian English spelling"
+fi
+
+echo ""
+echo "================================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Documented the auto-bump dependency workflow in `README.md` so future
contributors and operators understand the SHA-pinning convention,
`bump-deps.sh`, the scheduled workflow, the quarantine policy, the audit
gate, and reviewer responsibilities. Closes #96.

## Evidence

CLI/documentation change — no UI to screenshot. The new section was
verified by a TDD test (`tests/test-readme-bump-deps.sh`) that asserts
each behavioural point is present in the README. Quality gate output:

```
Total tests: 40
Passed: 40
Failed: 0
QUALITY CHECK PASSED
```

The new section embeds a Mermaid flow diagram so reviewers can see the
end-to-end pipeline at a glance:

```mermaid
flowchart LR
    A[Cron: Mon 06:00 UTC] --> B[bump-deps.sh]
    B --> C{Audit gate<br/>./quality.sh}
    C -- pass --> D[PR on chore/bump-deps]
    C -- fail --> E[Worker reverts]
```

## Test Plan

- Added `tests/test-readme-bump-deps.sh` — 11 assertions covering:
  - `## Dependency Maintenance` heading present
  - SHA pinning convention described (40-char SHAs)
  - Example pinned `uses:` line with `# vX.Y.Z` comment
  - `bump-deps.sh` documented with `--dry-run`, `--quarantine-hours`,
    `--help` flags
  - Local-usage example `./bump-deps.sh --dry-run` shown
  - Schedule documented (Mondays 06:00 UTC)
  - PR branch `chore/bump-deps` and `workflow_dispatch` referenced
  - Quarantine policy (`VIBE_BUMP_QUARANTINE_HOURS=24`,
    `stSoftwareAU/*` exemption) covered
  - Audit gate (`./quality.sh`) documented
  - Reviewer responsibilities listed
  - Australian English spelling enforced for the new section
- All 40 tests in `./quality.sh` pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-96 -->