### PR TITLE
helpers/repos.sh: push retry budget too small for multi-writer load — Vibe Coder pushes silently abandoned (Issue #125)

### DIFF
--- a/docs/pr-summary-125.md
+++ b/docs/pr-summary-125.md
@@ -1,0 +1,57 @@
+## Summary
+
+Expand the git push retry budget so a busy stretch with 12+ concurrent Vibe
+Coder writers racing on `docs/repos.json` can clear before the failure path
+discards the local commit. Closes #125.
+
+- `grq_backoff_delays` default: `1 4 16` → `1 4 16 30 60` (~111s budget).
+- `grq_max_push_attempts` default: `3` → `5`.
+- Both remain configurable via `GRQ_PUSH_RETRY_DELAYS_OVERRIDE` and
+  `GRQ_PUSH_MAX_ATTEMPTS` (unchanged contract).
+- Fixed a latent bash 3.2 bug: the existing `${arr[-1]}` fallback in
+  `helpers/repos.sh` and `run.sh` errors under `set -u` on macOS bash 3.2
+  when a test override supplies fewer entries than the attempt count.
+  Replaced with an explicit `LAST_IDX=$(( ${#arr[@]} - 1 ))`.
+
+## Evidence
+
+CLI/bash change — no UI surface to screenshot.
+
+Before vs after retry budget:
+
+| | Attempts | Backoff (s) | Total wall-clock |
+|---|---|---|---|
+| Before | 3 | 1, 4, 16 | ~21s |
+| After  | 5 | 1, 4, 16, 30, 60 | ~111s |
+
+Flow on a busy host (12+ concurrent writers):
+
+```mermaid
+flowchart LR
+    A[push] -->|non-FF| B[fetch + rebase]
+    B --> C{within budget?}
+    C -- yes --> A
+    C -- no --> D[grq_recover_to_remote<br/>discards local commit]
+    D --> E[dashboard goes stale]
+```
+
+The old 21s budget often expired in three races before the rebase + push
+could land, hitting D. The new ~111s budget over five attempts gives the
+loop room to win the race during a busy minute.
+
+Test runs:
+
+- `tests/test-graceful-failure-recovery.sh` — 22 passed, 0 failed
+  (added explicit assertions for the new defaults plus override sanity).
+- `tests/test-push-retry.sh` — 6 passed.
+- `tests/test-repos-push-rebase.sh` — 11 passed.
+
+## Test Plan
+
+- Updated `tests/test-graceful-failure-recovery.sh`:
+  - Asserts `grq_backoff_delays` default is now `1 4 16 30 60`.
+  - Asserts `grq_max_push_attempts` default is now `5`.
+  - Adds sanity checks that `GRQ_PUSH_RETRY_DELAYS_OVERRIDE` and
+    `GRQ_PUSH_MAX_ATTEMPTS` still override the defaults.
+- Existing rebase-recovery, rate-limit, and failure-reset tests continue
+  to pass against the larger budget.

--- a/helpers/git-retry.sh
+++ b/helpers/git-retry.sh
@@ -8,10 +8,12 @@
 #   grq_git_timeout_secs     — echoes the per-git-call timeout (default 120).
 #                              Override via GRQ_GIT_TIMEOUT_OVERRIDE.
 #   grq_backoff_delays       — echoes the space-separated backoff delays
-#                              (default "1 4 16"). Override via
-#                              GRQ_PUSH_RETRY_DELAYS_OVERRIDE for tests.
-#   grq_max_push_attempts    — echoes the max push attempts (default 3).
-#                              Override via GRQ_PUSH_MAX_ATTEMPTS.
+#                              (default "1 4 16 30 60" — ~111s total budget,
+#                              sized for 12+ concurrent Vibe Coder writers
+#                              racing on docs/repos.json; Issue #125).
+#                              Override via GRQ_PUSH_RETRY_DELAYS_OVERRIDE.
+#   grq_max_push_attempts    — echoes the max push attempts (default 5;
+#                              Issue #125). Override via GRQ_PUSH_MAX_ATTEMPTS.
 #   grq_run_git              — runs `git "$@"` wrapped in the timeout helper
 #                              (when available). Caller controls redirections.
 #   grq_is_rate_limit_error  — given stderr text on stdin, returns 0 if the
@@ -43,11 +45,14 @@ grq_git_timeout_secs() {
 }
 
 grq_backoff_delays() {
-    echo "${GRQ_PUSH_RETRY_DELAYS_OVERRIDE:-1 4 16}"
+    # Issue #125: bumped from "1 4 16" to "1 4 16 30 60" so a busy stretch
+    # with 12+ concurrent writers racing on docs/repos.json can clear.
+    echo "${GRQ_PUSH_RETRY_DELAYS_OVERRIDE:-1 4 16 30 60}"
 }
 
 grq_max_push_attempts() {
-    echo "${GRQ_PUSH_MAX_ATTEMPTS:-3}"
+    # Issue #125: bumped from 3 to 5 (paired with the longer backoff series).
+    echo "${GRQ_PUSH_MAX_ATTEMPTS:-5}"
 }
 
 # Run a git command wrapped with the timeout helper (when available).

--- a/helpers/repos.sh
+++ b/helpers/repos.sh
@@ -543,10 +543,14 @@ if [ "$STAGED_SOMETHING" = true ]; then
         if git commit -m "$COMMIT_MSG" --quiet 2>/dev/null; then
             # Backoff defaults from git-retry.sh; legacy
             # GIT_PUSH_RETRY_DELAY_OVERRIDE still honoured (back-compat).
-            BACKOFF_DELAYS_RAW=$(grq_backoff_delays 2>/dev/null || echo "1 4 16")
+            # Issue #125: defaults bumped to "1 4 16 30 60" / 5 attempts so
+            # 12+ concurrent Vibe Coder writers racing on docs/repos.json
+            # can clear within the retry budget instead of falling through
+            # to the recover-to-remote path and discarding the local commit.
+            BACKOFF_DELAYS_RAW=$(grq_backoff_delays 2>/dev/null || echo "1 4 16 30 60")
             # shellcheck disable=SC2206
             BACKOFF_DELAYS=( $BACKOFF_DELAYS_RAW )
-            GIT_PUSH_MAX_ATTEMPTS=$(grq_max_push_attempts 2>/dev/null || echo 3)
+            GIT_PUSH_MAX_ATTEMPTS=$(grq_max_push_attempts 2>/dev/null || echo 5)
             LEGACY_DELAY="${GIT_PUSH_RETRY_DELAY_OVERRIDE:-}"
             GIT_PUSH_SUCCESS=false
             LAST_PUSH_STDERR=""
@@ -565,7 +569,12 @@ if [ "$STAGED_SOMETHING" = true ]; then
                 # Decide the inter-attempt sleep up-front so rate-limit
                 # responses can override the standard backoff.
                 IDX=$((attempt - 1))
-                BACKOFF_SECS="${BACKOFF_DELAYS[$IDX]:-${BACKOFF_DELAYS[-1]}}"
+                # bash 3.2 (macOS default) errors on ${arr[-1]} with `set -u`,
+                # so compute the last index explicitly. The fallback covers
+                # the case where attempts > backoff entries (e.g. when a test
+                # override supplies fewer delays than the default 5 attempts).
+                LAST_IDX=$(( ${#BACKOFF_DELAYS[@]} - 1 ))
+                BACKOFF_SECS="${BACKOFF_DELAYS[$IDX]:-${BACKOFF_DELAYS[$LAST_IDX]}}"
                 if [ -n "$LEGACY_DELAY" ]; then
                     BACKOFF_SECS="$LEGACY_DELAY"
                 fi

--- a/run.sh
+++ b/run.sh
@@ -1043,13 +1043,14 @@ commit_and_push() {
     fi
     git commit -m "Update health status for $HOSTNAME at $commit_date" 2>/dev/null || true
 
-    # Backoff defaults from helpers/git-retry.sh (1s, 4s, 16s).
+    # Backoff defaults from helpers/git-retry.sh
+    # (Issue #125: 1s, 4s, 16s, 30s, 60s over 5 attempts).
     local backoff_raw
-    backoff_raw=$(grq_backoff_delays 2>/dev/null || echo "1 4 16")
+    backoff_raw=$(grq_backoff_delays 2>/dev/null || echo "1 4 16 30 60")
     # shellcheck disable=SC2206
     local backoff_delays=( $backoff_raw )
     local max_retries
-    max_retries=$(grq_max_push_attempts 2>/dev/null || echo 3)
+    max_retries=$(grq_max_push_attempts 2>/dev/null || echo 5)
 
     local push_succeeded=false
     local last_push_stderr=""
@@ -1069,7 +1070,11 @@ commit_and_push() {
         last_push_stderr=$(cat "$push_stderr_file" 2>/dev/null || echo "")
 
         local idx=$((attempt - 1))
-        local backoff_secs="${backoff_delays[$idx]:-${backoff_delays[-1]}}"
+        # bash 3.2 errors on ${arr[-1]} under `set -u`; resolve the last
+        # index explicitly so test overrides with fewer entries than the
+        # attempt count still work.
+        local last_idx=$(( ${#backoff_delays[@]} - 1 ))
+        local backoff_secs="${backoff_delays[$idx]:-${backoff_delays[$last_idx]}}"
         local sleep_secs="$backoff_secs"
 
         if echo "$last_push_stderr" | grq_is_rate_limit_error; then

--- a/tests/test-graceful-failure-recovery.sh
+++ b/tests/test-graceful-failure-recovery.sh
@@ -13,6 +13,7 @@
 #   5. Rate-limit responses trigger a sleep based on the reset window
 #      (probed via the GRQ_RATE_LIMIT_SLEEP_OVERRIDE hook).
 #   6. Backoff between retries follows the configured (1s, 4s, 16s) sequence.
+#   7. Default retry budget is 5 attempts over "1 4 16 30 60" (Issue #125).
 
 set -e
 
@@ -66,10 +67,29 @@ else
     fail_test "GRQ_GIT_TIMEOUT_OVERRIDE not honoured"
 fi
 
-if [ "$(grq_backoff_delays)" = "1 4 16" ]; then
-    pass_test "default backoff delays are 1 4 16"
+if [ "$(grq_backoff_delays)" = "1 4 16 30 60" ]; then
+    pass_test "default backoff delays are 1 4 16 30 60 (Issue #125)"
 else
-    fail_test "expected '1 4 16' backoff, got: $(grq_backoff_delays)"
+    fail_test "expected '1 4 16 30 60' backoff, got: $(grq_backoff_delays)"
+fi
+
+if [ "$(grq_max_push_attempts)" = "5" ]; then
+    pass_test "default max push attempts is 5 (Issue #125)"
+else
+    fail_test "expected 5 max push attempts, got: $(grq_max_push_attempts)"
+fi
+
+# Sanity: the override still works for both.
+if [ "$(GRQ_PUSH_RETRY_DELAYS_OVERRIDE='0 0' grq_backoff_delays)" = "0 0" ]; then
+    pass_test "GRQ_PUSH_RETRY_DELAYS_OVERRIDE is honoured"
+else
+    fail_test "GRQ_PUSH_RETRY_DELAYS_OVERRIDE not honoured"
+fi
+
+if [ "$(GRQ_PUSH_MAX_ATTEMPTS=2 grq_max_push_attempts)" = "2" ]; then
+    pass_test "GRQ_PUSH_MAX_ATTEMPTS is honoured"
+else
+    fail_test "GRQ_PUSH_MAX_ATTEMPTS not honoured"
 fi
 
 if echo "remote: error: API rate limit exceeded" | grq_is_rate_limit_error; then


### PR DESCRIPTION
## Summary

Expand the git push retry budget so a busy stretch with 12+ concurrent Vibe
Coder writers racing on `docs/repos.json` can clear before the failure path
discards the local commit. Closes #125.

- `grq_backoff_delays` default: `1 4 16` → `1 4 16 30 60` (~111s budget).
- `grq_max_push_attempts` default: `3` → `5`.
- Both remain configurable via `GRQ_PUSH_RETRY_DELAYS_OVERRIDE` and
  `GRQ_PUSH_MAX_ATTEMPTS` (unchanged contract).
- Fixed a latent bash 3.2 bug: the existing `${arr[-1]}` fallback in
  `helpers/repos.sh` and `run.sh` errors under `set -u` on macOS bash 3.2
  when a test override supplies fewer entries than the attempt count.
  Replaced with an explicit `LAST_IDX=$(( ${#arr[@]} - 1 ))`.

## Evidence

CLI/bash change — no UI surface to screenshot.

Before vs after retry budget:

| | Attempts | Backoff (s) | Total wall-clock |
|---|---|---|---|
| Before | 3 | 1, 4, 16 | ~21s |
| After  | 5 | 1, 4, 16, 30, 60 | ~111s |

Flow on a busy host (12+ concurrent writers):

```mermaid
flowchart LR
    A[push] -->|non-FF| B[fetch + rebase]
    B --> C{within budget?}
    C -- yes --> A
    C -- no --> D[grq_recover_to_remote<br/>discards local commit]
    D --> E[dashboard goes stale]
```

The old 21s budget often expired in three races before the rebase + push
could land, hitting D. The new ~111s budget over five attempts gives the
loop room to win the race during a busy minute.

Test runs:

- `tests/test-graceful-failure-recovery.sh` — 22 passed, 0 failed
  (added explicit assertions for the new defaults plus override sanity).
- `tests/test-push-retry.sh` — 6 passed.
- `tests/test-repos-push-rebase.sh` — 11 passed.

## Test Plan

- Updated `tests/test-graceful-failure-recovery.sh`:
  - Asserts `grq_backoff_delays` default is now `1 4 16 30 60`.
  - Asserts `grq_max_push_attempts` default is now `5`.
  - Adds sanity checks that `GRQ_PUSH_RETRY_DELAYS_OVERRIDE` and
    `GRQ_PUSH_MAX_ATTEMPTS` still override the defaults.
- Existing rebase-recovery, rate-limit, and failure-reset tests continue
  to pass against the larger budget.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-125 -->