### PR TITLE
Bump VERSION to 1.1.15 to invalidate stale PWA cache (#133)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-133.md
+++ b/docs/archive/pr-summaries/pr-summary-133.md
@@ -1,0 +1,59 @@
+## Summary
+PR #132 raised the disk-usage warning threshold from 80% to 90% in
+`docs/dashboard.js`, but did not bump `VERSION`. The dashboard is a PWA:
+`docs/sw.js` caches `./dashboard.js?v=<VERSION>` under
+`grq-health-static-v<VERSION>`, so clients with the service worker
+installed kept serving the old cached file and continued to flag hosts
+in warning at 81–87% with the message `High disk usage: X% (>= 80%)`.
+
+This PR bumps `VERSION` from `1.1.14` to `1.1.15` via `run.sh` and runs
+`./update_version.sh` so the service worker cache name, static-cache
+name, and every `?v=` cache-buster in `docs/sw.js` and
+`docs/index.html` rotate to `1.1.15`. Existing service-worker
+installations invalidate their old cache and fetch the new
+`dashboard.js` with `DISK_WARNING_PERCENT = 90`. A new
+`tests/test-version-consistency.sh` regression test asserts these
+versions stay in sync so any future change that bumps `run.sh` but
+forgets `sw.js` (or vice versa) fails the quality gate. Closes #133.
+
+## Evidence
+Screenshot from issue #133 showing the cached-old-code symptom — three
+hosts flagged warning at 81.8% / 81.6% / 86.9% with the literal
+message `(>= 80%)` even though `dashboard.js` on `Develop` reads 90%:
+
+![issue-133-cached-80](https://github.com/user-attachments/assets/bae94b90-8b94-4627-8ec7-48e964c07638)
+
+Cache-invalidation flow once this PR lands:
+
+```mermaid
+sequenceDiagram
+    participant U as User browser (PWA)
+    participant SW as Service Worker
+    participant GH as GitHub Pages
+    U->>SW: GET ./dashboard.js?v=1.1.15
+    SW->>SW: Lookup grq-health-static-v1.1.15 (miss)
+    SW->>GH: fetch ./dashboard.js?v=1.1.15
+    GH-->>SW: new dashboard.js (DISK_WARNING_PERCENT=90)
+    SW->>SW: Activate evicts grq-health-static-v1.1.14
+    SW-->>U: serves new dashboard.js
+```
+
+Local quality run: 49 / 50 tests pass. The lone failure
+(`test-gitleaks-workflow`) is pre-existing on `Develop` and was also
+called out as pre-existing by PR #132.
+
+## Test Plan
+- [x] Added `tests/test-version-consistency.sh` — asserts `run.sh`
+      `VERSION` matches `docs/dashboard.js` `const VERSION`,
+      `docs/sw.js` `// Version`, `CACHE_NAME`, `STATIC_CACHE_NAME`, the
+      `dashboard.js?v=` entry in the SW static-file list, and the
+      `styles.css?v=` / `dashboard.js?v=` / `sw.js?v=` cache-busters in
+      `docs/index.html`. 8 assertions, all PASS after the bump.
+- [x] Existing `tests/test-thresholds-constants.sh` still passes
+      (`DISK_WARNING_PERCENT === 90`, `DISK_WARNING_CLEAR_PERCENT === 87`).
+- [x] Existing `tests/test-disk-hysteresis.sh` and
+      `tests/test-disk-warning-message.sh` continue to pass against the
+      90 / 87 thresholds.
+- [x] `quality.sh < /dev/null` — 49 / 50 pass; only pre-existing
+      `test-gitleaks-workflow` failure remains (unchanged from
+      `Develop`).

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.14";
+const VERSION = "1.1.15";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.14" rel="stylesheet">
+    <link href="./styles.css?v=1.1.15" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -107,14 +107,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.14"></script>
+    <script src="./dashboard.js?v=1.1.15"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.14')
+                navigator.serviceWorker.register('./sw.js?v=1.1.15')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.14
+// Version: 1.1.15
 
-const CACHE_NAME = 'grq-health-v1.1.14';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.14';
+const CACHE_NAME = 'grq-health-v1.1.15';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.15';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.14',
+  './dashboard.js?v=1.1.15',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ fi
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.14"
+VERSION="1.1.15"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/test-version-consistency.sh
+++ b/tests/test-version-consistency.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Test for Issue #133: Service worker and HTML cache busters must match
+# run.sh VERSION so threshold/code changes (e.g. Issue #131) are picked up
+# by clients with the PWA installed instead of being masked by a stale
+# cached dashboard.js.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Testing Issue #133: client cache-buster version consistency"
+echo "==========================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+VERSION_RUN_SH=$(grep '^VERSION=' "$ROOT_DIR/run.sh" | head -1 | cut -d'"' -f2)
+if [ -z "$VERSION_RUN_SH" ]; then
+    fail_test "could not read VERSION from run.sh"
+    exit 1
+fi
+echo "  run.sh VERSION = $VERSION_RUN_SH"
+echo ""
+
+# dashboard.js — VERSION constant
+DASH_VER=$(grep '^const VERSION = ' "$ROOT_DIR/docs/dashboard.js" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+if [ "$DASH_VER" = "$VERSION_RUN_SH" ]; then
+    pass_test "dashboard.js const VERSION matches run.sh ($DASH_VER)"
+else
+    fail_test "dashboard.js const VERSION ($DASH_VER) != run.sh ($VERSION_RUN_SH)"
+fi
+
+# sw.js — comment, CACHE_NAME, STATIC_CACHE_NAME, dashboard.js?v= cache buster
+SW_COMMENT=$(grep '^// Version:' "$ROOT_DIR/docs/sw.js" | head -1 | awk '{print $3}')
+if [ "$SW_COMMENT" = "$VERSION_RUN_SH" ]; then
+    pass_test "sw.js // Version comment matches run.sh ($SW_COMMENT)"
+else
+    fail_test "sw.js // Version comment ($SW_COMMENT) != run.sh ($VERSION_RUN_SH)"
+fi
+
+SW_CACHE=$(grep "^const CACHE_NAME" "$ROOT_DIR/docs/sw.js" | head -1 | sed "s/.*'grq-health-v\([0-9.]*\)'.*/\1/")
+if [ "$SW_CACHE" = "$VERSION_RUN_SH" ]; then
+    pass_test "sw.js CACHE_NAME matches run.sh ($SW_CACHE)"
+else
+    fail_test "sw.js CACHE_NAME ($SW_CACHE) != run.sh ($VERSION_RUN_SH) — stale cache will be served"
+fi
+
+SW_STATIC=$(grep "^const STATIC_CACHE_NAME" "$ROOT_DIR/docs/sw.js" | head -1 | sed "s/.*'grq-health-static-v\([0-9.]*\)'.*/\1/")
+if [ "$SW_STATIC" = "$VERSION_RUN_SH" ]; then
+    pass_test "sw.js STATIC_CACHE_NAME matches run.sh ($SW_STATIC)"
+else
+    fail_test "sw.js STATIC_CACHE_NAME ($SW_STATIC) != run.sh ($VERSION_RUN_SH) — stale static cache will be served"
+fi
+
+SW_DASH=$(grep "dashboard\.js?v=" "$ROOT_DIR/docs/sw.js" | head -1 | sed "s/.*dashboard\.js?v=\([0-9.]*\)['\"].*/\1/")
+if [ "$SW_DASH" = "$VERSION_RUN_SH" ]; then
+    pass_test "sw.js dashboard.js?v= cache buster matches run.sh ($SW_DASH)"
+else
+    fail_test "sw.js dashboard.js?v= ($SW_DASH) != run.sh ($VERSION_RUN_SH)"
+fi
+
+# index.html — three cache busters
+for asset in "styles.css" "dashboard.js" "sw.js"; do
+    HTML_VER=$(grep "${asset}?v=" "$ROOT_DIR/docs/index.html" | head -1 | sed "s/.*${asset}?v=\([0-9.]*\).*/\1/")
+    if [ "$HTML_VER" = "$VERSION_RUN_SH" ]; then
+        pass_test "index.html ${asset}?v= matches run.sh ($HTML_VER)"
+    else
+        fail_test "index.html ${asset}?v= ($HTML_VER) != run.sh ($VERSION_RUN_SH) — clients will load stale ${asset}"
+    fi
+done
+
+echo ""
+echo "==========================================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
PR #132 raised the disk-usage warning threshold from 80% to 90% in
`docs/dashboard.js`, but did not bump `VERSION`. The dashboard is a PWA:
`docs/sw.js` caches `./dashboard.js?v=<VERSION>` under
`grq-health-static-v<VERSION>`, so clients with the service worker
installed kept serving the old cached file and continued to flag hosts
in warning at 81–87% with the message `High disk usage: X% (>= 80%)`.

This PR bumps `VERSION` from `1.1.14` to `1.1.15` via `run.sh` and runs
`./update_version.sh` so the service worker cache name, static-cache
name, and every `?v=` cache-buster in `docs/sw.js` and
`docs/index.html` rotate to `1.1.15`. Existing service-worker
installations invalidate their old cache and fetch the new
`dashboard.js` with `DISK_WARNING_PERCENT = 90`. A new
`tests/test-version-consistency.sh` regression test asserts these
versions stay in sync so any future change that bumps `run.sh` but
forgets `sw.js` (or vice versa) fails the quality gate. Closes #133.

## Evidence
Screenshot from issue #133 showing the cached-old-code symptom — three
hosts flagged warning at 81.8% / 81.6% / 86.9% with the literal
message `(>= 80%)` even though `dashboard.js` on `Develop` reads 90%:

![issue-133-cached-80](https://github.com/user-attachments/assets/bae94b90-8b94-4627-8ec7-48e964c07638)

Cache-invalidation flow once this PR lands:

```mermaid
sequenceDiagram
    participant U as User browser (PWA)
    participant SW as Service Worker
    participant GH as GitHub Pages
    U->>SW: GET ./dashboard.js?v=1.1.15
    SW->>SW: Lookup grq-health-static-v1.1.15 (miss)
    SW->>GH: fetch ./dashboard.js?v=1.1.15
    GH-->>SW: new dashboard.js (DISK_WARNING_PERCENT=90)
    SW->>SW: Activate evicts grq-health-static-v1.1.14
    SW-->>U: serves new dashboard.js
```

Local quality run: 49 / 50 tests pass. The lone failure
(`test-gitleaks-workflow`) is pre-existing on `Develop` and was also
called out as pre-existing by PR #132.

## Test Plan
- [x] Added `tests/test-version-consistency.sh` — asserts `run.sh`
      `VERSION` matches `docs/dashboard.js` `const VERSION`,
      `docs/sw.js` `// Version`, `CACHE_NAME`, `STATIC_CACHE_NAME`, the
      `dashboard.js?v=` entry in the SW static-file list, and the
      `styles.css?v=` / `dashboard.js?v=` / `sw.js?v=` cache-busters in
      `docs/index.html`. 8 assertions, all PASS after the bump.
- [x] Existing `tests/test-thresholds-constants.sh` still passes
      (`DISK_WARNING_PERCENT === 90`, `DISK_WARNING_CLEAR_PERCENT === 87`).
- [x] Existing `tests/test-disk-hysteresis.sh` and
      `tests/test-disk-warning-message.sh` continue to pass against the
      90 / 87 thresholds.
- [x] `quality.sh < /dev/null` — 49 / 50 pass; only pre-existing
      `test-gitleaks-workflow` failure remains (unchanged from
      `Develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)