### PR TITLE
Fix shellcheck warnings across run.sh and tests (#114)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.12";
+const VERSION = "1.1.13";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.12" rel="stylesheet">
+    <link href="./styles.css?v=1.1.13" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -107,14 +107,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.12"></script>
+    <script src="./dashboard.js?v=1.1.13"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.12')
+                navigator.serviceWorker.register('./sw.js?v=1.1.13')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-114.md
+++ b/docs/pr-summary-114.md
@@ -1,0 +1,62 @@
+## Summary
+
+Fixed every shellcheck warning the CI ShellCheck workflow flagged
+(`severity: warning`). The screenshot in the issue listed 19 warnings across
+`run.sh` and seven test scripts — all are now resolved, and a new regression
+test (`tests/test-shellcheck-clean.sh`) keeps the warning baseline clean for
+future PRs. Closes #114.
+
+## Evidence
+
+`shellcheck --severity=warning` (matching `.github/workflows/shellcheck.yml`)
+now reports zero issues across the 49 shell scripts in the repo:
+
+```
+$ ./tests/test-shellcheck-clean.sh
+Testing Issue #114: shellcheck warning-severity is clean
+========================================================
+
+Linting 49 shell scripts at severity=warning...
+  PASS: all shell scripts are clean at warning severity
+
+Results: 1 passed, 0 failed
+```
+
+Categories fixed:
+
+| Code | Meaning | Files affected |
+| ---- | ------- | -------------- |
+| SC2155 | Declare and assign separately to avoid masking return values | `run.sh` (7 occurrences in `scan_log_errors` + `update_json`) |
+| SC2034 | Variable appears unused | `tests/test-log-viewer-classification.sh`, `tests/test-memory-monitor-exclusion.sh`, `tests/test-push-retry.sh`, `tests/test-repos-push-rebase.sh`, `tests/test-scan-log-errors.sh`, `tests/test-status-overflow.sh` |
+| SC2154 | Variable referenced but not assigned (set inside the eval'd run.sh function) | `tests/test-memory-monitor-exclusion.sh`, `tests/test-scan-log-errors.sh` |
+| SC2188 | Redirection without a command | `tests/test-json-integrity.sh` (changed `> file` to `true > file`) |
+
+For SC2034/SC2154 inside tests that `eval` functions out of `run.sh`, the
+variables are genuinely consumed by the eval'd function — narrow
+`# shellcheck disable=...` directives document this.
+
+## Test Plan
+
+- New regression test: `tests/test-shellcheck-clean.sh` runs
+  `shellcheck --severity=warning` over every `*.sh` file in the repo and
+  fails if any warning surfaces. This is the same severity the GitHub
+  Actions workflow uses, so the local gate matches CI.
+- All seven modified test files were re-executed individually after the
+  changes — every one still passes (`tests/test-json-integrity.sh`,
+  `tests/test-log-viewer-classification.sh`,
+  `tests/test-memory-monitor-exclusion.sh`, `tests/test-push-retry.sh`,
+  `tests/test-repos-push-rebase.sh`, `tests/test-scan-log-errors.sh`,
+  `tests/test-status-overflow.sh`).
+- `./quality.sh` total tests went from 42 → 43 (added shellcheck regression
+  test). The two remaining failures (`test-gitleaks-workflow`,
+  `test-vibe-coder-dead-after-8h`) were failing on `Develop` before this
+  branch and are unrelated to shellcheck — out of scope for this issue.
+
+## Notes
+
+- Version bumped from `1.1.12` → `1.1.13` per project convention for code
+  changes; `./update_version.sh` was run to sync the version across HTML/JS.
+- The behaviour of `scan_log_errors` is unchanged: where `grep ... | wc -l`
+  was rewritten to `grep -c ...` the count is identical, and the
+  declare-and-assign split preserves the existing fallbacks
+  (`|| echo "0"`).

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.12
+// Version: 1.1.13
 
-const CACHE_NAME = 'grq-health-v1.1.12';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.12';
+const CACHE_NAME = 'grq-health-v1.1.13';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.13';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.12',
+  './dashboard.js?v=1.1.13',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd "${BASE_DIR}"
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.12"
+VERSION="1.1.13"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.
@@ -760,34 +760,40 @@ scan_log_errors() {
 
         # Count actual exceptions by looking for error messages that precede stack traces
         # Each exception starts with an error message, followed by stack trace lines
-        local stack_trace_exceptions=$(grep -B1 "^[[:space:]]\+at " "$filtered_log" | grep -v "^[[:space:]]\+at " | grep -v "^--$" | grep -E "Exception|^Error:|MEMETIC" | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
+        local stack_trace_exceptions
+        stack_trace_exceptions=$(grep -B1 "^[[:space:]]\+at " "$filtered_log" | grep -v "^[[:space:]]\+at " | grep -v "^--$" | grep -cE "Exception|^Error:|MEMETIC" 2>/dev/null | tr -d ' \n' || echo "0")
 
         # Count other critical errors that should be flagged
         # Missing commands/tools (excluding aws which is only expected on Macs)
         # Focus on missing script files which indicate configuration issues
         # Exclude .cache/ paths — cache files may not exist after cleanup (normal concurrency)
-        local missing_command_errors=$(grep -E "line [0-9]+: .*: No such file or directory" "$filtered_log" | grep -v '\.cache/' | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
+        local missing_command_errors
+        missing_command_errors=$(grep -E "line [0-9]+: .*: No such file or directory" "$filtered_log" | grep -cv '\.cache/' 2>/dev/null | tr -d ' \n' || echo "0")
 
         # Count warning emoji issues (⚠️)
-        local warning_emoji_errors=$(grep -c "⚠️" "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
+        local warning_emoji_errors
+        warning_emoji_errors=$(grep -c "⚠️" "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
 
         # Count failure emoji issues (❌)
         # Exclude "❌ Error N in <file>. Exiting." — these are normal task exit messages
         # from the GRQ application when a speculative optimisation task fails (expected behaviour)
-        local failure_emoji_errors=$(grep "❌" "$filtered_log" 2>/dev/null | grep -cv "❌ Error [0-9]" 2>/dev/null | tr -d ' \n' || echo "0")
+        local failure_emoji_errors
+        failure_emoji_errors=$(grep "❌" "$filtered_log" 2>/dev/null | grep -cv "❌ Error [0-9]" 2>/dev/null | tr -d ' \n' || echo "0")
 
 
         # Lock acquisition failures (removed - these are expected for daily tasks)
         local lock_failures=0
 
         # Permission/access errors
-        local permission_errors=$(grep -E "Permission denied|access denied|EACCES" "$filtered_log" | wc -l 2>/dev/null | tr -d ' \n' || echo "0")
+        local permission_errors
+        permission_errors=$(grep -cE "Permission denied|access denied|EACCES" "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
 
         # Network/connection errors (removed - too unreliable, causing false positives)
         local network_errors=0
 
         # Count all Deno crashes with C stack traces (includes out of memory, segfaults, etc.)
-        local deno_crashes=$(grep -c "==== C stack trace" "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
+        local deno_crashes
+        deno_crashes=$(grep -c "==== C stack trace" "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
 
         # Clean up filtered log
         rm -f "$filtered_log"
@@ -892,7 +898,8 @@ should_update() {
 
 # Function to update JSON file
 update_json() {
-    local system_info=$(get_system_info)
+    local system_info
+    system_info=$(get_system_info)
     local file_valid=false
 
     # Issue #65: Validate existing JSON before updating

--- a/tests/test-json-integrity.sh
+++ b/tests/test-json-integrity.sh
@@ -131,7 +131,7 @@ build_harness "$TEST_DIR"
 
 cd "$TEST_DIR"
 # Write empty file
-> docs/index.json
+true > docs/index.json
 
 OUTPUT=$(RUN_SH="$RUN_SH" JSON_FILE="docs/index.json" HOSTNAME="TEST-HOST" USER_KEY="testuser" \
     CURRENT_TS="$(date +%s)" bash test_harness.sh 2>&1 || true)

--- a/tests/test-log-viewer-classification.sh
+++ b/tests/test-log-viewer-classification.sh
@@ -5,8 +5,6 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOG_VIEWER="$SCRIPT_DIR/../docs/log-viewer.html"
 DENO="$HOME/.deno/bin/deno"
 
 echo "Testing Issue #29: Log line classification"

--- a/tests/test-memory-monitor-exclusion.sh
+++ b/tests/test-memory-monitor-exclusion.sh
@@ -41,6 +41,8 @@ echo "------------------------------------"
 echo "Test 1: MemoryMonitor warning lines are excluded..."
 HOME="$WORK_DIR"
 mkdir -p "$WORK_DIR/logs"
+# NODE_PID is read by the eval'd scan_log_errors function from run.sh
+# shellcheck disable=SC2034
 NODE_PID=""
 cat > "$WORK_DIR/logs/node.log" << 'EOF'
 run_core pid=20689 start=Sat Mar  7 21:30:59 AEDT 2026
@@ -54,9 +56,12 @@ EOF
 
 scan_log_errors
 
+# exception_count and exception_summary are set as globals inside scan_log_errors
+# shellcheck disable=SC2154
 if [ "$exception_count" -eq 0 ]; then
     pass_test "MemoryMonitor-only log has zero errors (count=$exception_count)"
 else
+    # shellcheck disable=SC2154
     fail_test "MemoryMonitor lines were falsely flagged: $exception_summary"
 fi
 

--- a/tests/test-push-retry.sh
+++ b/tests/test-push-retry.sh
@@ -60,7 +60,10 @@ cd "$REPO_DIR"
 
 # Source run.sh functions but don't execute main
 HOSTNAME="TEST-HOST"
+# CURRENT_TS and NO_GIT are read by the eval'd commit_and_push function from run.sh
+# shellcheck disable=SC2034
 CURRENT_TS=$(date +%s)
+# shellcheck disable=SC2034
 NO_GIT=false
 # Source just the commit_and_push function
 eval "$(sed -n '/^commit_and_push()/,/^}/p' "$RUN_SH")"
@@ -162,6 +165,8 @@ sed -i.bak "s|PLACEHOLDER_COUNT_FILE|${PUSH_COUNT_FILE3}|g" "${MOCK_BIN3}/git"
 sed -i.bak "s|PLACEHOLDER_REAL_GIT|${REAL_GIT}|g" "${MOCK_BIN3}/git"
 chmod +x "${MOCK_BIN3}/git"
 
+# CURRENT_TS is read by the eval'd commit_and_push function from run.sh
+# shellcheck disable=SC2034
 CURRENT_TS=$(date +%s)
 eval "$(sed -n '/^commit_and_push()/,/^}/p' "$RUN_SH")"
 

--- a/tests/test-repos-push-rebase.sh
+++ b/tests/test-repos-push-rebase.sh
@@ -254,7 +254,6 @@ OUTPUT3=$(cd "$TEST3_WORK" && GIT_PUSH_RETRY_DELAY_OVERRIDE=0 \
 
 # After the conflict-and-discard recovery, the working clone must NOT have
 # a backlog of unpushed commits relative to remote main.
-REMOTE_MAIN=$(cd "$TEST3_REMOTE" && git rev-parse main 2>/dev/null || echo "")
 (cd "$TEST3_WORK" && git fetch --quiet 2>/dev/null || true)
 UNPUSHED3=$(cd "$TEST3_WORK" && git rev-list --count "origin/main..HEAD" 2>/dev/null || echo "?")
 

--- a/tests/test-scan-log-errors.sh
+++ b/tests/test-scan-log-errors.sh
@@ -49,12 +49,17 @@ EOF
 HOME="$WORK_DIR"
 mkdir -p "$WORK_DIR/logs"
 cp "$LOG_FILE" "$WORK_DIR/logs/node.log"
+# NODE_PID is read by the eval'd scan_log_errors function from run.sh
+# shellcheck disable=SC2034
 NODE_PID=""
 scan_log_errors
 
+# exception_count and exception_summary are set as globals inside scan_log_errors
+# shellcheck disable=SC2154
 if [ "$exception_count" -eq 0 ]; then
     pass_test "Cache file not found is not flagged as error (count=$exception_count)"
 else
+    # shellcheck disable=SC2154
     fail_test "Cache file not found was falsely flagged: $exception_summary"
 fi
 

--- a/tests/test-shellcheck-clean.sh
+++ b/tests/test-shellcheck-clean.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Test for Issue #114: All shell scripts must pass shellcheck at warning severity
+# (matches the severity used by .github/workflows/shellcheck.yml).
+#
+# This is a regression test: when introduced, every script in the repo was
+# clean at warning severity. Future PRs that re-introduce common warnings
+# (declare-and-assign, unused variables, references-not-assigned, redirection
+# without command) will fail this gate before reaching CI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+
+echo "Testing Issue #114: shellcheck warning-severity is clean"
+echo "========================================================"
+echo ""
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "  SKIP: shellcheck not installed locally"
+    exit 0
+fi
+
+# Collect all shell scripts the CI workflow scans (it scans the whole repo).
+# Use a portable (bash 3.2 compatible) approach instead of mapfile.
+SHELL_FILES=()
+while IFS= read -r f; do
+    SHELL_FILES+=("$f")
+done < <(find "$REPO_ROOT" \
+    -path "$REPO_ROOT/.git" -prune -o \
+    -path "$REPO_ROOT/node_modules" -prune -o \
+    -type f -name "*.sh" -print | sort)
+
+if [ "${#SHELL_FILES[@]}" -eq 0 ]; then
+    echo "  FAIL: no shell scripts found to lint"
+    exit 1
+fi
+
+echo "Linting ${#SHELL_FILES[@]} shell scripts at severity=warning..."
+
+OUTPUT=$(shellcheck --severity=warning "${SHELL_FILES[@]}" 2>&1 || true)
+
+if [ -z "$OUTPUT" ]; then
+    echo "  PASS: all shell scripts are clean at warning severity"
+    echo ""
+    echo "Results: 1 passed, 0 failed"
+    exit 0
+fi
+
+echo "  FAIL: shellcheck reported warnings:"
+echo "$OUTPUT" | sed 's/^/    /'
+echo ""
+echo "Results: 0 passed, 1 failed"
+exit 1

--- a/tests/test-status-overflow.sh
+++ b/tests/test-status-overflow.sh
@@ -53,22 +53,12 @@ else
     fi
 fi
 
-# Test 5: Check that overflow is consistent across all card variants
+# Test 5: Card variants inherit overflow from the base .host-card class
 echo "Test 5: Checking overflow consistency across card variants..."
-CARD_VARIANTS=(".host-card.mia" ".host-card.mobile" ".host-card.outdated-macos" ".host-card.critical" ".host-card.warning" ".host-card.healthy")
-MISSING_OVERFLOW=""
-
-for variant in "${CARD_VARIANTS[@]}"; do
-    # Note: we now rely on the base .host-card having overflow: hidden
-    # Variants can override if needed
-    :
-done
-
-if [ -z "$MISSING_OVERFLOW" ]; then
-    echo "  PASS: Base .host-card should handle overflow for all variants"
-else
-    echo "  INFO: Some variants may need individual overflow handling"
-fi
+# All variants (.host-card.mia, .host-card.mobile, .host-card.outdated-macos,
+# .host-card.critical, .host-card.warning, .host-card.healthy) rely on the
+# base .host-card having overflow: hidden, which Test 1 already verified.
+echo "  PASS: Base .host-card should handle overflow for all variants"
 
 echo ""
 echo "============================================="


### PR DESCRIPTION
## Summary

Fixed every shellcheck warning the CI ShellCheck workflow flagged
(`severity: warning`). The screenshot in the issue listed 19 warnings across
`run.sh` and seven test scripts — all are now resolved, and a new regression
test (`tests/test-shellcheck-clean.sh`) keeps the warning baseline clean for
future PRs. Closes #114.

## Evidence

`shellcheck --severity=warning` (matching `.github/workflows/shellcheck.yml`)
now reports zero issues across the 49 shell scripts in the repo:

```
$ ./tests/test-shellcheck-clean.sh
Testing Issue #114: shellcheck warning-severity is clean
========================================================

Linting 49 shell scripts at severity=warning...
  PASS: all shell scripts are clean at warning severity

Results: 1 passed, 0 failed
```

Categories fixed:

| Code | Meaning | Files affected |
| ---- | ------- | -------------- |
| SC2155 | Declare and assign separately to avoid masking return values | `run.sh` (7 occurrences in `scan_log_errors` + `update_json`) |
| SC2034 | Variable appears unused | `tests/test-log-viewer-classification.sh`, `tests/test-memory-monitor-exclusion.sh`, `tests/test-push-retry.sh`, `tests/test-repos-push-rebase.sh`, `tests/test-scan-log-errors.sh`, `tests/test-status-overflow.sh` |
| SC2154 | Variable referenced but not assigned (set inside the eval'd run.sh function) | `tests/test-memory-monitor-exclusion.sh`, `tests/test-scan-log-errors.sh` |
| SC2188 | Redirection without a command | `tests/test-json-integrity.sh` (changed `> file` to `true > file`) |

For SC2034/SC2154 inside tests that `eval` functions out of `run.sh`, the
variables are genuinely consumed by the eval'd function — narrow
`# shellcheck disable=...` directives document this.

## Test Plan

- New regression test: `tests/test-shellcheck-clean.sh` runs
  `shellcheck --severity=warning` over every `*.sh` file in the repo and
  fails if any warning surfaces. This is the same severity the GitHub
  Actions workflow uses, so the local gate matches CI.
- All seven modified test files were re-executed individually after the
  changes — every one still passes (`tests/test-json-integrity.sh`,
  `tests/test-log-viewer-classification.sh`,
  `tests/test-memory-monitor-exclusion.sh`, `tests/test-push-retry.sh`,
  `tests/test-repos-push-rebase.sh`, `tests/test-scan-log-errors.sh`,
  `tests/test-status-overflow.sh`).
- `./quality.sh` total tests went from 42 → 43 (added shellcheck regression
  test). The two remaining failures (`test-gitleaks-workflow`,
  `test-vibe-coder-dead-after-8h`) were failing on `Develop` before this
  branch and are unrelated to shellcheck — out of scope for this issue.

## Notes

- Version bumped from `1.1.12` → `1.1.13` per project convention for code
  changes; `./update_version.sh` was run to sync the version across HTML/JS.
- The behaviour of `scan_log_errors` is unchanged: where `grep ... | wc -l`
  was rewritten to `grep -c ...` the count is identical, and the
  declare-and-assign split preserves the existing fallbacks
  (`|| echo "0"`).