### PR TITLE
Gracefully handle GH rate limits and transient push failures (#117)

### DIFF
--- a/docs/pr-summary-117.md
+++ b/docs/pr-summary-117.md
@@ -1,0 +1,84 @@
+## Summary
+
+Hardens the health-update push path against transient GitHub failures so a
+flaky network or rate-limit response cannot falsely mark a service as dead.
+The previous behaviour swallowed push errors silently and left a stale
+unpushed commit on the local clone — the next service's update would then
+commit on top, producing a misleading heartbeat for the failed service.
+
+Both `run.sh::commit_and_push` and `helpers/repos.sh` now share a small
+`helpers/git-retry.sh` library that:
+
+- Retries up to 3 attempts with **exponential backoff** (1s, 4s, 16s).
+- Wraps every git invocation in a **120s timeout** (`gtimeout`/`timeout`)
+  to bound slow-network hangs.
+- Detects GitHub **rate-limit / abuse-detection** responses in stderr
+  (`429`, `rate limit`, `too many requests`, `secondary rate limit`) and
+  sleeps until the reset window. When `gh` is available the reset epoch
+  is read from `gh api rate_limit`; otherwise the standard backoff is used.
+- After exhausting retries, **resets the local clone to `origin/<branch>`
+  and runs `git clean -fd`**, then **exits non-zero** so the failure is
+  itself observable instead of being silently swallowed.
+
+Closes #117.
+
+## Evidence
+
+CLI/backend change — no UI to screenshot.
+
+Verified by the new `tests/test-graceful-failure-recovery.sh` (19 assertions,
+all passing) plus the updated `tests/test-push-retry.sh` and
+`tests/test-repos-push-rebase.sh`. `./quality.sh` reports 42 passed / 3
+pre-existing failures unrelated to this change (`test-gitleaks-workflow`,
+`test-scan-log-errors`, `test-vibe-coder-dead-after-8h` — the last is
+Issue #118's tracked work).
+
+```mermaid
+flowchart TD
+    A[commit_and_push / repos.sh push] --> B{git push}
+    B -- success --> Z[Done]
+    B -- failure --> C[Capture stderr]
+    C --> D{Rate limit?}
+    D -- yes --> E[Sleep until reset window<br/>via gh api rate_limit or backoff]
+    D -- no --> F[Backoff 1s -> 4s -> 16s]
+    E --> G{Attempts left?}
+    F --> G
+    G -- yes --> H[fetch + rebase / pull --rebase] --> B
+    G -- no --> I[Surface stderr + porcelain status]
+    I --> J[git reset --hard origin/branch<br/>+ git clean -fd]
+    J --> K[Exit non-zero]
+```
+
+## Test Plan
+
+- **New** `tests/test-graceful-failure-recovery.sh` covering:
+  - `git-retry.sh` helpers: timeout default + override, backoff defaults,
+    rate-limit detection true/false, override sleep value.
+  - `repos.sh` exits non-zero when push retries are exhausted.
+  - `repos.sh` resets the working clone (HEAD, index, working tree) to
+    `origin/main` after exhausted retries — no stale unpushed commit
+    remains, working tree is clean, recovery action is logged.
+  - Rate-limit response triggers a sleep matching
+    `GRQ_RATE_LIMIT_SLEEP_OVERRIDE`, then succeeds on the next attempt.
+  - Backoff sleeps follow the configured `GRQ_PUSH_RETRY_DELAYS_OVERRIDE`
+    sequence.
+  - `run.sh::commit_and_push` exits non-zero on persistent push failure
+    and resets the local clone to `origin/<branch>`.
+- **Updated** `tests/test-push-retry.sh` (Issue #51 regression):
+  - Now sources `helpers/git-retry.sh` (new dependency of `commit_and_push`).
+  - Test 3 captures the exit code so `set -e` does not abort, and
+    additionally asserts `commit_and_push` returns non-zero on exhausted
+    retries — this is the new business-logic contract from this issue.
+- **Updated** `tests/test-repos-push-rebase.sh` (Issue #1862 regression):
+  - The setup helpers now also copy `helpers/git-retry.sh` into the
+    fixture clones so the embedded `repos.sh` can source it. No assertions
+    changed; existing 11 assertions still pass.
+
+### Tunables (defaults shown)
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `GRQ_PUSH_MAX_ATTEMPTS` | `3` | Push attempt budget |
+| `GRQ_PUSH_RETRY_DELAYS_OVERRIDE` | `1 4 16` | Backoff seconds (space-separated) |
+| `GRQ_GIT_TIMEOUT_OVERRIDE` | `120` | Per-git-call timeout (seconds) |
+| `GRQ_RATE_LIMIT_SLEEP_OVERRIDE` | _unset_ | Test hook to bypass `gh api rate_limit` |

--- a/helpers/git-retry.sh
+++ b/helpers/git-retry.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Git retry helpers for graceful handling of GitHub rate limits and
+# transient network failures. Sourced by run.sh and helpers/repos.sh.
+#
+# Exposes:
+#   grq_timeout_cmd          — echoes the timeout binary (gtimeout/timeout)
+#                              or empty if neither is installed.
+#   grq_git_timeout_secs     — echoes the per-git-call timeout (default 120).
+#                              Override via GRQ_GIT_TIMEOUT_OVERRIDE.
+#   grq_backoff_delays       — echoes the space-separated backoff delays
+#                              (default "1 4 16"). Override via
+#                              GRQ_PUSH_RETRY_DELAYS_OVERRIDE for tests.
+#   grq_max_push_attempts    — echoes the max push attempts (default 3).
+#                              Override via GRQ_PUSH_MAX_ATTEMPTS.
+#   grq_run_git              — runs `git "$@"` wrapped in the timeout helper
+#                              (when available). Caller controls redirections.
+#   grq_is_rate_limit_error  — given stderr text on stdin, returns 0 if the
+#                              text matches a GitHub rate-limit response.
+#   grq_rate_limit_sleep_secs — when called after a detected rate limit,
+#                              echoes how many seconds to sleep before the
+#                              next attempt. Honours
+#                              GRQ_RATE_LIMIT_SLEEP_OVERRIDE for tests; if
+#                              `gh` is available it queries
+#                              `gh api rate_limit` for the reset window.
+#   grq_recover_to_remote    — discards local commits/working-tree changes
+#                              on the current branch by `git reset --hard
+#                              origin/<branch>` + `git clean -fd`. Caller
+#                              must already be in the repo directory.
+
+# Resolve timeout binary cross-platform.
+grq_timeout_cmd() {
+    if command -v gtimeout >/dev/null 2>&1; then
+        echo "gtimeout"
+    elif command -v timeout >/dev/null 2>&1; then
+        echo "timeout"
+    else
+        echo ""
+    fi
+}
+
+grq_git_timeout_secs() {
+    echo "${GRQ_GIT_TIMEOUT_OVERRIDE:-120}"
+}
+
+grq_backoff_delays() {
+    echo "${GRQ_PUSH_RETRY_DELAYS_OVERRIDE:-1 4 16}"
+}
+
+grq_max_push_attempts() {
+    echo "${GRQ_PUSH_MAX_ATTEMPTS:-3}"
+}
+
+# Run a git command wrapped with the timeout helper (when available).
+# Usage: grq_run_git <git args...>
+# Caller is responsible for stdout/stderr redirection.
+grq_run_git() {
+    local timeout_bin
+    timeout_bin=$(grq_timeout_cmd)
+    local secs
+    secs=$(grq_git_timeout_secs)
+    if [ -n "$timeout_bin" ]; then
+        "$timeout_bin" "$secs" git "$@"
+    else
+        git "$@"
+    fi
+}
+
+# Detect a GitHub rate-limit / abuse response in arbitrary stderr text on
+# stdin. Returns 0 (true) when it looks like a rate limit, 1 otherwise.
+grq_is_rate_limit_error() {
+    grep -Eiq "rate limit|x-ratelimit|429|too many requests|abuse detection|secondary rate limit"
+}
+
+# Compute how long to sleep when a rate-limit response was detected.
+# Echoes a non-negative integer number of seconds.
+#
+# Resolution order:
+#   1. GRQ_RATE_LIMIT_SLEEP_OVERRIDE (used by tests to force a known value).
+#   2. `gh api rate_limit` reset epoch minus current time (when `gh` exists).
+#   3. Fallback to the supplied backoff seconds (first arg, default 60).
+grq_rate_limit_sleep_secs() {
+    local fallback="${1:-60}"
+
+    if [ -n "${GRQ_RATE_LIMIT_SLEEP_OVERRIDE:-}" ]; then
+        echo "$GRQ_RATE_LIMIT_SLEEP_OVERRIDE"
+        return 0
+    fi
+
+    if command -v gh >/dev/null 2>&1; then
+        local timeout_bin
+        timeout_bin=$(grq_timeout_cmd)
+        local reset_epoch
+        if [ -n "$timeout_bin" ]; then
+            reset_epoch=$("$timeout_bin" 10 gh api rate_limit \
+                --jq '.resources.core.reset' 2>/dev/null || echo "")
+        else
+            reset_epoch=$(gh api rate_limit --jq '.resources.core.reset' 2>/dev/null || echo "")
+        fi
+        if [[ "$reset_epoch" =~ ^[0-9]+$ ]]; then
+            local now
+            now=$(date +%s)
+            local diff=$((reset_epoch - now))
+            if [ "$diff" -gt 0 ]; then
+                # Add a small jitter so multiple workers don't wake at exactly
+                # the same instant.
+                echo $((diff + 5))
+                return 0
+            fi
+        fi
+    fi
+
+    echo "$fallback"
+}
+
+# Discard any local-only commits and working-tree changes on the current
+# branch by hard-resetting to origin/<branch> and cleaning untracked files.
+# This guards against the next service update committing on top of a stale
+# unpushed commit, which would falsely mark the previous service as alive.
+#
+# Caller must already be in the repo directory.
+grq_recover_to_remote() {
+    local branch
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+        echo "Warning: cannot recover detached HEAD to remote" >&2
+        return 1
+    fi
+
+    local timeout_bin
+    timeout_bin=$(grq_timeout_cmd)
+    local secs
+    secs=$(grq_git_timeout_secs)
+
+    # Fetch latest origin so the reset target reflects the remote tip.
+    if [ -n "$timeout_bin" ]; then
+        "$timeout_bin" "$secs" git fetch --quiet origin "$branch" 2>/dev/null || true
+    else
+        git fetch --quiet origin "$branch" 2>/dev/null || true
+    fi
+
+    git reset --hard "origin/${branch}" 2>/dev/null || return 1
+    git clean -fd 2>/dev/null || true
+    return 0
+}

--- a/helpers/repos.sh
+++ b/helpers/repos.sh
@@ -30,6 +30,13 @@ LOG_RETENTION_COUNT=5
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# Source shared git retry helpers (Issue #117).
+# shellcheck source=./git-retry.sh
+if [ -f "${SCRIPT_DIR}/git-retry.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${SCRIPT_DIR}/git-retry.sh"
+fi
+
 # Validate repo name: alphanumeric, hyphens, underscores, periods, colons, forward slashes, spaces
 validate_repo_name() {
     local name="$1"
@@ -453,21 +460,31 @@ for f in "${FILES_TO_ADD[@]}"; do
 done
 
 # Step 3: Commit and push
-# Issue #1862: When git push fails, the most common cause is non-fast-forward
-# (the remote moved on while we were preparing our commit). Between push
-# retries we attempt a fetch + rebase --autostash so the next push has a
-# chance to fast-forward. If the rebase conflicts on repos.json, abort and
-# reset to the remote — repos.json is a regenerated artefact and stale
-# conflicts are safe to discard. On final failure we surface the actual
-# `git push` stderr plus `git status --porcelain=v2 --branch` so operators
-# can diagnose the real cause instead of seeing a generic warning.
+# Issue #117 + #1862: Push retries use exponential backoff (default 1s, 4s,
+# 16s) and wrap each git call in a 120s timeout to handle slow networks.
+# A non-fast-forward failure is recovered by fetch + rebase --autostash so
+# the next push can fast-forward. If the rebase conflicts on repos.json we
+# abort and reset to the remote — repos.json is a regenerated artefact, so
+# discarding the stale local commit is safe. A GitHub rate-limit response
+# (HTTP 429 / abuse detection / "rate limit" in stderr) triggers a sleep
+# until the reset window (probed via `gh api rate_limit` when available)
+# before the next attempt. When all retries are exhausted we reset the
+# local clone to origin/<branch> + clean -fd so the next service update
+# does not commit on top of a stale unpushed commit (which would falsely
+# mark the previous service as alive), surface the actual stderr, and exit
+# non-zero so the failure itself is observable.
+PUSH_FINAL_STATUS=0
 if [ "$STAGED_SOMETHING" = true ]; then
     if ! git diff --cached --quiet 2>/dev/null; then
         # Commit the changes
         if git commit -m "$COMMIT_MSG" --quiet 2>/dev/null; then
-            GIT_PUSH_MAX_ATTEMPTS=3
-            # Allow tests to drive the loop without sleeping.
-            GIT_PUSH_RETRY_DELAY="${GIT_PUSH_RETRY_DELAY_OVERRIDE:-5}"
+            # Backoff defaults from git-retry.sh; legacy
+            # GIT_PUSH_RETRY_DELAY_OVERRIDE still honoured (back-compat).
+            BACKOFF_DELAYS_RAW=$(grq_backoff_delays 2>/dev/null || echo "1 4 16")
+            # shellcheck disable=SC2206
+            BACKOFF_DELAYS=( $BACKOFF_DELAYS_RAW )
+            GIT_PUSH_MAX_ATTEMPTS=$(grq_max_push_attempts 2>/dev/null || echo 3)
+            LEGACY_DELAY="${GIT_PUSH_RETRY_DELAY_OVERRIDE:-}"
             GIT_PUSH_SUCCESS=false
             LAST_PUSH_STDERR=""
             PUSH_STDERR_FILE=$(mktemp 2>/dev/null || echo "/tmp/repos_push_stderr.$$")
@@ -476,11 +493,25 @@ if [ "$STAGED_SOMETHING" = true ]; then
 
             for attempt in $(seq 1 "$GIT_PUSH_MAX_ATTEMPTS"); do
                 : > "$PUSH_STDERR_FILE"
-                if git push --quiet 2>"$PUSH_STDERR_FILE"; then
+                if grq_run_git push --quiet 2>"$PUSH_STDERR_FILE"; then
                     GIT_PUSH_SUCCESS=true
                     break
                 fi
                 LAST_PUSH_STDERR=$(cat "$PUSH_STDERR_FILE" 2>/dev/null || echo "")
+
+                # Decide the inter-attempt sleep up-front so rate-limit
+                # responses can override the standard backoff.
+                IDX=$((attempt - 1))
+                BACKOFF_SECS="${BACKOFF_DELAYS[$IDX]:-${BACKOFF_DELAYS[-1]}}"
+                if [ -n "$LEGACY_DELAY" ]; then
+                    BACKOFF_SECS="$LEGACY_DELAY"
+                fi
+                SLEEP_SECS="$BACKOFF_SECS"
+
+                if echo "$LAST_PUSH_STDERR" | grq_is_rate_limit_error; then
+                    SLEEP_SECS=$(grq_rate_limit_sleep_secs "$BACKOFF_SECS")
+                    echo "Warning: GitHub rate limit detected (attempt ${attempt}/${GIT_PUSH_MAX_ATTEMPTS}); sleeping ${SLEEP_SECS}s before retry"
+                fi
 
                 if [ "$attempt" -lt "$GIT_PUSH_MAX_ATTEMPTS" ]; then
                     echo "Warning: git push failed (attempt ${attempt}/${GIT_PUSH_MAX_ATTEMPTS}): ${LAST_PUSH_STDERR}"
@@ -489,8 +520,8 @@ if [ "$STAGED_SOMETHING" = true ]; then
                     # before the next attempt. Skip if we are not on a named
                     # branch — there is nothing to rebase onto in detached HEAD.
                     if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
-                        if git fetch --quiet origin "$CURRENT_BRANCH" 2>/dev/null; then
-                            if git rebase --autostash "origin/${CURRENT_BRANCH}" 2>/dev/null; then
+                        if grq_run_git fetch --quiet origin "$CURRENT_BRANCH" 2>/dev/null; then
+                            if grq_run_git rebase --autostash "origin/${CURRENT_BRANCH}" 2>/dev/null; then
                                 echo "Info: rebased onto origin/${CURRENT_BRANCH}, retrying push"
                             else
                                 # Rebase failed — almost always a conflict on
@@ -514,18 +545,28 @@ if [ "$STAGED_SOMETHING" = true ]; then
                         fi
                     fi
 
-                    sleep "$GIT_PUSH_RETRY_DELAY"
+                    sleep "$SLEEP_SECS"
                 fi
             done
 
             if [ "$GIT_PUSH_SUCCESS" = false ]; then
-                echo "Warning: git push failed after ${GIT_PUSH_MAX_ATTEMPTS} attempts, but local changes are committed"
+                echo "ERROR: git push failed after ${GIT_PUSH_MAX_ATTEMPTS} attempts"
                 if [ -n "$LAST_PUSH_STDERR" ]; then
                     echo "Last git push stderr:"
                     echo "$LAST_PUSH_STDERR" | sed 's/^/  /'
                 fi
                 echo "Branch status (git status --porcelain=v2 --branch):"
                 git status --porcelain=v2 --branch 2>&1 | sed 's/^/  /' || true
+
+                # Discard the stale local commit so the next service update
+                # does not commit on top of it (which would falsely mark
+                # the previous service as alive).
+                if grq_recover_to_remote 2>/dev/null; then
+                    echo "Info: reset local clone to origin/${CURRENT_BRANCH} and cleaned working tree"
+                else
+                    echo "Warning: failed to reset local clone to origin/${CURRENT_BRANCH}"
+                fi
+                PUSH_FINAL_STATUS=1
             fi
 
             rm -f "$PUSH_STDERR_FILE" 2>/dev/null || true
@@ -538,3 +579,8 @@ fi
 cd - > /dev/null
 # Re-enable strict error handling
 set -euo pipefail
+
+# Surface push failure as a non-zero exit so the worker can observe it.
+if [ "$PUSH_FINAL_STATUS" -ne 0 ]; then
+    exit "$PUSH_FINAL_STATUS"
+fi

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,14 @@ BASE_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 cd "${BASE_DIR}"
 
+# Source shared git retry helpers (Issue #117) when present. They are
+# loaded eagerly so commit_and_push can use them and so the script remains
+# usable when the helpers directory has not yet been provisioned.
+if [ -f "${BASE_DIR}/helpers/git-retry.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${BASE_DIR}/helpers/git-retry.sh"
+fi
+
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
@@ -1008,43 +1016,104 @@ update_json() {
 }
 
 # Function to commit and push changes
+#
+# Issue #117: Push uses exponential backoff (default 1s, 4s, 16s) and wraps
+# every git call in a 120s timeout to handle slow networks. GitHub
+# rate-limit responses (429 / "rate limit" / abuse detection) trigger a
+# sleep until the rate-limit reset window (probed via `gh api rate_limit`
+# when available) before the next attempt. When all retries are exhausted
+# we surface the actual stderr, reset the local clone to origin/<branch>
+# + clean -fd (so the next service update does not commit on top of a
+# stale unpushed commit, which would falsely mark the previous service as
+# alive), and return non-zero so the failure itself is observable.
 commit_and_push() {
-    if [ -d ".git" ]; then
-        git add docs/
-        # Cross-platform date formatting
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            # macOS - use -r flag
-            commit_date=$(date -r $CURRENT_TS 2>/dev/null || date)
-        else
-            # Linux - use @timestamp format
-            commit_date=$(date -d "@$CURRENT_TS" 2>/dev/null || date)
-        fi
-        git commit -m "Update health status for $HOSTNAME at $commit_date" 2>/dev/null || true
-        
-        # Try to push with retry logic (Issue #51)
-        # Retries up to 3 times with a brief delay to handle transient failures
-        # (git conflicts, network blips) that would otherwise cause false critical alerts
-        local max_retries=3
-        local push_succeeded=false
-        for attempt in $(seq 1 "$max_retries"); do
-            if git push 2>/dev/null; then
-                echo "Changes pushed to remote repository"
-                push_succeeded=true
-                break
-            fi
-            if [ "$attempt" -lt "$max_retries" ]; then
-                echo "Push failed (attempt $attempt/$max_retries), retrying after pull --rebase..."
-                sleep 2
-                git pull --rebase 2>/dev/null || true
-            fi
-        done
-        if [ "$push_succeeded" = false ]; then
-            echo "Push failed after $max_retries attempts"
-        fi
-    else
+    if [ ! -d ".git" ]; then
         echo "Not a git repository, skipping commit/push"
         exit 1
     fi
+
+    git add docs/
+    # Cross-platform date formatting
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS - use -r flag
+        commit_date=$(date -r "$CURRENT_TS" 2>/dev/null || date)
+    else
+        # Linux - use @timestamp format
+        commit_date=$(date -d "@$CURRENT_TS" 2>/dev/null || date)
+    fi
+    git commit -m "Update health status for $HOSTNAME at $commit_date" 2>/dev/null || true
+
+    # Backoff defaults from helpers/git-retry.sh (1s, 4s, 16s).
+    local backoff_raw
+    backoff_raw=$(grq_backoff_delays 2>/dev/null || echo "1 4 16")
+    # shellcheck disable=SC2206
+    local backoff_delays=( $backoff_raw )
+    local max_retries
+    max_retries=$(grq_max_push_attempts 2>/dev/null || echo 3)
+
+    local push_succeeded=false
+    local last_push_stderr=""
+    local push_stderr_file
+    push_stderr_file=$(mktemp 2>/dev/null || echo "/tmp/run_push_stderr.$$")
+    local current_branch
+    current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+    local attempt
+    for attempt in $(seq 1 "$max_retries"); do
+        : > "$push_stderr_file"
+        if grq_run_git push 2>"$push_stderr_file"; then
+            echo "Changes pushed to remote repository"
+            push_succeeded=true
+            break
+        fi
+        last_push_stderr=$(cat "$push_stderr_file" 2>/dev/null || echo "")
+
+        local idx=$((attempt - 1))
+        local backoff_secs="${backoff_delays[$idx]:-${backoff_delays[-1]}}"
+        local sleep_secs="$backoff_secs"
+
+        if echo "$last_push_stderr" | grq_is_rate_limit_error; then
+            sleep_secs=$(grq_rate_limit_sleep_secs "$backoff_secs")
+            echo "Warning: GitHub rate limit detected (attempt ${attempt}/${max_retries}); sleeping ${sleep_secs}s before retry"
+        fi
+
+        if [ "$attempt" -lt "$max_retries" ]; then
+            echo "Push failed (attempt ${attempt}/${max_retries}), retrying after pull --rebase: ${last_push_stderr}"
+            # Try a fetch + pull --rebase to recover from a non-fast-forward
+            # before the next attempt. Failures here are non-fatal — we will
+            # still retry the push.
+            if [ -n "$current_branch" ] && [ "$current_branch" != "HEAD" ]; then
+                grq_run_git fetch --quiet origin "$current_branch" 2>/dev/null || true
+            fi
+            grq_run_git pull --rebase --autostash 2>/dev/null || true
+            sleep "$sleep_secs"
+        fi
+    done
+
+    rm -f "$push_stderr_file" 2>/dev/null || true
+
+    if [ "$push_succeeded" = true ]; then
+        return 0
+    fi
+
+    echo "ERROR: Push failed after ${max_retries} attempts"
+    if [ -n "$last_push_stderr" ]; then
+        echo "Last git push stderr:"
+        echo "$last_push_stderr" | sed 's/^/  /'
+    fi
+    echo "Branch status (git status --porcelain=v2 --branch):"
+    git status --porcelain=v2 --branch 2>&1 | sed 's/^/  /' || true
+
+    # Reset the local clone to origin so the next service update does not
+    # commit on top of the stale unpushed commit (which would falsely mark
+    # the previous service as alive).
+    if grq_recover_to_remote 2>/dev/null; then
+        echo "Info: reset local clone to origin/${current_branch} and cleaned working tree"
+    else
+        echo "Warning: failed to reset local clone to origin/${current_branch}"
+    fi
+
+    return 1
 }
 
 # Main execution

--- a/tests/test-graceful-failure-recovery.sh
+++ b/tests/test-graceful-failure-recovery.sh
@@ -1,0 +1,407 @@
+#!/bin/bash
+# Test for Issue #117: Must gracefully handle GH rate limits and network issues
+#
+# Verifies that:
+#   1. helpers/git-retry.sh exposes the documented helpers and they behave.
+#   2. After all push retries are exhausted, the local repo is reset to
+#      origin so a subsequent service update does not commit on top of the
+#      stale unpushed commit (which would falsely mark the previous service
+#      as alive).
+#   3. When push retries are exhausted, run.sh's commit_and_push exits
+#      non-zero so the failure is observable.
+#   4. helpers/repos.sh exits non-zero when push retries are exhausted.
+#   5. Rate-limit responses trigger a sleep based on the reset window
+#      (probed via the GRQ_RATE_LIMIT_SLEEP_OVERRIDE hook).
+#   6. Backoff between retries follows the configured (1s, 4s, 16s) sequence.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GIT_RETRY_LIB="$PROJECT_ROOT/helpers/git-retry.sh"
+REPOS_SCRIPT="$PROJECT_ROOT/helpers/repos.sh"
+RUN_SH="$PROJECT_ROOT/run.sh"
+
+echo "Testing Issue #117: Graceful handling of GH rate limits and network issues"
+echo "=========================================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+WORK_BASE=$(mktemp -d)
+trap 'rm -rf "$WORK_BASE"' EXIT
+
+export GIT_AUTHOR_NAME="Test"
+export GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="Test"
+export GIT_COMMITTER_EMAIL="test@example.com"
+
+# --------------------------------------------------------------------------
+# Test 1: git-retry.sh helpers exist and behave
+# --------------------------------------------------------------------------
+echo "Test 1: git-retry.sh helpers behave correctly..."
+# shellcheck disable=SC1090
+source "$GIT_RETRY_LIB"
+
+if [ "$(grq_git_timeout_secs)" = "120" ]; then
+    pass_test "default git timeout is 120s"
+else
+    fail_test "expected 120s git timeout, got: $(grq_git_timeout_secs)"
+fi
+
+if GRQ_GIT_TIMEOUT_OVERRIDE=7 grq_git_timeout_secs | grep -q "^7$"; then
+    pass_test "GRQ_GIT_TIMEOUT_OVERRIDE is honoured"
+else
+    fail_test "GRQ_GIT_TIMEOUT_OVERRIDE not honoured"
+fi
+
+if [ "$(grq_backoff_delays)" = "1 4 16" ]; then
+    pass_test "default backoff delays are 1 4 16"
+else
+    fail_test "expected '1 4 16' backoff, got: $(grq_backoff_delays)"
+fi
+
+if echo "remote: error: API rate limit exceeded" | grq_is_rate_limit_error; then
+    pass_test "rate-limit error text is detected"
+else
+    fail_test "rate-limit error text was not detected"
+fi
+
+if echo "fatal: unable to access" | grq_is_rate_limit_error; then
+    fail_test "non rate-limit error misdetected as rate limit"
+else
+    pass_test "non rate-limit error is not misdetected"
+fi
+
+# Override path: ensure the deterministic sleep value is returned.
+SLEEP_SECS=$(GRQ_RATE_LIMIT_SLEEP_OVERRIDE=42 grq_rate_limit_sleep_secs 60)
+if [ "$SLEEP_SECS" = "42" ]; then
+    pass_test "GRQ_RATE_LIMIT_SLEEP_OVERRIDE is honoured"
+else
+    fail_test "expected 42s sleep override, got: $SLEEP_SECS"
+fi
+
+# --------------------------------------------------------------------------
+# Helper: build a real working clone with a bare remote.
+# --------------------------------------------------------------------------
+setup_clone() {
+    local base="$1"
+    local remote="${base}/remote.git"
+    local upstream="${base}/upstream"
+    local work="${base}/work"
+
+    git init --bare --initial-branch=main "$remote" >/dev/null 2>&1
+    git clone --quiet "$remote" "$upstream" >/dev/null 2>&1
+    mkdir -p "$upstream/docs" "$upstream/helpers"
+    echo '{"repos": []}' > "$upstream/docs/repos.json"
+    cp "$REPOS_SCRIPT" "$upstream/helpers/repos.sh"
+    cp "$GIT_RETRY_LIB" "$upstream/helpers/git-retry.sh"
+    chmod +x "$upstream/helpers/repos.sh" "$upstream/helpers/git-retry.sh"
+    (
+        cd "$upstream"
+        git add docs helpers >/dev/null 2>&1
+        git commit -m "initial" --quiet >/dev/null 2>&1
+        git push --quiet origin HEAD:main >/dev/null 2>&1
+    )
+
+    git clone --quiet "$remote" "$work" >/dev/null 2>&1
+    (
+        cd "$work"
+        git checkout -q main
+    )
+    echo "$work"
+}
+
+# --------------------------------------------------------------------------
+# Test 2: repos.sh exits non-zero when push fails for all retries
+# --------------------------------------------------------------------------
+echo ""
+echo "Test 2: repos.sh exits non-zero when all push attempts fail..."
+T2_BASE="${WORK_BASE}/t2"
+mkdir -p "$T2_BASE"
+WORK=$(setup_clone "$T2_BASE")
+
+# Break the remote so push always fails
+(cd "$WORK" && git remote set-url origin "${T2_BASE}/no-such-remote.git")
+
+set +e
+GRQ_PUSH_RETRY_DELAYS_OVERRIDE="0 0 0" \
+    "$WORK/helpers/repos.sh" "Net" --skip-rate-limit --project-root "$WORK" \
+    >"${T2_BASE}/out.log" 2>&1
+EXIT=$?
+set -e
+
+if [ "$EXIT" -ne 0 ]; then
+    pass_test "repos.sh exit code is non-zero on persistent push failure ($EXIT)"
+else
+    fail_test "repos.sh exited 0 on persistent push failure"
+fi
+
+# --------------------------------------------------------------------------
+# Test 3: After repos.sh push exhaustion, working clone matches origin
+#         (no stale local commit blocking the next service's update).
+# --------------------------------------------------------------------------
+echo ""
+echo "Test 3: repos.sh resets working clone to origin after exhausted retries..."
+T3_BASE="${WORK_BASE}/t3"
+mkdir -p "$T3_BASE"
+WORK=$(setup_clone "$T3_BASE")
+T3_REMOTE="${T3_BASE}/remote.git"
+
+# Snapshot the origin HEAD before the failed run.
+ORIGIN_HEAD_BEFORE=$(cd "$T3_REMOTE" && git rev-parse main 2>/dev/null)
+
+# Point at a dead remote so push fails for all 3 attempts.
+(cd "$WORK" && git remote set-url origin "${T3_BASE}/no-such-remote.git")
+
+set +e
+GRQ_PUSH_RETRY_DELAYS_OVERRIDE="0 0 0" \
+    "$WORK/helpers/repos.sh" "DeadService" --skip-rate-limit --project-root "$WORK" \
+    >"${T3_BASE}/out.log" 2>&1
+set -e
+
+# Restore the working remote so we can compare against the real origin.
+(cd "$WORK" && git remote set-url origin "$T3_REMOTE" && git fetch --quiet origin main)
+
+WORK_HEAD=$(cd "$WORK" && git rev-parse HEAD)
+UNPUSHED=$(cd "$WORK" && git rev-list --count "origin/main..HEAD" 2>/dev/null || echo "?")
+DIRTY=$(cd "$WORK" && git status --porcelain)
+
+if [ "$WORK_HEAD" = "$ORIGIN_HEAD_BEFORE" ]; then
+    pass_test "working clone HEAD reset to origin/main after exhausted retries"
+else
+    fail_test "working clone HEAD ($WORK_HEAD) does not match origin ($ORIGIN_HEAD_BEFORE)"
+fi
+
+if [ "$UNPUSHED" = "0" ]; then
+    pass_test "no stale unpushed commit remains after exhausted retries"
+else
+    fail_test "expected 0 unpushed commits, got: $UNPUSHED"
+fi
+
+if [ -z "$DIRTY" ]; then
+    pass_test "working tree is clean after exhausted retries"
+else
+    fail_test "working tree dirty after exhausted retries: $DIRTY"
+fi
+
+# Output should mention reset/recovery so operators can see what happened.
+if grep -Eiq "reset|recover|discard" "${T3_BASE}/out.log"; then
+    pass_test "repos.sh logs the reset/recovery action"
+else
+    fail_test "repos.sh did not log reset/recovery"
+fi
+
+# --------------------------------------------------------------------------
+# Test 4: rate-limit response triggers a sleep matching the override
+# --------------------------------------------------------------------------
+echo ""
+echo "Test 4: rate-limit response triggers configurable sleep..."
+T4_BASE="${WORK_BASE}/t4"
+mkdir -p "$T4_BASE"
+WORK=$(setup_clone "$T4_BASE")
+
+# Mock git so the first push prints a rate-limit error and the second succeeds.
+MOCK_BIN="${T4_BASE}/mock_bin"
+mkdir -p "$MOCK_BIN"
+PUSH_COUNT_FILE="${T4_BASE}/push_count"
+echo "0" > "$PUSH_COUNT_FILE"
+SLEEP_LOG="${T4_BASE}/sleep_log"
+: > "$SLEEP_LOG"
+
+REAL_GIT=$(command -v git)
+cat > "${MOCK_BIN}/git" <<MOCKEOF
+#!/bin/bash
+if [ "\$1" = "push" ]; then
+    count=\$(cat "$PUSH_COUNT_FILE")
+    count=\$((count + 1))
+    echo "\$count" > "$PUSH_COUNT_FILE"
+    if [ "\$count" -le 1 ]; then
+        echo "remote: error: API rate limit exceeded for user." >&2
+        exit 1
+    fi
+    exec "$REAL_GIT" "\$@"
+fi
+exec "$REAL_GIT" "\$@"
+MOCKEOF
+chmod +x "${MOCK_BIN}/git"
+
+# Mock sleep so we can record the requested sleep duration without waiting.
+cat > "${MOCK_BIN}/sleep" <<SLEEPEOF
+#!/bin/bash
+echo "\$1" >> "$SLEEP_LOG"
+exit 0
+SLEEPEOF
+chmod +x "${MOCK_BIN}/sleep"
+
+set +e
+PATH="${MOCK_BIN}:${PATH}" \
+    GRQ_PUSH_RETRY_DELAYS_OVERRIDE="0 0 0" \
+    GRQ_RATE_LIMIT_SLEEP_OVERRIDE=37 \
+    "$WORK/helpers/repos.sh" "RateLimited" --skip-rate-limit --project-root "$WORK" \
+    >"${T4_BASE}/out.log" 2>&1
+EXIT=$?
+set -e
+
+if grep -q "^37$" "$SLEEP_LOG"; then
+    pass_test "rate-limit sleep used the override (37s)"
+else
+    fail_test "expected 37s sleep recorded, got: $(cat "$SLEEP_LOG")"
+fi
+
+if [ "$EXIT" -eq 0 ]; then
+    pass_test "repos.sh succeeded after rate-limit pause + retry"
+else
+    fail_test "repos.sh exited $EXIT after rate-limit pause + retry. Output: $(cat "${T4_BASE}/out.log")"
+fi
+
+if grep -Eiq "rate.limit" "${T4_BASE}/out.log"; then
+    pass_test "repos.sh logged the rate-limit detection"
+else
+    fail_test "repos.sh did not log rate-limit detection. Output: $(cat "${T4_BASE}/out.log")"
+fi
+
+# --------------------------------------------------------------------------
+# Test 5: backoff between retries follows the configured sequence
+# --------------------------------------------------------------------------
+echo ""
+echo "Test 5: backoff sleeps follow the configured sequence..."
+T5_BASE="${WORK_BASE}/t5"
+mkdir -p "$T5_BASE"
+WORK=$(setup_clone "$T5_BASE")
+
+MOCK_BIN5="${T5_BASE}/mock_bin"
+mkdir -p "$MOCK_BIN5"
+SLEEP_LOG5="${T5_BASE}/sleep_log"
+: > "$SLEEP_LOG5"
+
+# Mock git to fail every push with a non-rate-limit error.
+cat > "${MOCK_BIN5}/git" <<MOCKEOF
+#!/bin/bash
+if [ "\$1" = "push" ]; then
+    echo "fatal: unable to access remote" >&2
+    exit 1
+fi
+exec "$REAL_GIT" "\$@"
+MOCKEOF
+chmod +x "${MOCK_BIN5}/git"
+
+cat > "${MOCK_BIN5}/sleep" <<SLEEPEOF
+#!/bin/bash
+echo "\$1" >> "$SLEEP_LOG5"
+exit 0
+SLEEPEOF
+chmod +x "${MOCK_BIN5}/sleep"
+
+set +e
+PATH="${MOCK_BIN5}:${PATH}" \
+    GRQ_PUSH_RETRY_DELAYS_OVERRIDE="2 5 11" \
+    "$WORK/helpers/repos.sh" "BackoffSvc" --skip-rate-limit --project-root "$WORK" \
+    >"${T5_BASE}/out.log" 2>&1
+set -e
+
+# With 3 attempts and the rebase recovery branch, sleeps occur after each
+# failed attempt (except the last). Both attempt-1 and attempt-2 must use
+# the configured backoff values.
+if grep -q "^2$" "$SLEEP_LOG5" && grep -q "^5$" "$SLEEP_LOG5"; then
+    pass_test "backoff sleeps used the configured 2s and 5s values"
+else
+    fail_test "expected 2 and 5 in sleep log, got: $(cat "$SLEEP_LOG5")"
+fi
+
+# --------------------------------------------------------------------------
+# Test 6: run.sh's commit_and_push exits non-zero on persistent push failure
+#         and resets the working clone.
+# --------------------------------------------------------------------------
+echo ""
+echo "Test 6: run.sh commit_and_push exits non-zero and resets on push failure..."
+T6_BASE="${WORK_BASE}/t6"
+mkdir -p "$T6_BASE"
+WORK=$(setup_clone "$T6_BASE")
+
+# Stage an uncommitted change in docs/ so commit_and_push has something to
+# commit (the same shape as a real heartbeat update).
+(
+    cd "$WORK"
+    mkdir -p docs
+    echo '{"hostname": "TEST"}' > docs/index.json
+    git add docs/index.json >/dev/null 2>&1
+    git commit -m "seed" --quiet >/dev/null 2>&1
+    git push --quiet origin HEAD:main >/dev/null 2>&1
+    echo '{"hostname": "TEST", "stale": true}' > docs/index.json
+)
+
+# Snapshot origin head so we can verify the reset target later.
+ORIGIN_HEAD_BEFORE=$(cd "${T6_BASE}/remote.git" && git rev-parse main)
+
+# Break the remote so push always fails.
+(cd "$WORK" && git remote set-url origin "${T6_BASE}/no-such-remote.git")
+
+# Source run.sh's commit_and_push function in a sub-shell so we can
+# observe its exit code.
+set +e
+(
+    cd "$WORK"
+    HOSTNAME="TEST"
+    # CURRENT_TS and NO_GIT are read by the eval'd commit_and_push function.
+    # shellcheck disable=SC2034
+    CURRENT_TS=$(date +%s)
+    # shellcheck disable=SC2034
+    NO_GIT=false
+    # Source the git-retry helpers so commit_and_push can use them.
+    # shellcheck disable=SC1090
+    source "$GIT_RETRY_LIB"
+    eval "$(sed -n '/^commit_and_push()/,/^}/p' "$RUN_SH")"
+    GRQ_PUSH_RETRY_DELAYS_OVERRIDE="0 0 0" commit_and_push
+) >"${T6_BASE}/out.log" 2>&1
+EXIT=$?
+set -e
+
+if [ "$EXIT" -ne 0 ]; then
+    pass_test "run.sh commit_and_push exits non-zero on persistent push failure ($EXIT)"
+else
+    fail_test "run.sh commit_and_push exited 0 on persistent push failure"
+fi
+
+# Restore the working remote and verify the working clone reset back to it.
+(cd "$WORK" && git remote set-url origin "${T6_BASE}/remote.git" && git fetch --quiet origin main)
+WORK_HEAD=$(cd "$WORK" && git rev-parse HEAD)
+UNPUSHED=$(cd "$WORK" && git rev-list --count "origin/main..HEAD" 2>/dev/null || echo "?")
+
+if [ "$WORK_HEAD" = "$ORIGIN_HEAD_BEFORE" ]; then
+    pass_test "run.sh resets working clone to origin after exhausted push retries"
+else
+    fail_test "working clone HEAD ($WORK_HEAD) != origin HEAD ($ORIGIN_HEAD_BEFORE)"
+fi
+
+if [ "$UNPUSHED" = "0" ]; then
+    pass_test "no unpushed commit remains after run.sh exhausts retries"
+else
+    fail_test "expected 0 unpushed commits, got: $UNPUSHED"
+fi
+
+if grep -Eiq "reset|discard|recover" "${T6_BASE}/out.log"; then
+    pass_test "run.sh logs the reset/recovery action"
+else
+    fail_test "run.sh did not log reset/recovery"
+fi
+
+# --------------------------------------------------------------------------
+echo ""
+echo "=========================================================================="
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test-push-retry.sh
+++ b/tests/test-push-retry.sh
@@ -6,6 +6,16 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUN_SH="$SCRIPT_DIR/../run.sh"
+GIT_RETRY_LIB="$SCRIPT_DIR/../helpers/git-retry.sh"
+
+# Issue #117: commit_and_push now uses helpers from git-retry.sh
+# (grq_run_git, grq_backoff_delays, grq_recover_to_remote, etc.). Source
+# the library so the extracted function can find them.
+# shellcheck disable=SC1090
+. "$GIT_RETRY_LIB"
+
+# Speed the retry loop up for tests so we don't wait 1+4+16=21s per retry.
+export GRQ_PUSH_RETRY_DELAYS_OVERRIDE="0 0 0"
 
 echo "Testing Issue #51: Heartbeat push retry on failure"
 echo "==================================================="
@@ -170,7 +180,13 @@ chmod +x "${MOCK_BIN3}/git"
 CURRENT_TS=$(date +%s)
 eval "$(sed -n '/^commit_and_push()/,/^}/p' "$RUN_SH")"
 
+# Issue #117: commit_and_push now exits non-zero when all retries are
+# exhausted so the failure is observable. Capture both the output and the
+# exit code via `|| true` to keep `set -e` happy.
+set +e
 PATH="${MOCK_BIN3}:${PATH}" OUTPUT=$(commit_and_push 2>&1)
+COMMIT_PUSH_EXIT=$?
+set -e
 FINAL_PUSH_COUNT3=$(cat "$PUSH_COUNT_FILE3")
 
 if [ "$FINAL_PUSH_COUNT3" -ge 3 ]; then
@@ -183,6 +199,13 @@ if echo "$OUTPUT" | grep -qi "failed\|push failed"; then
     pass_test "Failure message logged after all retries exhausted"
 else
     fail_test "Expected failure message, got: $OUTPUT"
+fi
+
+# Issue #117: confirm the function returns non-zero when push is exhausted.
+if [ "$COMMIT_PUSH_EXIT" -ne 0 ]; then
+    pass_test "commit_and_push exits non-zero on exhausted retries (Issue #117)"
+else
+    fail_test "Expected non-zero exit on exhausted retries, got: $COMMIT_PUSH_EXIT"
 fi
 
 # Summary

--- a/tests/test-repos-push-rebase.sh
+++ b/tests/test-repos-push-rebase.sh
@@ -58,7 +58,10 @@ setup_diverged_clone() {
     mkdir -p "$upstream_dir/docs" "$upstream_dir/helpers"
     echo '{"repos": []}' > "$upstream_dir/docs/repos.json"
     cp "$REPOS_SCRIPT" "$upstream_dir/helpers/repos.sh"
-    chmod +x "$upstream_dir/helpers/repos.sh"
+    # Issue #117: repos.sh sources helpers/git-retry.sh for the push retry
+    # helpers (timeout wrapping, rate-limit detection, recovery).
+    cp "$SCRIPT_DIR/../helpers/git-retry.sh" "$upstream_dir/helpers/git-retry.sh"
+    chmod +x "$upstream_dir/helpers/repos.sh" "$upstream_dir/helpers/git-retry.sh"
     (
         cd "$upstream_dir"
         git add docs helpers >/dev/null 2>&1
@@ -219,7 +222,9 @@ git clone --quiet "$TEST3_REMOTE" "$TEST3_UPSTREAM" >/dev/null 2>&1
 mkdir -p "$TEST3_UPSTREAM/docs" "$TEST3_UPSTREAM/helpers"
 echo '{"repos": []}' > "$TEST3_UPSTREAM/docs/repos.json"
 cp "$REPOS_SCRIPT" "$TEST3_UPSTREAM/helpers/repos.sh"
-chmod +x "$TEST3_UPSTREAM/helpers/repos.sh"
+# Issue #117: repos.sh sources helpers/git-retry.sh.
+cp "$SCRIPT_DIR/../helpers/git-retry.sh" "$TEST3_UPSTREAM/helpers/git-retry.sh"
+chmod +x "$TEST3_UPSTREAM/helpers/repos.sh" "$TEST3_UPSTREAM/helpers/git-retry.sh"
 (
     cd "$TEST3_UPSTREAM"
     git add docs helpers >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Hardens the health-update push path against transient GitHub failures so a
flaky network or rate-limit response cannot falsely mark a service as dead.
The previous behaviour swallowed push errors silently and left a stale
unpushed commit on the local clone — the next service's update would then
commit on top, producing a misleading heartbeat for the failed service.

Both `run.sh::commit_and_push` and `helpers/repos.sh` now share a small
`helpers/git-retry.sh` library that:

- Retries up to 3 attempts with **exponential backoff** (1s, 4s, 16s).
- Wraps every git invocation in a **120s timeout** (`gtimeout`/`timeout`)
  to bound slow-network hangs.
- Detects GitHub **rate-limit / abuse-detection** responses in stderr
  (`429`, `rate limit`, `too many requests`, `secondary rate limit`) and
  sleeps until the reset window. When `gh` is available the reset epoch
  is read from `gh api rate_limit`; otherwise the standard backoff is used.
- After exhausting retries, **resets the local clone to `origin/<branch>`
  and runs `git clean -fd`**, then **exits non-zero** so the failure is
  itself observable instead of being silently swallowed.

Closes #117.

## Evidence

CLI/backend change — no UI to screenshot.

Verified by the new `tests/test-graceful-failure-recovery.sh` (19 assertions,
all passing) plus the updated `tests/test-push-retry.sh` and
`tests/test-repos-push-rebase.sh`. `./quality.sh` reports 42 passed / 3
pre-existing failures unrelated to this change (`test-gitleaks-workflow`,
`test-scan-log-errors`, `test-vibe-coder-dead-after-8h` — the last is
Issue #118's tracked work).

```mermaid
flowchart TD
    A[commit_and_push / repos.sh push] --> B{git push}
    B -- success --> Z[Done]
    B -- failure --> C[Capture stderr]
    C --> D{Rate limit?}
    D -- yes --> E[Sleep until reset window<br/>via gh api rate_limit or backoff]
    D -- no --> F[Backoff 1s -> 4s -> 16s]
    E --> G{Attempts left?}
    F --> G
    G -- yes --> H[fetch + rebase / pull --rebase] --> B
    G -- no --> I[Surface stderr + porcelain status]
    I --> J[git reset --hard origin/branch<br/>+ git clean -fd]
    J --> K[Exit non-zero]
```

## Test Plan

- **New** `tests/test-graceful-failure-recovery.sh` covering:
  - `git-retry.sh` helpers: timeout default + override, backoff defaults,
    rate-limit detection true/false, override sleep value.
  - `repos.sh` exits non-zero when push retries are exhausted.
  - `repos.sh` resets the working clone (HEAD, index, working tree) to
    `origin/main` after exhausted retries — no stale unpushed commit
    remains, working tree is clean, recovery action is logged.
  - Rate-limit response triggers a sleep matching
    `GRQ_RATE_LIMIT_SLEEP_OVERRIDE`, then succeeds on the next attempt.
  - Backoff sleeps follow the configured `GRQ_PUSH_RETRY_DELAYS_OVERRIDE`
    sequence.
  - `run.sh::commit_and_push` exits non-zero on persistent push failure
    and resets the local clone to `origin/<branch>`.
- **Updated** `tests/test-push-retry.sh` (Issue #51 regression):
  - Now sources `helpers/git-retry.sh` (new dependency of `commit_and_push`).
  - Test 3 captures the exit code so `set -e` does not abort, and
    additionally asserts `commit_and_push` returns non-zero on exhausted
    retries — this is the new business-logic contract from this issue.
- **Updated** `tests/test-repos-push-rebase.sh` (Issue #1862 regression):
  - The setup helpers now also copy `helpers/git-retry.sh` into the
    fixture clones so the embedded `repos.sh` can source it. No assertions
    changed; existing 11 assertions still pass.

### Tunables (defaults shown)

| Env var | Default | Purpose |
| --- | --- | --- |
| `GRQ_PUSH_MAX_ATTEMPTS` | `3` | Push attempt budget |
| `GRQ_PUSH_RETRY_DELAYS_OVERRIDE` | `1 4 16` | Backoff seconds (space-separated) |
| `GRQ_GIT_TIMEOUT_OVERRIDE` | `120` | Per-git-call timeout (seconds) |
| `GRQ_RATE_LIMIT_SLEEP_OVERRIDE` | _unset_ | Test hook to bypass `gh api rate_limit` |



---

🤖 Processed by: stservice<!-- vibe-worker-issue-117 -->