### PR TITLE
Add cross-platform GPU usage card per host (Issue #136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,21 @@ The script performs the following operations:
    - Free disk space (in GB)
    - Memory usage percentage
    - CPU load average
+   - GPU usage (cross-platform, non-privileged — see below)
    - Operating system information
    - Network connectivity status
    - Timezone information
+
+   **GPU metrics (Issue #136)** are collected during the same scan, with no
+   `sudo`/`powermetrics` required. Any value that cannot be read degrades to
+   `N/A` rather than erroring or blocking the scan:
+   - **Apple Silicon** — live `Device Utilization %` and GPU memory in use via
+     `ioreg -r -d 1 -c IOAccelerator`; chipset model + core count via
+     `system_profiler SPDisplaysDataType`.
+   - **NVIDIA (Linux/Windows)** — utilisation %, VRAM used/total, temperature
+     and product name from a single `nvidia-smi` call.
+   - Other vendors (AMD, Intel integrated) and non-GPU hosts simply report
+     `N/A`. The dashboard shows a **GPU Load** card next to **CPU Load**.
 
 2. **Health Check Logic**:
    - Checks if the last heartbeat was more than 12 hours ago
@@ -170,6 +182,11 @@ The system uses a simple structure where each hostname is a key:
     "disk_usage_percent": "39.7",
     "mem_usage_percent": "65.2",
     "cpu_load": "1.25",
+    "gpu_load": "4%",
+    "gpu_model": "Apple M4 Pro",
+    "gpu_cores": "16",
+    "gpu_memory": "0.36 GB in use",
+    "gpu_breakdown": "N/A",
     "timezone": "AEST",
     "os_info": "macOS",
     "os_version": "15.5",

--- a/docs/archive/pr-summaries/pr-summary-136.md
+++ b/docs/archive/pr-summaries/pr-summary-136.md
@@ -1,0 +1,93 @@
+# PR Summary — Issue #136: Record and display GPU usage per host (cross-platform)
+
+## Summary
+
+Adds per-host **GPU** metrics that mirror the existing CPU card. GPU data is
+collected during the same `run.sh` scan, persisted into `docs/index.json`, and
+shown as a **GPU Load** card next to **CPU Load** on the dashboard. Collection
+is strictly **non-privileged** (no `sudo`, no `powermetrics`) and every value
+degrades gracefully to `N/A` rather than erroring or blocking the scan.
+
+Closes #136.
+
+### What was added
+
+- **Apple Silicon** — live `Device Utilization %` and GPU memory in use via
+  `ioreg -r -d 1 -c IOAccelerator`; chipset model + core count via
+  `system_profiler SPDisplaysDataType`.
+- **NVIDIA (Linux/Windows)** — utilisation %, VRAM used/total, temperature and
+  product name from a single `nvidia-smi` call.
+- Other vendors (AMD, Intel integrated) and non-GPU hosts report `N/A`.
+
+New `index.json` fields: `gpu_load`, `gpu_model`, `gpu_cores`, `gpu_memory`,
+`gpu_breakdown`.
+
+### Key files
+
+- `run.sh` — new `collect_gpu_info()` sets the `gpu_*` variables; the JSON
+  output and escaping were extended. Pipelines use `|| true` so a no-match
+  `grep` cannot abort the scan under `set -euo pipefail` (older chips that lack
+  the `ioreg` key still report `N/A`).
+- `docs/dashboard.js` — pure `formatGpuDisplay()` (in the unit-tested region)
+  plus a **GPU Load** card in `createHostCard`.
+- `README.md` — documents the collection approach and the new fields.
+
+> **Note on scope:** `docs/simple.html` is a summarised status page and does not
+> render per-host CPU cards, so there is no CPU card to mirror there — the GPU
+> card lives in the full dashboard (`docs/dashboard.js`) where the CPU card is.
+
+## Flow
+
+```mermaid
+flowchart LR
+    A[run.sh scan] --> B[collect_gpu_info]
+    B -->|macOS| C[ioreg + system_profiler]
+    B -->|NVIDIA| D[nvidia-smi]
+    B -->|none| E[N/A defaults]
+    C --> F[gpu_* fields]
+    D --> F
+    E --> F
+    F --> G[docs/index.json]
+    G --> H[dashboard.js formatGpuDisplay]
+    H --> I[GPU Load card next to CPU Load]
+```
+
+## Evidence
+
+A headless browser / Playwright MCP was **not available** on the build host, so
+no PNG screenshot could be captured. Instead:
+
+- A static, openable render of the card markup (using the real `styles.css`)
+  is committed at `docs/evidence/issue-136-gpu-card.html`.
+- The exact strings the card renders, produced by `formatGpuDisplay()`:
+
+  ```
+  [GRQ-25 (Apple M4 Pro, real)]  ->  GPU Load: 4% (16 cores, Apple M4 Pro)  |  0.36 GB in use
+  [NVIDIA host]                  ->  GPU Load: 30% (NVIDIA GeForce RTX 3080)  |  2048 / 8192 MB  |  65°C
+  [Host with no GPU data]        ->  GPU Load: N/A
+  ```
+
+- Live collection on the build host (GRQ-25, Apple M4 Pro) produced
+  `4% | Apple M4 Pro | 16 | 0.36 GB in use | N/A`, and these real values were
+  written into `docs/index.json` for GRQ-25.
+
+## Test Plan
+
+- `tests/test-gpu-display.sh` — unit tests for the pure `formatGpuDisplay()`
+  helper: Apple full string, NVIDIA without core count, bare-number
+  normalisation, all-N/A, N/A-load-with-known-model, `unknown`/empty handling,
+  and partial fields.
+- `tests/test-gpu-collection.sh` — extracts `collect_gpu_info()` and exercises
+  it with **stubbed** `nvidia-smi`/`ioreg`/`system_profiler` so it is
+  hardware-independent and cross-platform: NVIDIA host, no-GPU host (all
+  `N/A`), Apple Silicon host, and the regression case where the `ioreg`
+  utilisation key is absent (must not abort under `set -euo pipefail`).
+- `./quality.sh` passes for all GPU-related tests, JSON validity and version
+  consistency.
+
+### Pre-existing failure (out of scope)
+
+`./quality.sh` reports one failing test, `test-gitleaks-workflow`
+(`Missing gitleaks-action step or GITHUB_TOKEN env`). This failure is
+**pre-existing and unrelated** to this change — it reproduces on a clean tree
+with the working changes stashed, and no `.github/` files were modified here.

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.15";
+const VERSION = "1.1.17";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -947,6 +947,44 @@ function getHealthStatus(_hostname, data, options) {
     return 'healthy';
 }
 
+// Issue #136: Format the per-host GPU display string, mirroring the CPU card.
+// Returns "<load> (<cores> cores, <model>)" with whichever parts are known,
+// or "N/A" when no GPU data is readable. Treats missing / "unknown" / "N/A"
+// values as absent so older chips and non-GPU hosts degrade gracefully.
+function formatGpuDisplay(data) {
+    const isNa = (v) => {
+        if (v === undefined || v === null) return true;
+        const s = String(v).trim().toLowerCase();
+        return s === '' || s === 'unknown' || s === 'n/a' || s === 'na';
+    };
+
+    // Live utilisation — normalise a bare number to a percentage.
+    let display = 'N/A';
+    if (!isNa(data.gpu_load)) {
+        const load = String(data.gpu_load).trim();
+        if (load.includes('%')) {
+            display = load;
+        } else {
+            const n = parseFloat(load);
+            display = Number.isNaN(n) ? 'N/A' : `${n}%`;
+        }
+    }
+
+    // Append core count and model where available, matching the CPU card.
+    const extras = [];
+    if (!isNa(data.gpu_cores)) {
+        extras.push(`${data.gpu_cores} cores`);
+    }
+    if (!isNa(data.gpu_model)) {
+        extras.push(String(data.gpu_model));
+    }
+    if (extras.length > 0) {
+        display += ` (${extras.join(', ')})`;
+    }
+
+    return display;
+}
+
 function createHostCard(hostname, data) {
     const healthStatus = getCachedHealthStatus(hostname);
     const statusClass = healthStatus;
@@ -1131,7 +1169,10 @@ function createHostCard(hostname, data) {
         }
         cpuDisplay += ')';
     }
-    
+
+    // Issue #136: Format GPU usage display (mirrors the CPU card).
+    const gpuDisplay = formatGpuDisplay(data);
+
     // Machine type is now displayed in the header
     
     // Format memory display
@@ -1217,6 +1258,12 @@ function createHostCard(hostname, data) {
                     </div>
                 </div>
                 <div class="row mt-2">
+                    <div class="col-6">
+                        <small class="text-muted">GPU Load</small>
+                        <div class="fw-bold">${escapeHtml(gpuDisplay)}</div>
+                        ${data.gpu_memory && data.gpu_memory !== 'N/A' ? `<small class="text-muted">${escapeHtml(data.gpu_memory)}</small>` : ''}
+                        ${data.gpu_breakdown && data.gpu_breakdown !== 'N/A' ? `<small class="text-muted">${escapeHtml(data.gpu_breakdown)}</small>` : ''}
+                    </div>
                     <div class="col-6">
                         <small class="text-muted">Timezone</small>
                         <div class="fw-bold">${escapeHtml(data.timezone)}</div>

--- a/docs/evidence/issue-136-gpu-card.html
+++ b/docs/evidence/issue-136-gpu-card.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<!--
+  Issue #136 visual evidence: the new GPU Load card rendered next to CPU Load.
+  Playwright MCP / a headless browser were unavailable on the build host, so
+  this static page reproduces the exact dashboard markup (docs/dashboard.js
+  createHostCard) and styling (docs/styles.css) for reviewers to open directly.
+  The GPU strings shown are produced by formatGpuDisplay() — see
+  tests/test-gpu-display.sh.
+-->
+<html lang="en-AU">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Issue #136 — GPU card evidence</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../styles.css" rel="stylesheet">
+    <style>body { padding: 2rem; background: #f5f5f5; }</style>
+</head>
+<body>
+    <h4 class="mb-4">Issue #136 — GPU Load card (rendered next to CPU Load)</h4>
+    <div class="row g-3">
+        <!-- Apple Silicon host (real GRQ-25 values) -->
+        <div class="col-lg-6 col-xl-4">
+            <div class="host-card healthy" data-status="healthy">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="mb-0">🟢 GRQ-25 <span class="badge bg-secondary ms-2" style="font-size: 0.7rem;">Mac mini</span></h5>
+                    <span class="health-status healthy">Healthy</span>
+                </div>
+                <div class="row mt-2">
+                    <div class="col-6">
+                        <small class="text-muted">CPU Load</small>
+                        <div class="fw-bold">12% (16 cores, Apple M4 Pro)</div>
+                    </div>
+                    <div class="col-6">
+                        <small class="text-muted">Network</small>
+                        <div class="fw-bold">connected</div>
+                    </div>
+                </div>
+                <div class="row mt-2">
+                    <div class="col-6">
+                        <small class="text-muted">GPU Load</small>
+                        <div class="fw-bold">4% (16 cores, Apple M4 Pro)</div>
+                        <small class="text-muted">0.36 GB in use</small>
+                    </div>
+                    <div class="col-6">
+                        <small class="text-muted">Timezone</small>
+                        <div class="fw-bold">AEST</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- NVIDIA host -->
+        <div class="col-lg-6 col-xl-4">
+            <div class="host-card healthy" data-status="healthy">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="mb-0">🟢 gpu-linux <span class="badge bg-secondary ms-2" style="font-size: 0.7rem;">Linux</span></h5>
+                    <span class="health-status healthy">Healthy</span>
+                </div>
+                <div class="row mt-2">
+                    <div class="col-6">
+                        <small class="text-muted">CPU Load</small>
+                        <div class="fw-bold">34% (32 cores)</div>
+                    </div>
+                    <div class="col-6">
+                        <small class="text-muted">Network</small>
+                        <div class="fw-bold">connected</div>
+                    </div>
+                </div>
+                <div class="row mt-2">
+                    <div class="col-6">
+                        <small class="text-muted">GPU Load</small>
+                        <div class="fw-bold">30% (NVIDIA GeForce RTX 3080)</div>
+                        <small class="text-muted">2048 / 8192 MB</small>
+                        <small class="text-muted">65&deg;C</small>
+                    </div>
+                    <div class="col-6">
+                        <small class="text-muted">Timezone</small>
+                        <div class="fw-bold">UTC</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- Host with no GPU data (graceful N/A) -->
+        <div class="col-lg-6 col-xl-4">
+            <div class="host-card healthy" data-status="healthy">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="mb-0">🟢 oracle-3 <span class="badge bg-secondary ms-2" style="font-size: 0.7rem;">Linux</span></h5>
+                    <span class="health-status healthy">Healthy</span>
+                </div>
+                <div class="row mt-2">
+                    <div class="col-6">
+                        <small class="text-muted">CPU Load</small>
+                        <div class="fw-bold">8% (4 cores)</div>
+                    </div>
+                    <div class="col-6">
+                        <small class="text-muted">Network</small>
+                        <div class="fw-bold">connected</div>
+                    </div>
+                </div>
+                <div class="row mt-2">
+                    <div class="col-6">
+                        <small class="text-muted">GPU Load</small>
+                        <div class="fw-bold">N/A</div>
+                    </div>
+                    <div class="col-6">
+                        <small class="text-muted">Timezone</small>
+                        <div class="fw-bold">UTC</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.15" rel="stylesheet">
+    <link href="./styles.css?v=1.1.17" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -107,14 +107,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.15"></script>
+    <script src="./dashboard.js?v=1.1.17"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.15')
+                navigator.serviceWorker.register('./sw.js?v=1.1.17')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/index.json
+++ b/docs/index.json
@@ -1022,7 +1022,12 @@
       "elephant"
     ],
     "user_stale_hours": 24,
-    "reporting_warning_count": 0
+    "reporting_warning_count": 0,
+    "gpu_load": "4%",
+    "gpu_model": "Apple M4 Pro",
+    "gpu_cores": "16",
+    "gpu_memory": "0.36 GB in use",
+    "gpu_breakdown": "N/A"
   },
   "GRQ-26": {
     "uptime": 466701,

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.15
+// Version: 1.1.17
 
-const CACHE_NAME = 'grq-health-v1.1.15';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.15';
+const CACHE_NAME = 'grq-health-v1.1.17';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.17';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.15',
+  './dashboard.js?v=1.1.17',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ fi
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.16"
+VERSION="1.1.17"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.
@@ -119,6 +119,92 @@ if is_aws_instance; then
     echo "Skipping health monitoring - this is an AWS instance (spot/temporary)"
     exit 0
 fi
+
+# Issue #136: Collect GPU metrics cross-platform (non-privileged only).
+# Mirrors the CPU card: utilisation %, model, core count and memory in use.
+# No sudo/powermetrics is used. Any value that cannot be read degrades to
+# "N/A" so older chips, non-GPU hosts and non-NVIDIA hosts never error or
+# block the scan. Sets the gpu_* variables in the caller's scope.
+collect_gpu_info() {
+    gpu_load="N/A"
+    gpu_model="N/A"
+    gpu_cores="N/A"
+    gpu_memory="N/A"
+    gpu_breakdown="N/A"
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # Apple Silicon: live "Device Utilization %" and GPU memory in use via
+        # ioreg (non-privileged). Unified memory means there is no dedicated
+        # VRAM figure, so the in-use system memory is reported instead.
+        if command -v ioreg >/dev/null 2>&1; then
+            local ioaccel
+            ioaccel=$(ioreg -r -d 1 -c IOAccelerator 2>/dev/null || echo "")
+            if [[ -n "$ioaccel" ]]; then
+                local gpu_util_raw gpu_mem_raw gpu_mem_gb
+                # ioreg reports PerformanceStatistics as a single-line dict, e.g.
+                #   ..."Device Utilization %"=4,..."In use system memory"=542097408}
+                # so extract each key's value with a targeted grep -o rather than
+                # splitting on "=". `|| true` keeps a no-match grep from aborting
+                # the scan under `set -euo pipefail` (older chips lack these keys).
+                gpu_util_raw=$( { echo "$ioaccel" | grep -o '"Device Utilization %"=[0-9]\{1,\}' | head -1 | tr -dc '0-9'; } 2>/dev/null || true)
+                if [[ "$gpu_util_raw" =~ ^[0-9]+$ ]]; then
+                    gpu_load="${gpu_util_raw}%"
+                fi
+                # Match the exact key (the closing quote before "=" excludes the
+                # separate "In use system memory (driver)" entry).
+                gpu_mem_raw=$( { echo "$ioaccel" | grep -o '"In use system memory"=[0-9]\{1,\}' | head -1 | tr -dc '0-9'; } 2>/dev/null || true)
+                if [[ "$gpu_mem_raw" =~ ^[0-9]+$ ]] && [[ "$gpu_mem_raw" -gt 0 ]]; then
+                    gpu_mem_gb=$(echo "scale=2; $gpu_mem_raw / 1024 / 1024 / 1024" | bc -l 2>/dev/null || echo "0")
+                    # bc drops the leading zero for values < 1 (".50"); restore it.
+                    [[ "$gpu_mem_gb" == .* ]] && gpu_mem_gb="0$gpu_mem_gb"
+                    gpu_memory="${gpu_mem_gb} GB in use"
+                fi
+            fi
+        fi
+        # GPU model + core count via system_profiler (non-privileged).
+        if command -v system_profiler >/dev/null 2>&1; then
+            local gpu_sp gpu_model_raw gpu_cores_raw
+            gpu_sp=$(system_profiler SPDisplaysDataType 2>/dev/null || echo "")
+            if [[ -n "$gpu_sp" ]]; then
+                gpu_model_raw=$( { echo "$gpu_sp" | grep -i "Chipset Model:" | head -1 | sed 's/.*Chipset Model:[[:space:]]*//' | tr -d '\n'; } 2>/dev/null || true)
+                if [[ -n "$gpu_model_raw" ]]; then
+                    gpu_model="$gpu_model_raw"
+                fi
+                gpu_cores_raw=$( { echo "$gpu_sp" | grep -i "Total Number of Cores:" | head -1 | tr -dc '0-9'; } 2>/dev/null || true)
+                if [[ "$gpu_cores_raw" =~ ^[0-9]+$ ]]; then
+                    gpu_cores="$gpu_cores_raw"
+                fi
+            fi
+        fi
+    fi
+
+    # NVIDIA (Linux/Windows): a single nvidia-smi call covers utilisation,
+    # VRAM used/total, temperature and model. Overrides the defaults above when
+    # present; if nvidia-smi is absent the host simply keeps "N/A".
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        local gpu_smi gpu_util_n gpu_mem_used_n gpu_mem_total_n gpu_temp_n gpu_name_n
+        gpu_smi=$( { nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu,name --format=csv,noheader,nounits 2>/dev/null | head -1; } || true)
+        if [[ -n "$gpu_smi" ]]; then
+            gpu_util_n=$(echo "$gpu_smi" | awk -F',' '{gsub(/ /,"",$1); print $1}')
+            gpu_mem_used_n=$(echo "$gpu_smi" | awk -F',' '{gsub(/ /,"",$2); print $2}')
+            gpu_mem_total_n=$(echo "$gpu_smi" | awk -F',' '{gsub(/ /,"",$3); print $3}')
+            gpu_temp_n=$(echo "$gpu_smi" | awk -F',' '{gsub(/ /,"",$4); print $4}')
+            gpu_name_n=$(echo "$gpu_smi" | awk -F',' '{sub(/^[[:space:]]*/,"",$5); print $5}')
+            if [[ "$gpu_util_n" =~ ^[0-9]+$ ]]; then
+                gpu_load="${gpu_util_n}%"
+            fi
+            if [[ "$gpu_mem_used_n" =~ ^[0-9]+$ ]] && [[ "$gpu_mem_total_n" =~ ^[0-9]+$ ]]; then
+                gpu_memory="${gpu_mem_used_n} / ${gpu_mem_total_n} MB"
+            fi
+            if [[ "$gpu_temp_n" =~ ^[0-9]+$ ]]; then
+                gpu_breakdown="${gpu_temp_n}°C"
+            fi
+            if [[ -n "$gpu_name_n" ]]; then
+                gpu_model="$gpu_name_n"
+            fi
+        fi
+    fi
+}
 
 # Function to get system information
 get_system_info() {
@@ -575,7 +661,12 @@ get_system_info() {
     fi
     
     cpu_load="${cpu_load_percent}%"
-    
+
+    # Issue #136: Collect GPU metrics (sets gpu_load/gpu_model/gpu_cores/
+    # gpu_memory/gpu_breakdown). Always non-privileged; unreadable values
+    # degrade to "N/A" rather than blocking the scan.
+    collect_gpu_info
+
     # Get timezone
     timezone=$(date +%Z)
     
@@ -735,6 +826,11 @@ get_system_info() {
     cpu_speed_escaped=$(escape_json "$cpu_speed")
     machine_type_escaped=$(escape_json "$machine_type")
     cpu_breakdown_escaped=$(escape_json "$cpu_breakdown")
+    gpu_load_escaped=$(escape_json "$gpu_load")
+    gpu_model_escaped=$(escape_json "$gpu_model")
+    gpu_cores_escaped=$(escape_json "$gpu_cores")
+    gpu_memory_escaped=$(escape_json "$gpu_memory")
+    gpu_breakdown_escaped=$(escape_json "$gpu_breakdown")
     load_averages_escaped=$(escape_json "$load_averages")
     timezone_escaped=$(escape_json "$timezone")
     os_info_escaped=$(escape_json "$os_info")
@@ -751,7 +847,7 @@ get_system_info() {
         reporting_warning_count=0
     fi
 
-    echo "{\"uptime\": $uptime_sec, \"free_disk_space\": \"$free_disk_space_escaped\", \"used_disk_percent\": \"$used_disk_percent_escaped\", \"total_disk_gb\": \"$total_disk_gb_escaped\", \"mem_usage_percent\": \"$mem_usage_percent_escaped\", \"total_mem_gb\": \"$total_mem_gb_escaped\", \"cpu_load\": \"$cpu_load_escaped\", \"cpu_cores\": \"$cpu_cores_escaped\", \"cpu_model\": \"$cpu_speed_escaped\", \"machine_type\": \"$machine_type_escaped\", \"cpu_breakdown\": \"$cpu_breakdown_escaped\", \"load_averages\": \"$load_averages_escaped\", \"timezone\": \"$timezone_escaped\", \"os_info\": \"$os_info_escaped\", \"os_version\": \"$os_version_escaped\", \"network_status\": \"$network_status_escaped\", \"ip_addresses\": \"$ip_addresses_escaped\", \"exception_count\": $exception_count, \"exception_summary\": \"$exception_summary_escaped\", \"reporting_warning_count\": $reporting_warning_count, \"config_warning\": \"$config_warning_escaped\"}"
+    echo "{\"uptime\": $uptime_sec, \"free_disk_space\": \"$free_disk_space_escaped\", \"used_disk_percent\": \"$used_disk_percent_escaped\", \"total_disk_gb\": \"$total_disk_gb_escaped\", \"mem_usage_percent\": \"$mem_usage_percent_escaped\", \"total_mem_gb\": \"$total_mem_gb_escaped\", \"cpu_load\": \"$cpu_load_escaped\", \"cpu_cores\": \"$cpu_cores_escaped\", \"cpu_model\": \"$cpu_speed_escaped\", \"machine_type\": \"$machine_type_escaped\", \"cpu_breakdown\": \"$cpu_breakdown_escaped\", \"gpu_load\": \"$gpu_load_escaped\", \"gpu_model\": \"$gpu_model_escaped\", \"gpu_cores\": \"$gpu_cores_escaped\", \"gpu_memory\": \"$gpu_memory_escaped\", \"gpu_breakdown\": \"$gpu_breakdown_escaped\", \"load_averages\": \"$load_averages_escaped\", \"timezone\": \"$timezone_escaped\", \"os_info\": \"$os_info_escaped\", \"os_version\": \"$os_version_escaped\", \"network_status\": \"$network_status_escaped\", \"ip_addresses\": \"$ip_addresses_escaped\", \"exception_count\": $exception_count, \"exception_summary\": \"$exception_summary_escaped\", \"reporting_warning_count\": $reporting_warning_count, \"config_warning\": \"$config_warning_escaped\"}"
 }
 
 # Function to scan log file for errors and return count

--- a/tests/test-gpu-collection.sh
+++ b/tests/test-gpu-collection.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Test for Issue #136: cross-platform GPU metric collection in run.sh.
+# Extracts collect_gpu_info() and exercises it with stubbed vendor commands so
+# the test is hardware-independent and cross-platform.
+
+# The gpu_* variables are assigned by the eval'd collect_gpu_info function,
+# which shellcheck cannot see, so it treats them as unassigned.
+# shellcheck disable=SC2154
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_SH="$SCRIPT_DIR/../run.sh"
+
+echo "Testing Issue #136: GPU metric collection"
+echo "========================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail_test() { echo "  FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# Extract the collect_gpu_info function from run.sh
+eval "$(sed -n '/^collect_gpu_info()/,/^}/p' "$RUN_SH")"
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+REAL_PATH="$PATH"
+
+make_stub() {
+    # $1 = command name, $2 = body
+    local dir="$1" name="$2" body="$3"
+    mkdir -p "$dir"
+    printf '#!/bin/bash\n%s\n' "$body" > "$dir/$name"
+    chmod +x "$dir/$name"
+}
+
+# --- Test 1: NVIDIA host (Linux) ---
+echo "Test 1: NVIDIA host populates load, VRAM, temperature and model..."
+NV_BIN="$WORK_DIR/nvidia-bin"
+make_stub "$NV_BIN" "nvidia-smi" 'echo "30, 2048, 8192, 65, NVIDIA GeForce RTX 3080"'
+(
+    OSTYPE="linux-gnu"
+    PATH="$NV_BIN:$REAL_PATH"
+    collect_gpu_info
+    echo "$gpu_load|$gpu_memory|$gpu_breakdown|$gpu_model"
+) > "$WORK_DIR/out1"
+read -r OUT1 < "$WORK_DIR/out1"
+if [ "$OUT1" = "30%|2048 / 8192 MB|65°C|NVIDIA GeForce RTX 3080" ]; then
+    pass_test "NVIDIA fields parsed — $OUT1"
+else
+    fail_test "NVIDIA fields parsed — got $OUT1"
+fi
+
+# --- Test 2: No GPU host (Linux, no nvidia-smi) degrades to N/A ---
+echo "Test 2: Host without a GPU degrades every field to N/A..."
+EMPTY_BIN="$WORK_DIR/empty-bin"
+mkdir -p "$EMPTY_BIN"
+# Provide only the coreutils the function needs, not nvidia-smi.
+for tool in bash echo grep sed awk tr head bc command; do
+    src="$(command -v "$tool" 2>/dev/null || true)"
+    [ -n "$src" ] && ln -sf "$src" "$EMPTY_BIN/$tool" 2>/dev/null || true
+done
+(
+    OSTYPE="linux-gnu"
+    PATH="$EMPTY_BIN"
+    collect_gpu_info
+    echo "$gpu_load|$gpu_model|$gpu_cores|$gpu_memory|$gpu_breakdown"
+) > "$WORK_DIR/out2"
+read -r OUT2 < "$WORK_DIR/out2"
+if [ "$OUT2" = "N/A|N/A|N/A|N/A|N/A" ]; then
+    pass_test "no-GPU host all N/A — $OUT2"
+else
+    fail_test "no-GPU host all N/A — got $OUT2"
+fi
+
+# --- Test 3: Apple Silicon host via ioreg + system_profiler ---
+echo "Test 3: Apple Silicon populates load, memory, model and core count..."
+MAC_BIN="$WORK_DIR/mac-bin"
+# ioreg reports PerformanceStatistics as one line; include the (driver) decoy
+# and a trailing "In use system memory" to mirror the real format.
+make_stub "$MAC_BIN" "ioreg" 'echo "      \"PerformanceStatistics\" = {\"In use system memory (driver)\"=0,\"Device Utilization %\"=45,\"In use system memory\"=2684354560}"'
+make_stub "$MAC_BIN" "system_profiler" 'cat <<EOF
+    Chipset Model: Apple M2 Pro
+    Total Number of Cores: 19
+EOF'
+(
+    OSTYPE="darwin23"
+    PATH="$MAC_BIN:$REAL_PATH"
+    collect_gpu_info
+    echo "$gpu_load|$gpu_memory|$gpu_model|$gpu_cores"
+) > "$WORK_DIR/out3"
+read -r OUT3 < "$WORK_DIR/out3"
+if [ "$OUT3" = "45%|2.50 GB in use|Apple M2 Pro|19" ]; then
+    pass_test "Apple Silicon fields parsed — $OUT3"
+else
+    fail_test "Apple Silicon fields parsed — got $OUT3"
+fi
+
+# --- Test 4: Apple Silicon missing Device Utilization key falls back to N/A load ---
+echo "Test 4: Apple host missing utilisation key shows N/A load but keeps model..."
+MAC_BIN2="$WORK_DIR/mac-bin2"
+make_stub "$MAC_BIN2" "ioreg" 'echo "      \"PerformanceStatistics\" = {\"Alloc system memory\"=927285248}"'
+make_stub "$MAC_BIN2" "system_profiler" 'cat <<EOF
+    Chipset Model: Apple M1
+    Total Number of Cores: 8
+EOF'
+(
+    # Run under the same flags as run.sh — a no-match grep must NOT abort.
+    set -euo pipefail
+    OSTYPE="darwin23"
+    PATH="$MAC_BIN2:$REAL_PATH"
+    collect_gpu_info
+    echo "$gpu_load|$gpu_model|$gpu_cores"
+) > "$WORK_DIR/out4"
+read -r OUT4 < "$WORK_DIR/out4"
+if [ "$OUT4" = "N/A|Apple M1|8" ]; then
+    pass_test "graceful N/A load with known model — $OUT4"
+else
+    fail_test "graceful N/A load with known model — got $OUT4"
+fi
+
+echo ""
+echo "========================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test-gpu-display.sh
+++ b/tests/test-gpu-display.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Test for Issue #136: Record and display GPU usage per host (cross-platform)
+# Verifies the pure formatGpuDisplay() helper that powers the dashboard GPU card.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/extract-functions.sh"
+
+echo "Testing Issue #136: GPU usage display"
+echo "====================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+OUTPUT=$(run_js_test '
+// Test 1: function exists
+{
+    if (typeof formatGpuDisplay === "function") {
+        console.log("TEST_RESULT:function-exists:PASS:formatGpuDisplay defined");
+    } else {
+        console.log("TEST_RESULT:function-exists:FAIL:formatGpuDisplay not found");
+    }
+}
+
+// Test 2: Apple Silicon — load, cores and model combine like the CPU card
+{
+    const r = formatGpuDisplay({ gpu_load: "45%", gpu_cores: "10", gpu_model: "Apple M2 Pro" });
+    if (r === "45% (10 cores, Apple M2 Pro)") {
+        console.log("TEST_RESULT:apple-full:PASS:" + r);
+    } else {
+        console.log("TEST_RESULT:apple-full:FAIL:got " + r);
+    }
+}
+
+// Test 3: NVIDIA — no core count, model still appended
+{
+    const r = formatGpuDisplay({ gpu_load: "30%", gpu_cores: "N/A", gpu_model: "NVIDIA GeForce RTX 3080" });
+    if (r === "30% (NVIDIA GeForce RTX 3080)") {
+        console.log("TEST_RESULT:nvidia-no-cores:PASS:" + r);
+    } else {
+        console.log("TEST_RESULT:nvidia-no-cores:FAIL:got " + r);
+    }
+}
+
+// Test 4: Bare numeric load is normalised to a percentage
+{
+    const r = formatGpuDisplay({ gpu_load: "12", gpu_model: "Apple M1" });
+    if (r === "12% (Apple M1)") {
+        console.log("TEST_RESULT:bare-number:PASS:" + r);
+    } else {
+        console.log("TEST_RESULT:bare-number:FAIL:got " + r);
+    }
+}
+
+// Test 5: No GPU data at all degrades to N/A
+{
+    const r = formatGpuDisplay({});
+    if (r === "N/A") {
+        console.log("TEST_RESULT:no-data:PASS:" + r);
+    } else {
+        console.log("TEST_RESULT:no-data:FAIL:got " + r);
+    }
+}
+
+// Test 6: Live % unreadable but model known still surfaces the GPU
+{
+    const r = formatGpuDisplay({ gpu_load: "N/A", gpu_cores: "8", gpu_model: "Apple M1" });
+    if (r === "N/A (8 cores, Apple M1)") {
+        console.log("TEST_RESULT:na-load-known-model:PASS:" + r);
+    } else {
+        console.log("TEST_RESULT:na-load-known-model:FAIL:got " + r);
+    }
+}
+
+// Test 7: "unknown"/empty values are treated as absent
+{
+    const r = formatGpuDisplay({ gpu_load: "unknown", gpu_cores: "", gpu_model: "unknown" });
+    if (r === "N/A") {
+        console.log("TEST_RESULT:unknown-values:PASS:" + r);
+    } else {
+        console.log("TEST_RESULT:unknown-values:FAIL:got " + r);
+    }
+}
+
+// Test 8: Missing fields (undefined) are handled without throwing
+{
+    const r = formatGpuDisplay({ gpu_load: "55%" });
+    if (r === "55%") {
+        console.log("TEST_RESULT:partial-fields:PASS:" + r);
+    } else {
+        console.log("TEST_RESULT:partial-fields:FAIL:got " + r);
+    }
+}
+')
+
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*)
+            local_name="$(echo "$line" | cut -d: -f2)"
+            local_result="$(echo "$line" | cut -d: -f3)"
+            local_detail="$(echo "$line" | cut -d: -f4-)"
+            if [ "$local_result" = "PASS" ]; then
+                pass_test "$local_name — $local_detail"
+            else
+                fail_test "$local_name — $local_detail"
+            fi
+            ;;
+    esac
+done <<< "$OUTPUT"
+
+echo ""
+echo "====================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
# PR Summary — Issue #136: Record and display GPU usage per host (cross-platform)

## Summary

Adds per-host **GPU** metrics that mirror the existing CPU card. GPU data is
collected during the same `run.sh` scan, persisted into `docs/index.json`, and
shown as a **GPU Load** card next to **CPU Load** on the dashboard. Collection
is strictly **non-privileged** (no `sudo`, no `powermetrics`) and every value
degrades gracefully to `N/A` rather than erroring or blocking the scan.

Closes #136.

### What was added

- **Apple Silicon** — live `Device Utilization %` and GPU memory in use via
  `ioreg -r -d 1 -c IOAccelerator`; chipset model + core count via
  `system_profiler SPDisplaysDataType`.
- **NVIDIA (Linux/Windows)** — utilisation %, VRAM used/total, temperature and
  product name from a single `nvidia-smi` call.
- Other vendors (AMD, Intel integrated) and non-GPU hosts report `N/A`.

New `index.json` fields: `gpu_load`, `gpu_model`, `gpu_cores`, `gpu_memory`,
`gpu_breakdown`.

### Key files

- `run.sh` — new `collect_gpu_info()` sets the `gpu_*` variables; the JSON
  output and escaping were extended. Pipelines use `|| true` so a no-match
  `grep` cannot abort the scan under `set -euo pipefail` (older chips that lack
  the `ioreg` key still report `N/A`).
- `docs/dashboard.js` — pure `formatGpuDisplay()` (in the unit-tested region)
  plus a **GPU Load** card in `createHostCard`.
- `README.md` — documents the collection approach and the new fields.

> **Note on scope:** `docs/simple.html` is a summarised status page and does not
> render per-host CPU cards, so there is no CPU card to mirror there — the GPU
> card lives in the full dashboard (`docs/dashboard.js`) where the CPU card is.

## Flow

```mermaid
flowchart LR
    A[run.sh scan] --> B[collect_gpu_info]
    B -->|macOS| C[ioreg + system_profiler]
    B -->|NVIDIA| D[nvidia-smi]
    B -->|none| E[N/A defaults]
    C --> F[gpu_* fields]
    D --> F
    E --> F
    F --> G[docs/index.json]
    G --> H[dashboard.js formatGpuDisplay]
    H --> I[GPU Load card next to CPU Load]
```

## Evidence

A headless browser / Playwright MCP was **not available** on the build host, so
no PNG screenshot could be captured. Instead:

- A static, openable render of the card markup (using the real `styles.css`)
  is committed at `docs/evidence/issue-136-gpu-card.html`.
- The exact strings the card renders, produced by `formatGpuDisplay()`:

  ```
  [GRQ-25 (Apple M4 Pro, real)]  ->  GPU Load: 4% (16 cores, Apple M4 Pro)  |  0.36 GB in use
  [NVIDIA host]                  ->  GPU Load: 30% (NVIDIA GeForce RTX 3080)  |  2048 / 8192 MB  |  65°C
  [Host with no GPU data]        ->  GPU Load: N/A
  ```

- Live collection on the build host (GRQ-25, Apple M4 Pro) produced
  `4% | Apple M4 Pro | 16 | 0.36 GB in use | N/A`, and these real values were
  written into `docs/index.json` for GRQ-25.

## Test Plan

- `tests/test-gpu-display.sh` — unit tests for the pure `formatGpuDisplay()`
  helper: Apple full string, NVIDIA without core count, bare-number
  normalisation, all-N/A, N/A-load-with-known-model, `unknown`/empty handling,
  and partial fields.
- `tests/test-gpu-collection.sh` — extracts `collect_gpu_info()` and exercises
  it with **stubbed** `nvidia-smi`/`ioreg`/`system_profiler` so it is
  hardware-independent and cross-platform: NVIDIA host, no-GPU host (all
  `N/A`), Apple Silicon host, and the regression case where the `ioreg`
  utilisation key is absent (must not abort under `set -euo pipefail`).
- `./quality.sh` passes for all GPU-related tests, JSON validity and version
  consistency.

### Pre-existing failure (out of scope)

`./quality.sh` reports one failing test, `test-gitleaks-workflow`
(`Missing gitleaks-action step or GITHUB_TOKEN env`). This failure is
**pre-existing and unrelated** to this change — it reproduces on a clean tree
with the working changes stashed, and no `.github/` files were modified here.
