### PR TITLE
Raise disk-usage warning threshold from 80% to 90%

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,11 +293,11 @@ External task runners (e.g. a Quality gate in a worker repo) should follow the c
 
 - **Healthy**: 
   - Heartbeat within 24 hours
-  - Disk usage under 80%
+  - Disk usage under 90%
   - OS version up to date
 - **Warning**:
-  - Disk usage at or above 80% (with hysteresis: clears only when dropping to or below 77%)
-  - A host can remain in warning state between 77% and 80% until it drops below the clear threshold — this hysteresis band prevents status oscillation when disk usage hovers near the boundary
+  - Disk usage at or above 90% (with hysteresis: clears only when dropping to or below 87%)
+  - A host can remain in warning state between 87% and 90% until it drops below the clear threshold — this hysteresis band prevents status oscillation when disk usage hovers near the boundary
   - Outdated OS version
   - Heartbeat within 24 hours
 - **Critical**: 

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,11 +99,11 @@ Mobile machines that are expected to be offline:
 
 ### Healthy
 - Heartbeat within 24 hours
-- Disk usage under 80%
+- Disk usage under 90%
 - OS version up to date
 
 ### Warning
-- Disk usage at or above 80% (with hysteresis: clears at or below 77%)
+- Disk usage at or above 90% (with hysteresis: clears at or below 87%)
 - Outdated OS version
 - Heartbeat within 24 hours
 

--- a/docs/archive/pr-summaries/pr-summary-131.md
+++ b/docs/archive/pr-summaries/pr-summary-131.md
@@ -1,0 +1,26 @@
+## Summary
+
+Raised the disk-usage warning threshold in the dashboard from 80% to 90%, and moved the hysteresis clear threshold from 77% to 87% to preserve the existing 3-percentage-point gap. Closes #131.
+
+- `docs/dashboard.js`: `DISK_WARNING_PERCENT` 80 → 90, `DISK_WARNING_CLEAR_PERCENT` 77 → 87.
+- `README.md` and `docs/README.md`: health-status documentation updated to the new thresholds.
+- Tests updated so threshold-constant assertions and hard-coded sample values reflect the new boundaries; threshold-relative tests are unchanged.
+
+## Evidence
+
+Backend/CLI change with no UI layout difference — the dashboard simply flags fewer hosts because the trigger moved up by 10 points. Tested via the existing test suite:
+
+- `tests/test-thresholds-constants.sh` — asserts `DISK_WARNING_PERCENT === 90` and `DISK_WARNING_CLEAR_PERCENT === 87`.
+- `tests/test-disk-hysteresis.sh` — verifies `isDiskWarning` triggers above 90% and clears at/below 87% (threshold-relative cases unchanged; one hard-coded sample bumped to 95%).
+- `tests/test-disk-warning-message.sh` — verifies above-threshold and in-band branches of `buildDiskWarningMessage` with the new thresholds.
+- `tests/test-readme-disk-thresholds.sh` — extracts the constants from `dashboard.js` and confirms the README documents the same values.
+
+`./quality.sh` passes apart from a pre-existing, unrelated `test-gitleaks-workflow.sh` failure (`Missing gitleaks-action step or GITHUB_TOKEN env`) that also fails on `origin/Develop`.
+
+## Test Plan
+
+- [x] `./quality.sh < /dev/null` — 48 of 49 tests pass; the one failure is pre-existing on Develop and unrelated to disk thresholds.
+- [x] `tests/test-thresholds-constants.sh` updated to assert the new 90 / 87 values.
+- [x] `tests/test-disk-warning-message.sh` updated so the hard-coded above-threshold samples (85 → 95, 85.2 → 95.2) still exercise the above-threshold branch under the new 90% trigger.
+- [x] `tests/test-disk-hysteresis.sh` hard-coded "above threshold" sample bumped from 80 to 95.
+- [x] `tests/test-readme-disk-thresholds.sh` continues to pass because the README was updated to match the new constants.

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -33,8 +33,8 @@ const THRESHOLDS = {
     IDLE_LOAD_5M: 15,         // 5-minute load average threshold for idle detection (%)
     IDLE_LOAD_15M: 20,        // 15-minute load average threshold for idle detection (%)
     IDLE_HIGH_LOAD: 50,       // Load above this indicates active work (recently started/stopped)
-    DISK_WARNING_PERCENT: 80, // Disk usage at or above this triggers a warning (Issue #71)
-    DISK_WARNING_CLEAR_PERCENT: 77, // Disk usage must drop to or below this to clear warning (hysteresis)
+    DISK_WARNING_PERCENT: 90, // Disk usage at or above this triggers a warning (Issue #131)
+    DISK_WARNING_CLEAR_PERCENT: 87, // Disk usage must drop to or below this to clear warning (hysteresis)
     HEARTBEAT_CRITICAL_HOURS: 24, // Hours without heartbeat before marking host critical
     USER_STALE_DEFAULT_HOURS: 24, // Default hours before a user is marked stale (3x the 8h heartbeat threshold)
     MACOS_MIN_VERSION: '14.0',    // macOS versions below this trigger a warning

--- a/tests/test-disk-hysteresis.sh
+++ b/tests/test-disk-hysteresis.sh
@@ -50,11 +50,11 @@ const now = Math.floor(Date.now() / 1000);
 
 // Test 3: Disk clearly above threshold triggers warning (not previously warning)
 {
-    const result = isDiskWarning(80, false);
+    const result = isDiskWarning(95, false);
     if (result === true) {
-        console.log("TEST_RESULT:above-triggers:PASS:80% triggers warning");
+        console.log("TEST_RESULT:above-triggers:PASS:95% triggers warning");
     } else {
-        console.log("TEST_RESULT:above-triggers:FAIL:80% should trigger warning, got " + result);
+        console.log("TEST_RESULT:above-triggers:FAIL:95% should trigger warning, got " + result);
     }
 }
 

--- a/tests/test-disk-warning-message.sh
+++ b/tests/test-disk-warning-message.sh
@@ -37,12 +37,12 @@ OUTPUT=$(run_js_test '
 
 // Test 2: Above threshold — message references the trigger threshold
 {
-    const msg = buildDiskWarningMessage(85.2);
+    const msg = buildDiskWarningMessage(95.2);
     const expected = THRESHOLDS.DISK_WARNING_PERCENT;
-    if (msg.includes("85.2%") && msg.includes(String(expected) + "%")) {
+    if (msg.includes("95.2%") && msg.includes(String(expected) + "%")) {
         console.log("TEST_RESULT:above-threshold-msg:PASS:message includes usage and threshold: " + msg);
     } else {
-        console.log("TEST_RESULT:above-threshold-msg:FAIL:expected usage 85.2% and threshold " + expected + "% in message, got: " + msg);
+        console.log("TEST_RESULT:above-threshold-msg:FAIL:expected usage 95.2% and threshold " + expected + "% in message, got: " + msg);
     }
 }
 
@@ -82,7 +82,7 @@ OUTPUT=$(run_js_test '
 
 // Test 6: Above threshold — message does NOT mention hysteresis
 {
-    const msg = buildDiskWarningMessage(85);
+    const msg = buildDiskWarningMessage(95);
     if (!msg.includes("hysteresis")) {
         console.log("TEST_RESULT:above-no-hysteresis:PASS:above-threshold message does not mention hysteresis");
     } else {
@@ -90,9 +90,9 @@ OUTPUT=$(run_js_test '
     }
 }
 
-// Test 7: Threshold values are dynamic (not hardcoded 80/77)
+// Test 7: Threshold values are dynamic (not hardcoded 90/87)
 {
-    const aboveMsg = buildDiskWarningMessage(90);
+    const aboveMsg = buildDiskWarningMessage(THRESHOLDS.DISK_WARNING_PERCENT + 5);
     const bandMsg = buildDiskWarningMessage(THRESHOLDS.DISK_WARNING_PERCENT - 1);
     const warnPct = THRESHOLDS.DISK_WARNING_PERCENT;
     const clearPct = THRESHOLDS.DISK_WARNING_CLEAR_PERCENT;
@@ -107,8 +107,8 @@ OUTPUT=$(run_js_test '
 
 // Test 8: Message always starts with "High disk usage:"
 {
-    const msg1 = buildDiskWarningMessage(85);
-    const msg2 = buildDiskWarningMessage(78);
+    const msg1 = buildDiskWarningMessage(95);
+    const msg2 = buildDiskWarningMessage(88);
     if (msg1.startsWith("High disk usage:") && msg2.startsWith("High disk usage:")) {
         console.log("TEST_RESULT:prefix-consistent:PASS:both messages start with High disk usage:");
     } else {

--- a/tests/test-thresholds-constants.sh
+++ b/tests/test-thresholds-constants.sh
@@ -184,21 +184,21 @@ OUTPUT=$(run_js_test '
     }
 }
 
-// Test 13: Issue #71 — Disk warning threshold is 80%
+// Test 13: Issue #131 — Disk warning threshold is 90%
 {
-    if (THRESHOLDS.DISK_WARNING_PERCENT === 80) {
-        console.log("TEST_RESULT:disk-warning-80:PASS:DISK_WARNING_PERCENT is 80%");
+    if (THRESHOLDS.DISK_WARNING_PERCENT === 90) {
+        console.log("TEST_RESULT:disk-warning-90:PASS:DISK_WARNING_PERCENT is 90%");
     } else {
-        console.log("TEST_RESULT:disk-warning-80:FAIL:expected 80, got " + THRESHOLDS.DISK_WARNING_PERCENT);
+        console.log("TEST_RESULT:disk-warning-90:FAIL:expected 90, got " + THRESHOLDS.DISK_WARNING_PERCENT);
     }
 }
 
-// Test 14: Issue #71 — Disk warning clear threshold is 77% (3-point hysteresis)
+// Test 14: Issue #131 — Disk warning clear threshold is 87% (3-point hysteresis)
 {
-    if (THRESHOLDS.DISK_WARNING_CLEAR_PERCENT === 77) {
-        console.log("TEST_RESULT:disk-clear-77:PASS:DISK_WARNING_CLEAR_PERCENT is 77%");
+    if (THRESHOLDS.DISK_WARNING_CLEAR_PERCENT === 87) {
+        console.log("TEST_RESULT:disk-clear-87:PASS:DISK_WARNING_CLEAR_PERCENT is 87%");
     } else {
-        console.log("TEST_RESULT:disk-clear-77:FAIL:expected 77, got " + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT);
+        console.log("TEST_RESULT:disk-clear-87:FAIL:expected 87, got " + THRESHOLDS.DISK_WARNING_CLEAR_PERCENT);
     }
 }
 


### PR DESCRIPTION
## Summary
Raised `DISK_WARNING_PERCENT` from 80 to 90 in `docs/dashboard.js`, and moved `DISK_WARNING_CLEAR_PERCENT` from 77 to 87 so the existing 3-percentage-point hysteresis gap is preserved. README documentation (root and `docs/`) updated to match, and tests for the threshold constants and the warning-message branches bumped to the new values. Closes #131.

## Evidence
Backend/CLI change with no UI layout difference — only the trigger point moves. Verified via the existing test suite:

- `tests/test-thresholds-constants.sh` asserts `DISK_WARNING_PERCENT === 90` and `DISK_WARNING_CLEAR_PERCENT === 87`.
- `tests/test-disk-hysteresis.sh` and `tests/test-disk-warning-message.sh` exercise `isDiskWarning` and `buildDiskWarningMessage` against the new thresholds.
- `tests/test-readme-disk-thresholds.sh` extracts the constants from `dashboard.js` and confirms the README documents them.

`./quality.sh` passes apart from a pre-existing `test-gitleaks-workflow.sh` failure that also fails on `origin/Develop` and is unrelated to this change.

## Test plan
- [x] `./quality.sh < /dev/null` — 48 of 49 tests pass; the lone failure is pre-existing on Develop.
- [x] Threshold-constant tests assert the new 90 / 87 values.
- [x] Warning-message tests still exercise the above-threshold branch (samples 85 → 95, 85.2 → 95.2) and the in-band branch.
- [x] README disk-threshold test still passes because both READMEs now mention 90% and 87%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)