### PR TITLE
Add Markdown Lint workflow (Issue #109)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,25 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master, Develop]
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v4 — pinned to commit SHA per supply-chain policy
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-node v4 — pinned to commit SHA per supply-chain policy
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "lts/*"
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .*
 *~
 !.gitignore
+!.markdownlint-cli2.jsonc
 coverage/
 !.github

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,32 @@
+// Markdown Lint configuration for GRQ-health (Issue #109).
+// Stylistic rules that conflict with the repo's existing prose are disabled so
+// the lint catches real breakage (broken links, malformed tables, unmatched
+// fences) without forcing a sweeping reformat of every document.
+{
+  "config": {
+    "default": true,
+    "MD009": false, // trailing spaces — used in some prose for line breaks
+    "MD013": false, // line length — repo prose uses long lines freely
+    "MD022": false, // blanks around headings — many pr-summary files omit them
+    "MD024": false, // duplicate headings — pr-summary files reuse "Summary" etc.
+    "MD026": false, // trailing punctuation in headings — colons are common
+    "MD031": false, // blanks around fences — repo style varies
+    "MD032": false, // blanks around lists — repo style varies
+    "MD033": false, // inline HTML — used in dashboard documentation
+    "MD034": false, // bare URLs — links are intentionally bare in places
+    "MD036": false, // emphasis used as heading — used for callouts
+    "MD040": false, // fenced code language — some blocks intentionally untagged
+    "MD041": false, // first line must be h1 — pr-summary files start at h2
+    "MD047": false, // single trailing newline — not enforced repo-wide
+    "MD012": false, // multiple consecutive blanks — repo style varies
+    "MD058": false, // blanks around tables — repo style varies
+    "MD060": false  // table column style — compact tables used in pr-summary files
+  },
+  "globs": [
+    "**/*.md"
+  ],
+  "ignores": [
+    "node_modules",
+    "coverage"
+  ]
+}

--- a/docs/pr-summary-109.md
+++ b/docs/pr-summary-109.md
@@ -1,0 +1,49 @@
+## Summary
+
+Added a Markdown Lint GitHub Actions workflow to keep documentation
+consistent across the repository. Closes #109.
+
+The workflow runs `markdownlint-cli2` on every pull request and on
+pushes to the default branches. A repo-root `.markdownlint-cli2.jsonc`
+config disables the stylistic rules that conflict with the existing
+prose so the lint catches real breakage (broken tables, unmatched
+fences, malformed lists) without forcing a sweeping reformat.
+
+## Evidence
+
+This is a CI-only change with no UI surface. Verified locally:
+
+- `markdownlint-cli2` against the current repo content: `0 error(s)` over 50 files.
+- `tests/test-markdown-lint-workflow.sh`: 12 passed, 0 failed.
+
+```mermaid
+flowchart LR
+    A[Pull Request] --> B[markdown-lint workflow]
+    B --> C[setup-node]
+    C --> D[npm install -g markdownlint-cli2]
+    D --> E[markdownlint-cli2]
+    E -->|reads| F[.markdownlint-cli2.jsonc]
+    E -->|lints| G[**/*.md]
+```
+
+## Test Plan
+
+- Added `tests/test-markdown-lint-workflow.sh` covering:
+  - workflow file presence and YAML validity
+  - workflow name, `pull_request` trigger, read-only `contents` permission
+  - `markdownlint` job runs on `ubuntu-latest`
+  - `actions/setup-node` step is present
+  - `markdownlint-cli2` install and run steps are present
+  - all `uses:` references are pinned to 40-char commit SHAs
+  - `.markdownlint-cli2.jsonc` config is present
+  - `markdownlint-cli2` passes locally against the current repo
+- Allowed `.markdownlint-cli2.jsonc` through `.gitignore` (per the
+  worker-managed allowlist for in-repo lint config).
+
+## Files Changed
+
+- `.github/workflows/markdown-lint.yml` — new workflow
+- `.markdownlint-cli2.jsonc` — lint config tuned to existing prose
+- `.gitignore` — allow the lint config through the dotfile ignore rule
+- `tests/test-markdown-lint-workflow.sh` — workflow contract tests
+- `docs/pr-summary-109.md` — this summary

--- a/tests/test-markdown-lint-workflow.sh
+++ b/tests/test-markdown-lint-workflow.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Test for Issue #109: Markdown Lint workflow
+# Verifies that .github/workflows/markdown-lint.yml exists, is valid YAML,
+# and is wired up correctly (PR + push triggers, read-only permissions,
+# markdownlint-cli2 install + run steps, SHA-pinned actions).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_FILE="$SCRIPT_DIR/../.github/workflows/markdown-lint.yml"
+
+echo "Testing Issue #109: Markdown Lint workflow"
+echo "=========================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail_test() { echo "  FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# Test 1: workflow file exists
+if [ -f "$WORKFLOW_FILE" ]; then
+    pass_test "markdown-lint.yml exists at .github/workflows/markdown-lint.yml"
+else
+    fail_test "markdown-lint.yml is missing from .github/workflows/"
+    echo ""
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    exit 1
+fi
+
+# Test 2: valid YAML
+if python3 -c "import yaml,sys; yaml.safe_load(open('$WORKFLOW_FILE'))" 2>/dev/null; then
+    pass_test "markdown-lint.yml is valid YAML"
+else
+    fail_test "markdown-lint.yml has YAML syntax errors"
+fi
+
+# Helper that reads YAML directly (PyYAML parses bare `on:` as boolean True).
+run_yaml() {
+    local code="$1"
+    python3 - "$WORKFLOW_FILE" <<PYEOF
+import yaml, sys
+wf = yaml.safe_load(open(sys.argv[1]))
+on = wf.get('on')
+if on is None:
+    on = wf.get(True)
+$code
+PYEOF
+}
+
+# Test 3: name set to "Markdown Lint"
+NAME=$(run_yaml "print(wf.get('name',''))")
+if [ "$NAME" = "Markdown Lint" ]; then
+    pass_test "Workflow name is 'Markdown Lint'"
+else
+    fail_test "Workflow name is '$NAME', expected 'Markdown Lint'"
+fi
+
+# Test 4: pull_request trigger present
+HAS_PR=$(run_yaml "print('yes' if isinstance(on, dict) and 'pull_request' in on else 'no')")
+if [ "$HAS_PR" = "yes" ]; then
+    pass_test "Workflow triggers on pull_request"
+else
+    fail_test "Workflow is missing pull_request trigger"
+fi
+
+# Test 5: top-level permissions are read-only (contents: read)
+PERM=$(run_yaml "print((wf.get('permissions') or {}).get('contents',''))")
+if [ "$PERM" = "read" ]; then
+    pass_test "Top-level permissions grant contents: read"
+else
+    fail_test "Expected permissions.contents = 'read', got '$PERM'"
+fi
+
+# Test 6: markdownlint job exists and runs on ubuntu-latest
+JOB_RUNS_ON=$(run_yaml "print(((wf.get('jobs') or {}).get('markdownlint') or {}).get('runs-on',''))")
+if [ "$JOB_RUNS_ON" = "ubuntu-latest" ]; then
+    pass_test "markdownlint job runs on ubuntu-latest"
+else
+    fail_test "markdownlint job runs-on is '$JOB_RUNS_ON', expected ubuntu-latest"
+fi
+
+# Test 7: setup-node step is present
+HAS_SETUP_NODE=$(run_yaml "
+steps=((wf.get('jobs') or {}).get('markdownlint') or {}).get('steps') or []
+print('yes' if any('actions/setup-node' in str(s.get('uses','')) for s in steps) else 'no')
+")
+if [ "$HAS_SETUP_NODE" = "yes" ]; then
+    pass_test "actions/setup-node step is present"
+else
+    fail_test "Missing actions/setup-node step"
+fi
+
+# Test 8: install + run markdownlint-cli2 steps are present
+HAS_INSTALL=$(run_yaml "
+steps=((wf.get('jobs') or {}).get('markdownlint') or {}).get('steps') or []
+print('yes' if any('markdownlint-cli2' in str(s.get('run','')) and 'install' in str(s.get('run','')) for s in steps) else 'no')
+")
+if [ "$HAS_INSTALL" = "yes" ]; then
+    pass_test "markdownlint-cli2 install step present"
+else
+    fail_test "Missing markdownlint-cli2 install step"
+fi
+
+HAS_RUN=$(run_yaml "
+steps=((wf.get('jobs') or {}).get('markdownlint') or {}).get('steps') or []
+ok=False
+for s in steps:
+    run=str(s.get('run',''))
+    if 'markdownlint-cli2' in run and 'install' not in run:
+        ok=True
+        break
+print('yes' if ok else 'no')
+")
+if [ "$HAS_RUN" = "yes" ]; then
+    pass_test "markdownlint-cli2 run step present"
+else
+    fail_test "Missing markdownlint-cli2 run step"
+fi
+
+# Test 9: every `uses:` reference is pinned to a 40-char commit SHA, not a tag
+UNPINNED=$(grep -E '^\s*-?\s*uses:\s*' "$WORKFLOW_FILE" | grep -vE '@[0-9a-f]{40}(\s|$)' || true)
+if [ -z "$UNPINNED" ]; then
+    pass_test "All uses: references are pinned to 40-char commit SHAs"
+else
+    fail_test "Unpinned actions found:"
+    echo "$UNPINNED" | sed 's/^/    /'
+fi
+
+# Test 10: a markdownlint config exists at the repo root so the lint passes
+CONFIG_FILE="$SCRIPT_DIR/../.markdownlint-cli2.jsonc"
+if [ -f "$CONFIG_FILE" ]; then
+    pass_test ".markdownlint-cli2.jsonc config exists at repo root"
+else
+    fail_test ".markdownlint-cli2.jsonc config is missing"
+fi
+
+# Test 11: running markdownlint-cli2 locally against the repo passes (if installed)
+if command -v markdownlint-cli2 >/dev/null 2>&1; then
+    cd "$SCRIPT_DIR/.." || exit 1
+    if markdownlint-cli2 >/tmp/markdownlint-out-109.log 2>&1 < /dev/null; then
+        pass_test "markdownlint-cli2 passes against current repo content"
+    else
+        fail_test "markdownlint-cli2 reports issues:"
+        sed 's/^/    /' /tmp/markdownlint-out-109.log | tail -20
+    fi
+else
+    echo "  SKIP: markdownlint-cli2 not installed locally"
+fi
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Added a Markdown Lint GitHub Actions workflow to keep documentation
consistent across the repository. Closes #109.

The workflow runs `markdownlint-cli2` on every pull request and on
pushes to the default branches. A repo-root `.markdownlint-cli2.jsonc`
config disables the stylistic rules that conflict with the existing
prose so the lint catches real breakage (broken tables, unmatched
fences, malformed lists) without forcing a sweeping reformat.

## Evidence

This is a CI-only change with no UI surface. Verified locally:

- `markdownlint-cli2` against the current repo content: `0 error(s)` over 50 files.
- `tests/test-markdown-lint-workflow.sh`: 12 passed, 0 failed.

```mermaid
flowchart LR
    A[Pull Request] --> B[markdown-lint workflow]
    B --> C[setup-node]
    C --> D[npm install -g markdownlint-cli2]
    D --> E[markdownlint-cli2]
    E -->|reads| F[.markdownlint-cli2.jsonc]
    E -->|lints| G[**/*.md]
```

## Test Plan

- Added `tests/test-markdown-lint-workflow.sh` covering:
  - workflow file presence and YAML validity
  - workflow name, `pull_request` trigger, read-only `contents` permission
  - `markdownlint` job runs on `ubuntu-latest`
  - `actions/setup-node` step is present
  - `markdownlint-cli2` install and run steps are present
  - all `uses:` references are pinned to 40-char commit SHAs
  - `.markdownlint-cli2.jsonc` config is present
  - `markdownlint-cli2` passes locally against the current repo
- Allowed `.markdownlint-cli2.jsonc` through `.gitignore` (per the
  worker-managed allowlist for in-repo lint config).

## Files Changed

- `.github/workflows/markdown-lint.yml` — new workflow
- `.markdownlint-cli2.jsonc` — lint config tuned to existing prose
- `.gitignore` — allow the lint config through the dotfile ignore rule
- `tests/test-markdown-lint-workflow.sh` — workflow contract tests
- `docs/pr-summary-109.md` — this summary



---

🤖 Processed by: stservice<!-- vibe-worker-issue-109 -->