### PR TITLE
Issue #127: [stage-failure-health] is the authoritative classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ A distributed health monitoring system that tracks the status of multiple hosts 
 - **All issues are counted** in the dashboard exception count
 
 #### Exception Detection in run.sh:
+- **Authoritative signal (Issue #127)**: When the log contains
+  `[stage-failure-health] failures=N firstStage=S firstExitCode=C firstHitLine=L`
+  (emitted by GRQ#2313), `scan_log_errors` trusts that line over every other
+  heuristic:
+  - `failures=0` → run classified as **successful**; any noisy
+    "Task failed with status N" line is ignored.
+  - `failures>0` → run classified as **failed**; `exception_count=N` and the
+    summary names `firstStage`, `firstExitCode`, `firstHitLine`.
+- **Reporting warnings (Issue #127)**: `[reporting-warning] …` lines are
+  counted into a separate `reporting_warning_count` field on the per-user
+  and per-host JSON, surfaced in `docs/index.json` so operators can
+  distinguish three states:
+  1. Healthy — `exception_count=0`, `reporting_warning_count=0`.
+  2. Healthy with transient reporting issues — `exception_count=0`,
+     `reporting_warning_count>0`.
+  3. Failed — `exception_count>0`.
+- **Legacy fall-back**: Logs without `[stage-failure-health]` (predating
+  GRQ#2313) continue to use the original heuristic classifier below.
 - **Stack traces**: Lines with "Exception", "Error", "MEMETIC" followed by stack trace lines
 - **Missing commands**: "No such file or directory" errors
 - **Warning emojis**: Lines containing "⚠️"

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.13";
+const VERSION = "1.1.14";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.13" rel="stylesheet">
+    <link href="./styles.css?v=1.1.14" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -107,14 +107,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.13"></script>
+    <script src="./dashboard.js?v=1.1.14"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.13')
+                navigator.serviceWorker.register('./sw.js?v=1.1.14')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/pr-summary-127.md
+++ b/docs/pr-summary-127.md
@@ -1,0 +1,73 @@
+## Summary
+
+Teach `scan_log_errors` in `run.sh` to treat the `[stage-failure-health]
+failures=N firstStage=S firstExitCode=C firstHitLine=L` line (emitted by
+GRQ#2313) as the authoritative work-success/failure signal, and count
+`[reporting-warning] …` lines into a separate `reporting_warning_count`
+field on `docs/index.json` so operators can distinguish a healthy run
+from a healthy run with transient reporting issues.
+
+Fixes the GRQ-3-sloth misclassification from GRQ#2387 where a
+*successful* `discoveryReplay` run was flagged as failed because a noisy
+"Task failed with status 2" line followed an authoritative
+`failures=0`. Closes #127.
+
+## Evidence
+
+This is a backend/log-parsing change with no UI surface. Verified via
+the new `tests/test-stage-failure-health.sh` regression suite plus the
+existing `tests/test-scan-log-errors.sh` legacy classifier tests:
+
+```text
+Test 1: failures=0 followed by 'Task failed with status 2' classifies as success...
+  PASS: GRQ-3-sloth.log fixture classified as success (count=0)
+Test 2: failures=3 is classified as failed with stage metadata...
+  PASS: failures=3 surfaced as exception_count=3
+  PASS: failure summary names firstStage (summary=3 stage failure(s) (first: discoveryReplay exit=42 line=1234))
+  PASS: failure summary names firstExitCode
+Test 3: [reporting-warning] is counted separately and does not fail the run...
+  PASS: reporting-warning present, failures=0 → success
+  PASS: reporting_warning_count=2 surfaced
+Test 4: Legacy log with stack trace still detected as error...
+  PASS: Legacy stack trace still detected (count=1)
+Test 5: Legacy clean log still classifies as success...
+  PASS: Legacy clean log classified as success
+Test 6: failures=0 overrides ⚠️ emoji legacy counts...
+  PASS: ⚠️ noise ignored when failures=0
+
+Results: 9 passed, 0 failed
+```
+
+Classifier flow:
+
+```mermaid
+flowchart TD
+    A[node log] --> B{contains<br/>[stage-failure-health]?}
+    B -- no --> L[Legacy heuristics<br/>stack traces / ⚠️ / ❌ / etc.]
+    B -- yes --> C{failures<br/>field}
+    C -- failures=0 --> S[exception_count=0<br/>successful]
+    C -- failures>0 --> F[exception_count=N<br/>summary names firstStage / exit / line]
+    S --> W{reporting-warning<br/>lines present?}
+    F --> W
+    W -- count>0 --> R[reporting_warning_count>0<br/>surfaced in index.json]
+    W -- count=0 --> J[index.json updated]
+    R --> J
+    L --> J
+```
+
+The pre-existing `test-gitleaks-workflow` failure on the branch
+(`Missing gitleaks-action step or GITHUB_TOKEN env`) is unrelated to
+this change — confirmed by `git stash` baseline run.
+
+## Test Plan
+
+- Added `tests/test-stage-failure-health.sh` — 9 assertions across 6
+  scenarios covering the authoritative signal, legacy fall-back,
+  reporting-warning counting, and the GRQ-3-sloth regression fixture.
+- Existing `tests/test-scan-log-errors.sh` still passes — legacy
+  classifier untouched for logs predating GRQ#2313.
+- Ran `./quality.sh < /dev/null` end-to-end — 48/49 pass; the single
+  failure is the pre-existing `test-gitleaks-workflow` issue unrelated
+  to #127.
+- Version bumped `1.1.13 → 1.1.14` and `./update_version.sh` ran to
+  propagate to `docs/index.html`, `docs/dashboard.js`, `docs/sw.js`.

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.13
+// Version: 1.1.14
 
-const CACHE_NAME = 'grq-health-v1.1.13';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.13';
+const CACHE_NAME = 'grq-health-v1.1.14';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.14';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.13',
+  './dashboard.js?v=1.1.14',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ fi
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.13"
+VERSION="1.1.14"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.
@@ -744,7 +744,14 @@ get_system_info() {
     exception_summary_escaped=$(escape_json "$exception_summary")
     config_warning_escaped=$(escape_json "$config_warning")
     
-    echo "{\"uptime\": $uptime_sec, \"free_disk_space\": \"$free_disk_space_escaped\", \"used_disk_percent\": \"$used_disk_percent_escaped\", \"total_disk_gb\": \"$total_disk_gb_escaped\", \"mem_usage_percent\": \"$mem_usage_percent_escaped\", \"total_mem_gb\": \"$total_mem_gb_escaped\", \"cpu_load\": \"$cpu_load_escaped\", \"cpu_cores\": \"$cpu_cores_escaped\", \"cpu_model\": \"$cpu_speed_escaped\", \"machine_type\": \"$machine_type_escaped\", \"cpu_breakdown\": \"$cpu_breakdown_escaped\", \"load_averages\": \"$load_averages_escaped\", \"timezone\": \"$timezone_escaped\", \"os_info\": \"$os_info_escaped\", \"os_version\": \"$os_version_escaped\", \"network_status\": \"$network_status_escaped\", \"ip_addresses\": \"$ip_addresses_escaped\", \"exception_count\": $exception_count, \"exception_summary\": \"$exception_summary_escaped\", \"config_warning\": \"$config_warning_escaped\"}"
+    # Issue #127: surface reporting_warning_count alongside exception_count
+    # so the dashboard can distinguish a healthy run with transient reporting
+    # issues from a real work-failure.
+    if [[ ! "${reporting_warning_count:-0}" =~ ^[0-9]+$ ]]; then
+        reporting_warning_count=0
+    fi
+
+    echo "{\"uptime\": $uptime_sec, \"free_disk_space\": \"$free_disk_space_escaped\", \"used_disk_percent\": \"$used_disk_percent_escaped\", \"total_disk_gb\": \"$total_disk_gb_escaped\", \"mem_usage_percent\": \"$mem_usage_percent_escaped\", \"total_mem_gb\": \"$total_mem_gb_escaped\", \"cpu_load\": \"$cpu_load_escaped\", \"cpu_cores\": \"$cpu_cores_escaped\", \"cpu_model\": \"$cpu_speed_escaped\", \"machine_type\": \"$machine_type_escaped\", \"cpu_breakdown\": \"$cpu_breakdown_escaped\", \"load_averages\": \"$load_averages_escaped\", \"timezone\": \"$timezone_escaped\", \"os_info\": \"$os_info_escaped\", \"os_version\": \"$os_version_escaped\", \"network_status\": \"$network_status_escaped\", \"ip_addresses\": \"$ip_addresses_escaped\", \"exception_count\": $exception_count, \"exception_summary\": \"$exception_summary_escaped\", \"reporting_warning_count\": $reporting_warning_count, \"config_warning\": \"$config_warning_escaped\"}"
 }
 
 # Function to scan log file for errors and return count
@@ -754,17 +761,59 @@ scan_log_errors() {
     if [[ -n "${NODE_PID:-}" ]]; then
       log_file="${HOME}/logs/node-${NODE_PID}.log"
     fi
-    
+
     # Initialize global variables
     exception_count=0
     exception_summary=""
-    
+    # Issue #127: count transient reporting-layer issues separately from
+    # work-failures so the dashboard can distinguish a healthy run from
+    # a healthy run with reporting hiccups.
+    reporting_warning_count=0
+
     if [ -f "$log_file" ]; then
         # Issue #61: Filter out [MemoryMonitor] lines — these are operational noise
         # (cache clearing warnings) that should not be flagged as errors.
         local filtered_log
         filtered_log=$(mktemp)
         grep -v '\[MemoryMonitor\]' "$log_file" > "$filtered_log" 2>/dev/null || true
+
+        # Issue #127: [reporting-warning] lines are transient reporting hiccups
+        # (e.g. failed-to-push a health update) and must NOT be treated as
+        # work-failures. Count them regardless of which classifier path runs.
+        reporting_warning_count=$(grep -c '\[reporting-warning\]' "$filtered_log" 2>/dev/null | tr -d ' \n' || echo "0")
+
+        # Issue #127: prefer the authoritative [stage-failure-health] line
+        # over noisy exit-code / "Task failed with status N" messages.
+        # Format: [stage-failure-health] failures=N firstStage=S firstExitCode=C firstHitLine=L
+        local stage_health_line
+        stage_health_line=$(grep -m1 '\[stage-failure-health\]' "$filtered_log" 2>/dev/null || true)
+
+        if [ -n "$stage_health_line" ]; then
+            local failures first_stage first_exit first_line
+            failures=$(echo "$stage_health_line" | sed -nE 's/.*failures=([0-9]+).*/\1/p')
+            [ -z "$failures" ] && failures=0
+
+            if [ "$failures" -eq 0 ]; then
+                exception_count=0
+                if [ "$reporting_warning_count" -gt 0 ]; then
+                    exception_summary="No errors found (${reporting_warning_count} reporting warning(s))"
+                else
+                    exception_summary="No errors found"
+                fi
+            else
+                exception_count="$failures"
+                first_stage=$(echo "$stage_health_line" | sed -nE 's/.*firstStage=([^ ]+).*/\1/p')
+                first_exit=$(echo "$stage_health_line" | sed -nE 's/.*firstExitCode=([^ ]+).*/\1/p')
+                first_line=$(echo "$stage_health_line" | sed -nE 's/.*firstHitLine=([^ ]+).*/\1/p')
+                exception_summary="${failures} stage failure(s) (first: ${first_stage:-unknown} exit=${first_exit:-?} line=${first_line:-?})"
+            fi
+
+            rm -f "$filtered_log"
+            return 0
+        fi
+
+        # Legacy fall-back: no [stage-failure-health] line (logs predating
+        # GRQ#2313). Continue with the original heuristic classifier.
 
         # Count actual exceptions by looking for error messages that precede stack traces
         # Each exception starts with an error message, followed by stack trace lines
@@ -944,7 +993,7 @@ update_json() {
            # Ensure users map exists and update this user entry
            | .[$host].users = (.[$host].users // {})
            | .[$host].users[$user] = ((.[$host].users[$user] // {})
-               + ($info | {exception_count, exception_summary, config_warning})
+               + ($info | {exception_count, exception_summary, reporting_warning_count, config_warning})
                | .heart_beat_ts = ($ts | tonumber)
                | .version = $version)
            # Aggregate across users so dashboard can flag a stuck user
@@ -954,6 +1003,7 @@ update_json() {
            | .[$host].heart_beat_ts = (.[$host].best_user_heart_beat_ts // ($ts | tonumber))
            | .[$host].version = $version
            | .[$host].exception_count = ([.[$host].users[]? | (.exception_count // 0)] | add // 0)
+           | .[$host].reporting_warning_count = ([.[$host].users[]? | (.reporting_warning_count // 0)] | add // 0)
            | .[$host].exception_summary =
                (if (.[$host].exception_count // 0) > 0 then
                    ( .[$host].users
@@ -988,7 +1038,7 @@ update_json() {
                "version": $version,
                "user_stale_hours": ($user_stale_hours | tonumber),
                "users": {
-                   ($user): (($info | {exception_count, exception_summary, config_warning}) + {"heart_beat_ts": ($ts | tonumber), "version": $version})
+                   ($user): (($info | {exception_count, exception_summary, reporting_warning_count, config_warning}) + {"heart_beat_ts": ($ts | tonumber), "version": $version})
                },
                "user_count": 1,
                "worst_user_heart_beat_ts": ($ts | tonumber),

--- a/tests/test-stage-failure-health.sh
+++ b/tests/test-stage-failure-health.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Test for Issue #127: [stage-failure-health] is the authoritative success/failure signal
+#
+# Background: GRQ now emits a deterministic line:
+#   [stage-failure-health] failures=N firstStage=S firstExitCode=C firstHitLine=L
+# The consumer (scan_log_errors in run.sh) must trust this line over noisy
+# "Task failed with status N" reporting-layer messages. See GRQ#2387.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_SH="$SCRIPT_DIR/../run.sh"
+
+echo "Testing Issue #127: [stage-failure-health] authoritative classifier"
+echo "==================================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Create a temporary directory for test log files
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Extract scan_log_errors from run.sh
+eval "$(sed -n '/^scan_log_errors()/,/^}/p' "$RUN_SH")"
+
+HOME="$WORK_DIR"
+mkdir -p "$WORK_DIR/logs"
+# shellcheck disable=SC2034
+NODE_PID=""
+
+# ---------------------------------------------------------------------------
+# Test 1: GRQ-3-sloth.log misclassification scenario from GRQ#2387
+# Authoritative line says failures=0, but noisy "Task failed with status 2"
+# follows. Result MUST be classified as successful (exception_count=0).
+# ---------------------------------------------------------------------------
+echo "Test 1: failures=0 followed by 'Task failed with status 2' classifies as success..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+[2026-05-18 06:26:35 AEST] Discovery loop completed after 2 iteration(s) in 5642s
+[wasm-activation-health] failures=0 firstUuid=none firstStage=none
+[stage-failure-health] failures=0 firstStage=none firstExitCode=0 firstHitLine=0
+Task failed with status 2 at 2026-05-18 02:29:37 AEST [option=discoveryReplay]
+EOF
+
+scan_log_errors
+# shellcheck disable=SC2154
+if [ "$exception_count" -eq 0 ]; then
+    pass_test "GRQ-3-sloth.log fixture classified as success (count=$exception_count)"
+else
+    # shellcheck disable=SC2154
+    fail_test "GRQ-3-sloth.log fixture falsely flagged: $exception_summary"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: failures>0 must be classified as failed with surfaced metadata
+# ---------------------------------------------------------------------------
+echo "Test 2: failures=3 is classified as failed with stage metadata..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+Some normal log output
+[stage-failure-health] failures=3 firstStage=discoveryReplay firstExitCode=42 firstHitLine=1234
+Task completed
+EOF
+
+scan_log_errors
+if [ "$exception_count" -eq 3 ]; then
+    pass_test "failures=3 surfaced as exception_count=3"
+else
+    fail_test "failures=3 not surfaced correctly (count=$exception_count)"
+fi
+
+# shellcheck disable=SC2154
+if echo "$exception_summary" | grep -q "discoveryReplay"; then
+    pass_test "failure summary names firstStage (summary=$exception_summary)"
+else
+    fail_test "failure summary missing firstStage: $exception_summary"
+fi
+
+if echo "$exception_summary" | grep -q "42"; then
+    pass_test "failure summary names firstExitCode (summary=$exception_summary)"
+else
+    fail_test "failure summary missing firstExitCode: $exception_summary"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: [reporting-warning] lines surface separately, not as failures
+# ---------------------------------------------------------------------------
+echo "Test 3: [reporting-warning] is counted separately and does not fail the run..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+[reporting-warning] transient git push retry succeeded after 2 attempts
+[reporting-warning] could not record run health
+[stage-failure-health] failures=0 firstStage=none firstExitCode=0 firstHitLine=0
+EOF
+
+scan_log_errors
+if [ "$exception_count" -eq 0 ]; then
+    pass_test "reporting-warning present, failures=0 → success (count=$exception_count)"
+else
+    fail_test "reporting-warning falsely flagged as failure: $exception_summary"
+fi
+
+# shellcheck disable=SC2154
+if [ "${reporting_warning_count:-0}" -eq 2 ]; then
+    pass_test "reporting_warning_count=2 surfaced (got $reporting_warning_count)"
+else
+    fail_test "reporting_warning_count expected 2, got ${reporting_warning_count:-unset}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Legacy logs (no [stage-failure-health]) keep the existing classifier
+# ---------------------------------------------------------------------------
+echo "Test 4: Legacy log with stack trace still detected as error..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+2026-03-07T10:35:47.452Z [INFO] Starting process
+Error: Something went wrong
+    at Object.runInContext (vm.js:130:16)
+    at main (index.js:52:8)
+EOF
+
+scan_log_errors
+if [ "$exception_count" -gt 0 ]; then
+    pass_test "Legacy stack trace still detected (count=$exception_count)"
+else
+    fail_test "Legacy stack trace NOT detected — fall-back broken"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Legacy clean log (no [stage-failure-health]) classifies as success
+# ---------------------------------------------------------------------------
+echo "Test 5: Legacy clean log still classifies as success..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+run_core pid=20689 start=Sat Mar  7 21:30:59 AEDT 2026
+Version 1.3.14
+HEAD is now at 8f0cfaf Evolution score 0.4065 -> 0.4066
+EOF
+
+scan_log_errors
+if [ "$exception_count" -eq 0 ]; then
+    pass_test "Legacy clean log classified as success (count=$exception_count)"
+else
+    fail_test "Legacy clean log falsely flagged: $exception_summary"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: failures=0 with a ⚠️ warning in the noise is still success
+# (authoritative line overrides legacy emoji counts)
+# ---------------------------------------------------------------------------
+echo "Test 6: failures=0 overrides ⚠️ emoji legacy counts..."
+cat > "$WORK_DIR/logs/node.log" << 'EOF'
+some stage emitted ⚠️ a non-critical warning
+[stage-failure-health] failures=0 firstStage=none firstExitCode=0 firstHitLine=0
+EOF
+
+scan_log_errors
+if [ "$exception_count" -eq 0 ]; then
+    pass_test "⚠️ noise ignored when failures=0 (count=$exception_count)"
+else
+    fail_test "⚠️ noise falsely flagged despite failures=0: $exception_summary"
+fi
+
+# Summary
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Teach `scan_log_errors` in `run.sh` to treat the `[stage-failure-health]
failures=N firstStage=S firstExitCode=C firstHitLine=L` line (emitted by
GRQ#2313) as the authoritative work-success/failure signal, and count
`[reporting-warning] …` lines into a separate `reporting_warning_count`
field on `docs/index.json` so operators can distinguish a healthy run
from a healthy run with transient reporting issues.

Fixes the GRQ-3-sloth misclassification from GRQ#2387 where a
*successful* `discoveryReplay` run was flagged as failed because a noisy
"Task failed with status 2" line followed an authoritative
`failures=0`. Closes #127.

## Evidence

This is a backend/log-parsing change with no UI surface. Verified via
the new `tests/test-stage-failure-health.sh` regression suite plus the
existing `tests/test-scan-log-errors.sh` legacy classifier tests:

```text
Test 1: failures=0 followed by 'Task failed with status 2' classifies as success...
  PASS: GRQ-3-sloth.log fixture classified as success (count=0)
Test 2: failures=3 is classified as failed with stage metadata...
  PASS: failures=3 surfaced as exception_count=3
  PASS: failure summary names firstStage (summary=3 stage failure(s) (first: discoveryReplay exit=42 line=1234))
  PASS: failure summary names firstExitCode
Test 3: [reporting-warning] is counted separately and does not fail the run...
  PASS: reporting-warning present, failures=0 → success
  PASS: reporting_warning_count=2 surfaced
Test 4: Legacy log with stack trace still detected as error...
  PASS: Legacy stack trace still detected (count=1)
Test 5: Legacy clean log still classifies as success...
  PASS: Legacy clean log classified as success
Test 6: failures=0 overrides ⚠️ emoji legacy counts...
  PASS: ⚠️ noise ignored when failures=0

Results: 9 passed, 0 failed
```

Classifier flow:

```mermaid
flowchart TD
    A[node log] --> B{contains<br/>[stage-failure-health]?}
    B -- no --> L[Legacy heuristics<br/>stack traces / ⚠️ / ❌ / etc.]
    B -- yes --> C{failures<br/>field}
    C -- failures=0 --> S[exception_count=0<br/>successful]
    C -- failures>0 --> F[exception_count=N<br/>summary names firstStage / exit / line]
    S --> W{reporting-warning<br/>lines present?}
    F --> W
    W -- count>0 --> R[reporting_warning_count>0<br/>surfaced in index.json]
    W -- count=0 --> J[index.json updated]
    R --> J
    L --> J
```

The pre-existing `test-gitleaks-workflow` failure on the branch
(`Missing gitleaks-action step or GITHUB_TOKEN env`) is unrelated to
this change — confirmed by `git stash` baseline run.

## Test Plan

- Added `tests/test-stage-failure-health.sh` — 9 assertions across 6
  scenarios covering the authoritative signal, legacy fall-back,
  reporting-warning counting, and the GRQ-3-sloth regression fixture.
- Existing `tests/test-scan-log-errors.sh` still passes — legacy
  classifier untouched for logs predating GRQ#2313.
- Ran `./quality.sh < /dev/null` end-to-end — 48/49 pass; the single
  failure is the pre-existing `test-gitleaks-workflow` issue unrelated
  to #127.
- Version bumped `1.1.13 → 1.1.14` and `./update_version.sh` ran to
  propagate to `docs/index.html`, `docs/dashboard.js`, `docs/sw.js`.