### PR TITLE
Fix repos.sh push retry loop silently dropping a host health update (#139)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-139.md
+++ b/docs/archive/pr-summaries/pr-summary-139.md
@@ -1,0 +1,76 @@
+# repos.sh: push retry loop no longer silently drops a host health update
+
+## Summary
+
+Fixed two defects in the `helpers/repos.sh` push retry loop that could lose a
+host's health update — surfacing as a stale/unhealthy tile on the dashboard.
+Closes #139.
+
+**Defect 1 — the final attempt had no fetch+rebase recovery.** Recovery was
+gated by `if [ "$attempt" -lt "$GIT_PUSH_MAX_ATTEMPTS" ]`, so the last attempt
+re-pushed a now-stale commit with no fresh base and failed
+(`status=failed reason=push-failed`). The loop is now **rebase-before-push**:
+every retry fetches and rebases onto the latest remote tip *before* pushing, so
+even the final attempt lands on a fresh base. The first attempt still pushes
+optimistically (the Step 1 `git pull` already freshened the base), keeping the
+common uncontended path a single push. The inter-attempt backoff is now
+**jittered** (`grq_apply_jitter`, 0–2s by default) to de-sync a fleet that all
+collided at the same instant.
+
+**Defect 2 — the rebase-conflict path silently reported success while
+discarding the update.** On a `docs/repos.json` rebase conflict the loop reset
+to remote, set `GIT_PUSH_SUCCESS=true` and broke — dropping the update with no
+signal. It now resets to the fresh remote tip and **re-applies this host's
+update** on top (via the idempotent `update_repos_json_*` helpers, keyed on the
+host name) and keeps retrying, so the update reaches the remote. If the update
+genuinely cannot be re-applied (e.g. a failure-mode log consumed from stdin is
+no longer on disk) it is surfaced as a distinct, non-fatal
+`status=update-dropped` instead of being masked as success.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via TDD: the new
+regression test fails against the unfixed code (defect 1 → `push-failed`,
+defect 2 → host entry missing from remote) and passes after the fix.
+
+```mermaid
+flowchart TD
+    A[push attempt] --> B{push ok?}
+    B -->|yes| Z[success]
+    B -->|no| C{first attempt?}
+    C -->|yes, retry| D[backoff + jitter]
+    C -->|no| E[fetch + rebase BEFORE next push]
+    E --> F{rebase ok?}
+    F -->|yes| D
+    F -->|conflict on repos.json| G[reset to remote tip]
+    G --> H[re-apply this host's update]
+    H --> I{re-applied?}
+    I -->|yes| D
+    I -->|remote already current| Z
+    I -->|cannot re-apply| J["status=update-dropped (non-fatal, observable)"]
+    D --> A
+```
+
+Before this change the final attempt skipped box **E**, and box **G** jumped
+straight to `success` — silently dropping the update.
+
+## Test Plan
+
+- Added `tests/test-repos-push-final-attempt.sh`:
+  - **Defect 1**: a `sleep` shim deterministically advances the remote during
+    the final backoff; asserts the host update still reaches the remote, the
+    concurrent commit is preserved, no unpushed backlog remains, and the run
+    does **not** report `push-failed`.
+  - **Defect 2**: a `docs/repos.json` rebase conflict; asserts the host entry
+    is re-applied and pushed to the remote (not dropped) and the remote's
+    competing entry is preserved.
+  - **Jitter**: `grq_apply_jitter` returns the base unchanged for base `0` or
+    ceiling `0`, and otherwise stays within `[base, base+ceiling]`.
+- Updated `tests/test-graceful-failure-recovery.sh` Test 5 to set
+  `GRQ_PUSH_JITTER_MAX=0` so the exact backoff-sequence assertion stays
+  deterministic (jitter is intentional new behaviour, covered by the new test).
+- Existing suites pass unchanged: `test-repos-push-rebase`, `test-push-retry`,
+  `test-push-rebase-quiet`, `test-repos-failure`, `test-stage-failure-health`,
+  `test-graceful-failure-recovery`.
+- `./quality.sh` passes except the pre-existing, unrelated
+  `test-gitleaks-workflow` failure (present on `HEAD` before this change).

--- a/helpers/git-retry.sh
+++ b/helpers/git-retry.sh
@@ -59,6 +59,25 @@ grq_max_push_attempts() {
     echo "${GRQ_PUSH_MAX_ATTEMPTS:-5}"
 }
 
+# Add a small random jitter (0..GRQ_PUSH_JITTER_MAX secs, default 2) to a
+# backoff delay so a fleet of workers that all collided on the same shared
+# branch at the same instant do not retry in lock-step (Issue #139). A base
+# delay of 0 (used by tests via GIT_PUSH_RETRY_DELAY_OVERRIDE) is returned
+# unchanged so retries stay instant; set GRQ_PUSH_JITTER_MAX=0 to disable
+# jitter entirely.
+# Usage: grq_apply_jitter <base_seconds>  -> echoes base (+ jitter)
+grq_apply_jitter() {
+    local base="${1:-0}"
+    local max="${GRQ_PUSH_JITTER_MAX:-2}"
+    # Guard against non-numeric input and the disable/zero cases.
+    if ! [[ "$base" =~ ^[0-9]+$ ]] || [ "$base" -le 0 ] || \
+       ! [[ "$max" =~ ^[0-9]+$ ]] || [ "$max" -le 0 ]; then
+        echo "$base"
+        return 0
+    fi
+    echo $(( base + (RANDOM % (max + 1)) ))
+}
+
 # Run a git command wrapped with the timeout helper (when available).
 # Usage: grq_run_git <git args...>
 # Caller is responsible for stdout/stderr redirection.

--- a/helpers/repos.sh
+++ b/helpers/repos.sh
@@ -46,7 +46,11 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # pushed / skipped / failed outcomes without parsing localised messages.
 # Format:
 #   repos.sh status=<status> reason=<reason> name='<repo_name>'
-# Statuses: skipped | updated | added | failed-recorded | failed | unknown
+# Statuses: skipped | updated | added | failed-recorded | failed |
+#           update-dropped | unknown
+# update-dropped (Issue #139): non-fatal — the health update could not be
+# re-applied after a persistent rebase conflict on the shared docs/repos.json,
+# so it was dropped. Surfaced distinctly instead of masked as success.
 RUN_STATUS="unknown"
 RUN_REASON="unknown"
 REPO_NAME=""
@@ -522,21 +526,75 @@ for f in "${FILES_TO_ADD[@]}"; do
     fi
 done
 
+# Re-apply this host's health update onto the current working tree and commit
+# it (Issue #139 defect 2). Used by the push loop after a rebase conflict on
+# the shared docs/repos.json forces a hard reset to the remote tip: rather
+# than discarding this host's update (and silently reporting success), we
+# regenerate the entry on top of the fresh base and re-commit it so it can be
+# pushed. The update_repos_json_* helpers are idempotent and keyed on the host
+# name, so re-running them on the fresh base cannot itself conflict.
+# Returns:
+#   0 — re-applied and committed a fresh local commit ready to push
+#   2 — nothing to commit (remote already carries this host's update)
+#   1 — could not re-apply (e.g. failure-mode log no longer on disk)
+reapply_health_update() {
+    if [ "$FAILED_MODE" = true ]; then
+        # The failure log written earlier was removed by the hard reset. Only
+        # re-create it when the source log is still a readable file; a consumed
+        # stdin log ("-") cannot be reproduced, so surface a dropped update.
+        if [ "$LOG_PATH" != "-" ] && [ -f "$LOG_PATH" ]; then
+            LOG_RELATIVE_PATH=$(store_failure_log)
+            FILES_TO_ADD=("${REPOS_JSON}")
+            local reapply_slug reapply_log_dir
+            reapply_slug=$(sanitise_task_slug "$REPO_NAME")
+            reapply_log_dir="${PROJECT_ROOT}/docs/logs/${reapply_slug}"
+            if [ -d "$reapply_log_dir" ]; then
+                FILES_TO_ADD+=("$reapply_log_dir")
+            fi
+            update_repos_json_failure "$LOG_RELATIVE_PATH"
+        else
+            return 1
+        fi
+    else
+        update_repos_json_success
+    fi
+
+    local reapply_staged=false reapply_file
+    for reapply_file in "${FILES_TO_ADD[@]}"; do
+        if git add "$reapply_file" 2>/dev/null; then
+            reapply_staged=true
+        fi
+    done
+
+    if [ "$reapply_staged" = true ] && ! git diff --cached --quiet 2>/dev/null; then
+        if git commit -m "$COMMIT_MSG" --quiet 2>/dev/null; then
+            return 0
+        fi
+        return 1
+    fi
+    return 2
+}
+
 # Step 3: Commit and push
-# Issue #117 + #1862: Push retries use exponential backoff (default 1s, 4s,
-# 16s) and wrap each git call in a 120s timeout to handle slow networks.
-# A non-fast-forward failure is recovered by fetch + rebase --autostash so
-# the next push can fast-forward. If the rebase conflicts on repos.json we
-# abort and reset to the remote — repos.json is a regenerated artefact, so
-# discarding the stale local commit is safe. A GitHub rate-limit response
-# (HTTP 429 / abuse detection / "rate limit" in stderr) triggers a sleep
-# until the reset window (probed via `gh api rate_limit` when available)
-# before the next attempt. When all retries are exhausted we reset the
-# local clone to origin/<branch> + clean -fd so the next service update
-# does not commit on top of a stale unpushed commit (which would falsely
-# mark the previous service as alive), surface the actual stderr, and exit
-# non-zero so the failure itself is observable.
+# Issue #117 + #1862 + #139: Push retries use exponential backoff (default
+# 1s, 4s, 16s, 30s, 60s, jittered) and wrap each git call in a 120s timeout to
+# handle slow networks. We push optimistically on the first attempt (the base
+# was just freshened by the Step 1 pull); every subsequent retry fetches and
+# rebases BEFORE pushing so even the final attempt lands on the latest remote
+# tip instead of re-sending a now-stale commit (#139 defect 1). If a rebase
+# conflicts on repos.json we reset to the remote and re-apply this host's
+# update on top, then keep retrying — the update is preserved rather than
+# silently dropped (#139 defect 2). A GitHub rate-limit response (HTTP 429 /
+# abuse detection / "rate limit" in stderr) triggers a sleep until the reset
+# window (probed via `gh api rate_limit` when available) before the next
+# attempt. When all retries are exhausted we reset the local clone to
+# origin/<branch> + clean -fd so the next service update does not commit on top
+# of a stale unpushed commit (which would falsely mark the previous service as
+# alive), surface the actual stderr, and exit non-zero so the failure itself is
+# observable. If an update genuinely cannot be re-applied it is surfaced as a
+# non-fatal status=update-dropped rather than masked as success.
 PUSH_FINAL_STATUS=0
+UPDATE_DROPPED=false
 if [ "$STAGED_SOMETHING" = true ]; then
     if ! git diff --cached --quiet 2>/dev/null; then
         # Commit the changes
@@ -559,15 +617,70 @@ if [ "$STAGED_SOMETHING" = true ]; then
             CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
             for attempt in $(seq 1 "$GIT_PUSH_MAX_ATTEMPTS"); do
+                # Issue #139 defect 1: rebase BEFORE pushing on every retry
+                # (rebase-before-push, not push-then-rebase) so even the final
+                # attempt lands on the freshest remote tip. The first attempt
+                # pushes optimistically — the Step 1 pull already freshened the
+                # base, so the common uncontended path stays a single push.
+                # Skip when not on a named branch (nothing to rebase onto in a
+                # detached HEAD).
+                if [ "$attempt" -gt 1 ] && [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
+                    if grq_run_git fetch --quiet origin "$CURRENT_BRANCH" 2>/dev/null; then
+                        if grq_run_git rebase --autostash "origin/${CURRENT_BRANCH}" 2>/dev/null; then
+                            echo "Info: rebased onto origin/${CURRENT_BRANCH} before push (attempt ${attempt}/${GIT_PUSH_MAX_ATTEMPTS})"
+                        else
+                            # Rebase conflict — almost always on the shared
+                            # repos.json. Issue #139 defect 2: instead of
+                            # discarding this host's update and (silently)
+                            # reporting success, reset to the fresh remote tip
+                            # and RE-APPLY the update on top, then keep retrying
+                            # the push so the update is preserved.
+                            echo "Warning: rebase onto origin/${CURRENT_BRANCH} conflicted; resetting to remote and re-applying this host's update"
+                            git rebase --abort 2>/dev/null || true
+                            rm -rf .git/rebase-merge .git/rebase-apply 2>/dev/null || true
+                            git reset --hard "origin/${CURRENT_BRANCH}" 2>/dev/null || true
+
+                            reapply_health_update
+                            REAPPLY_RC=$?
+                            if [ "$REAPPLY_RC" -eq 0 ]; then
+                                echo "Info: re-applied this host's update onto origin/${CURRENT_BRANCH} after conflict"
+                            elif [ "$REAPPLY_RC" -eq 2 ]; then
+                                # Remote already carries this host's update —
+                                # nothing left to push. Treat as success.
+                                echo "Info: origin/${CURRENT_BRANCH} already carries this host's update; nothing to push"
+                                GIT_PUSH_SUCCESS=true
+                                break
+                            else
+                                # Could not re-apply (e.g. failure-mode log no
+                                # longer on disk). Surface a distinct non-fatal
+                                # status so the dropped update is observable
+                                # instead of masked as success.
+                                echo "Warning: could not re-apply this host's update after conflict; update dropped"
+                                UPDATE_DROPPED=true
+                                break
+                            fi
+                        fi
+                    else
+                        echo "Warning: git fetch origin ${CURRENT_BRANCH} failed; pushing without a fresh base (attempt ${attempt}/${GIT_PUSH_MAX_ATTEMPTS})"
+                    fi
+                fi
+
                 : > "$PUSH_STDERR_FILE"
                 if grq_run_git push --quiet 2>"$PUSH_STDERR_FILE"; then
                     GIT_PUSH_SUCCESS=true
                     break
                 fi
                 LAST_PUSH_STDERR=$(cat "$PUSH_STDERR_FILE" 2>/dev/null || echo "")
+                echo "Warning: git push failed (attempt ${attempt}/${GIT_PUSH_MAX_ATTEMPTS}): ${LAST_PUSH_STDERR}"
 
-                # Decide the inter-attempt sleep up-front so rate-limit
-                # responses can override the standard backoff.
+                # No further attempts remain — stop. The freshest rebase+push
+                # already happened on this final attempt (defect 1 fix).
+                if [ "$attempt" -ge "$GIT_PUSH_MAX_ATTEMPTS" ]; then
+                    break
+                fi
+
+                # Decide the inter-attempt sleep. A rate-limit response
+                # overrides the standard (jittered) backoff.
                 IDX=$((attempt - 1))
                 # bash 3.2 (macOS default) errors on ${arr[-1]} with `set -u`,
                 # so compute the last index explicitly. The fallback covers
@@ -578,50 +691,19 @@ if [ "$STAGED_SOMETHING" = true ]; then
                 if [ -n "$LEGACY_DELAY" ]; then
                     BACKOFF_SECS="$LEGACY_DELAY"
                 fi
-                SLEEP_SECS="$BACKOFF_SECS"
+                # Issue #139: jitter the backoff so a fleet that collided at the
+                # same instant does not retry in lock-step.
+                SLEEP_SECS=$(grq_apply_jitter "$BACKOFF_SECS")
 
                 if echo "$LAST_PUSH_STDERR" | grq_is_rate_limit_error; then
                     SLEEP_SECS=$(grq_rate_limit_sleep_secs "$BACKOFF_SECS")
                     echo "Warning: GitHub rate limit detected (attempt ${attempt}/${GIT_PUSH_MAX_ATTEMPTS}); sleeping ${SLEEP_SECS}s before retry"
                 fi
 
-                if [ "$attempt" -lt "$GIT_PUSH_MAX_ATTEMPTS" ]; then
-                    echo "Warning: git push failed (attempt ${attempt}/${GIT_PUSH_MAX_ATTEMPTS}): ${LAST_PUSH_STDERR}"
-
-                    # Try to recover from non-fast-forward via fetch + rebase
-                    # before the next attempt. Skip if we are not on a named
-                    # branch — there is nothing to rebase onto in detached HEAD.
-                    if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
-                        if grq_run_git fetch --quiet origin "$CURRENT_BRANCH" 2>/dev/null; then
-                            if grq_run_git rebase --autostash "origin/${CURRENT_BRANCH}" 2>/dev/null; then
-                                echo "Info: rebased onto origin/${CURRENT_BRANCH}, retrying push"
-                            else
-                                # Rebase failed — almost always a conflict on
-                                # repos.json. The repo is a regenerated
-                                # artefact, so the safe move is to abort and
-                                # reset to remote, discarding our stale local
-                                # commit. The next scheduled run will record
-                                # the latest timestamp again.
-                                echo "Warning: rebase onto origin/${CURRENT_BRANCH} failed; discarding stale local commit and resetting to remote"
-                                git rebase --abort 2>/dev/null || true
-                                rm -rf .git/rebase-merge .git/rebase-apply 2>/dev/null || true
-                                git reset --hard "origin/${CURRENT_BRANCH}" 2>/dev/null || true
-                                # Nothing left to push — exit the retry loop
-                                # cleanly. A subsequent run will re-record the
-                                # timestamp.
-                                GIT_PUSH_SUCCESS=true
-                                break
-                            fi
-                        else
-                            echo "Warning: git fetch origin ${CURRENT_BRANCH} failed; cannot rebase before retry"
-                        fi
-                    fi
-
-                    sleep "$SLEEP_SECS"
-                fi
+                sleep "$SLEEP_SECS"
             done
 
-            if [ "$GIT_PUSH_SUCCESS" = false ]; then
+            if [ "$GIT_PUSH_SUCCESS" = false ] && [ "$UPDATE_DROPPED" = false ]; then
                 echo "ERROR: git push failed after ${GIT_PUSH_MAX_ATTEMPTS} attempts"
                 if [ -n "$LAST_PUSH_STDERR" ]; then
                     echo "Last git push stderr:"
@@ -639,6 +721,18 @@ if [ "$STAGED_SOMETHING" = true ]; then
                     echo "Warning: failed to reset local clone to origin/${CURRENT_BRANCH}"
                 fi
                 PUSH_FINAL_STATUS=1
+            elif [ "$UPDATE_DROPPED" = true ]; then
+                # Issue #139 defect 2: the update could not be re-applied after
+                # a persistent rebase conflict. This is non-fatal (core work
+                # continues) but must be observable, not masked as success.
+                # Reset to remote so the next run starts clean; the distinct
+                # status=update-dropped is emitted at exit.
+                echo "Warning: this host's health update was dropped after a rebase conflict on docs/repos.json"
+                if grq_recover_to_remote 2>/dev/null; then
+                    echo "Info: reset local clone to origin/${CURRENT_BRANCH} and cleaned working tree"
+                else
+                    echo "Warning: failed to reset local clone to origin/${CURRENT_BRANCH}"
+                fi
             fi
 
             rm -f "$PUSH_STDERR_FILE" 2>/dev/null || true
@@ -657,4 +751,11 @@ if [ "$PUSH_FINAL_STATUS" -ne 0 ]; then
     RUN_STATUS="failed"
     RUN_REASON="push-failed"
     exit "$PUSH_FINAL_STATUS"
+fi
+
+# Issue #139 defect 2: a dropped update is non-fatal (exit 0) but must be
+# observable rather than masquerading as a normal update.
+if [ "${UPDATE_DROPPED:-false}" = true ]; then
+    RUN_STATUS="update-dropped"
+    RUN_REASON="update-dropped"
 fi

--- a/tests/test-graceful-failure-recovery.sh
+++ b/tests/test-graceful-failure-recovery.sh
@@ -325,8 +325,13 @@ SLEEPEOF
 chmod +x "${MOCK_BIN5}/sleep"
 
 set +e
+# Issue #139: repos.sh now jitters the backoff (adds 0..GRQ_PUSH_JITTER_MAX
+# seconds) to de-sync the fleet. Disable jitter here so this test can assert
+# the exact configured base sequence deterministically; the jitter behaviour
+# itself is covered by tests/test-repos-push-final-attempt.sh.
 PATH="${MOCK_BIN5}:${PATH}" \
     GRQ_PUSH_RETRY_DELAYS_OVERRIDE="2 5 11" \
+    GRQ_PUSH_JITTER_MAX=0 \
     "$WORK/helpers/repos.sh" "BackoffSvc" --skip-rate-limit --project-root "$WORK" \
     >"${T5_BASE}/out.log" 2>&1
 set -e

--- a/tests/test-repos-push-final-attempt.sh
+++ b/tests/test-repos-push-final-attempt.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# Test for Issue #139: helpers/repos.sh push retry loop can silently drop a
+# host health update.
+#
+# Two defects are covered:
+#   1. The final push attempt got no fetch+rebase recovery, so if the remote
+#      moved during the last backoff the final attempt re-pushed a stale
+#      commit and failed (status=push-failed). The fix rebases BEFORE pushing
+#      on every retry, so the final attempt also pushes onto a fresh base.
+#   2. A rebase conflict on docs/repos.json reset to remote, set
+#      GIT_PUSH_SUCCESS=true and broke — silently dropping this host's update
+#      while reporting success. The fix re-applies this host's update onto the
+#      fresh base and pushes it (the update reaches the remote), rather than
+#      discarding it unseen.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOS_SCRIPT="$SCRIPT_DIR/../helpers/repos.sh"
+GIT_RETRY_LIB="$SCRIPT_DIR/../helpers/git-retry.sh"
+
+echo "Testing Issue #139: final-attempt recovery + no silent update drop"
+echo "================================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+export GIT_AUTHOR_NAME="Test"
+export GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="Test"
+export GIT_COMMITTER_EMAIL="test@example.com"
+
+# --------------------------------------------------------------------------
+# Test 1 (defect 1): the remote moves during the final backoff; the last
+# attempt must still recover via fetch+rebase and push successfully.
+#
+# A `sleep` shim placed first on PATH deterministically advances the shared
+# remote by one commit the first time repos.sh sleeps between retries — this
+# emulates a concurrent fleet writer landing a commit while we back off.
+# --------------------------------------------------------------------------
+echo "Test 1: remote moves during final backoff — last attempt recovers..."
+T1="${TMPDIR_BASE}/test1"
+mkdir -p "$T1"
+REMOTE1="${T1}/remote.git"
+UPSTREAM1="${T1}/upstream"
+WORK1="${T1}/work"
+
+git init --bare --initial-branch=main "$REMOTE1" >/dev/null 2>&1
+git clone --quiet "$REMOTE1" "$UPSTREAM1" >/dev/null 2>&1
+mkdir -p "$UPSTREAM1/docs" "$UPSTREAM1/helpers"
+echo '{"repos": []}' > "$UPSTREAM1/docs/repos.json"
+cp "$REPOS_SCRIPT" "$UPSTREAM1/helpers/repos.sh"
+cp "$GIT_RETRY_LIB" "$UPSTREAM1/helpers/git-retry.sh"
+chmod +x "$UPSTREAM1/helpers/repos.sh" "$UPSTREAM1/helpers/git-retry.sh"
+(
+    cd "$UPSTREAM1"
+    git add docs helpers >/dev/null 2>&1
+    git commit -m "initial" --quiet >/dev/null 2>&1
+    git push --quiet origin HEAD:main >/dev/null 2>&1
+)
+
+git clone --quiet "$REMOTE1" "$WORK1" >/dev/null 2>&1
+(
+    cd "$WORK1"
+    git checkout -q main
+    git config pull.ff only
+    echo "local-only" > docs/local_only.txt
+    git add docs/local_only.txt >/dev/null 2>&1
+    git commit -m "local-only commit" --quiet >/dev/null 2>&1
+)
+
+# Diverge #1: a remote-only commit exists before repos.sh runs (non-FF push).
+(
+    cd "$UPSTREAM1"
+    git pull --quiet >/dev/null 2>&1 || true
+    echo "remote-change" > docs/remote_only.txt
+    git add docs/remote_only.txt >/dev/null 2>&1
+    git commit -m "remote-only commit" --quiet >/dev/null 2>&1
+    git push --quiet origin HEAD:main >/dev/null 2>&1
+)
+
+# Build the sleep shim: on its first invocation, land diverge #2 on the
+# remote, then behave as an instant no-op sleep.
+SHIM_DIR="${T1}/shim"
+mkdir -p "$SHIM_DIR"
+cat > "${SHIM_DIR}/sleep" <<SHIM
+#!/bin/bash
+# Issue #139 test injector — advances the remote once, then no-op sleep.
+if [ ! -f "\$SLEEP_SHIM_MARKER" ]; then
+    touch "\$SLEEP_SHIM_MARKER"
+    (
+        cd "\$SLEEP_SHIM_UPSTREAM" || exit 0
+        git pull --quiet >/dev/null 2>&1 || true
+        echo "second-remote-change" > docs/remote_only2.txt
+        git add docs/remote_only2.txt >/dev/null 2>&1
+        git commit -m "second remote-only commit" --quiet >/dev/null 2>&1
+        git push --quiet origin HEAD:main >/dev/null 2>&1
+    )
+fi
+exit 0
+SHIM
+chmod +x "${SHIM_DIR}/sleep"
+
+OUTPUT1=$(cd "$WORK1" && \
+    PATH="${SHIM_DIR}:$PATH" \
+    SLEEP_SHIM_MARKER="${T1}/shim.marker" \
+    SLEEP_SHIM_UPSTREAM="$UPSTREAM1" \
+    GRQ_PUSH_MAX_ATTEMPTS=2 \
+    GIT_PUSH_RETRY_DELAY_OVERRIDE=0 \
+    ./helpers/repos.sh "FinalAttemptRepo" --skip-rate-limit --project-root "$WORK1" 2>&1 || true)
+
+(cd "$WORK1" && git fetch --quiet 2>/dev/null || true)
+
+# The host's health update must have reached the remote despite the remote
+# moving during the final backoff. On the unfixed code the final attempt
+# re-pushes a stale commit and fails, so the entry never lands.
+REMOTE1_JSON=$(cd "$REMOTE1" && git show "main:docs/repos.json" 2>/dev/null || echo "")
+if echo "$REMOTE1_JSON" | grep -q '"FinalAttemptRepo"'; then
+    pass_test "Host update reached remote after remote moved during final backoff"
+else
+    fail_test "FinalAttemptRepo missing on remote. json='$REMOTE1_JSON' output: $OUTPUT1"
+fi
+
+# The concurrent commit that landed during the backoff must be preserved
+# (proves the final attempt rebased onto the fresh tip rather than clobbering).
+REMOTE1_HAS_D2=$(cd "$REMOTE1" && git show "main:docs/remote_only2.txt" 2>/dev/null || echo "")
+if [ "$REMOTE1_HAS_D2" = "second-remote-change" ]; then
+    pass_test "Concurrent commit landed during backoff was preserved"
+else
+    fail_test "Concurrent backoff commit lost. Got: '$REMOTE1_HAS_D2'. Output: $OUTPUT1"
+fi
+
+# No unpushed backlog should remain.
+UNPUSHED1=$(cd "$WORK1" && git rev-list --count "origin/main..HEAD" 2>/dev/null || echo "?")
+if [ "$UNPUSHED1" = "0" ]; then
+    pass_test "No unpushed commits remain after final-attempt recovery"
+else
+    fail_test "Expected 0 unpushed commits, got: $UNPUSHED1. Output: $OUTPUT1"
+fi
+
+# The status line must not be push-failed.
+if echo "$OUTPUT1" | grep -q "reason=push-failed"; then
+    fail_test "Run reported push-failed despite recoverable divergence. Output: $OUTPUT1"
+else
+    pass_test "Run did not report push-failed"
+fi
+
+# --------------------------------------------------------------------------
+# Test 2 (defect 2): a rebase conflict on docs/repos.json must NOT silently
+# drop this host's update. The update must be re-applied onto the fresh base
+# and pushed so it reaches the remote.
+# --------------------------------------------------------------------------
+echo ""
+echo "Test 2: rebase conflict on repos.json re-applies the update, not drops it..."
+T2="${TMPDIR_BASE}/test2"
+mkdir -p "$T2"
+REMOTE2="${T2}/remote.git"
+UPSTREAM2="${T2}/upstream"
+WORK2="${T2}/work"
+
+git init --bare --initial-branch=main "$REMOTE2" >/dev/null 2>&1
+git clone --quiet "$REMOTE2" "$UPSTREAM2" >/dev/null 2>&1
+mkdir -p "$UPSTREAM2/docs" "$UPSTREAM2/helpers"
+echo '{"repos": []}' > "$UPSTREAM2/docs/repos.json"
+cp "$REPOS_SCRIPT" "$UPSTREAM2/helpers/repos.sh"
+cp "$GIT_RETRY_LIB" "$UPSTREAM2/helpers/git-retry.sh"
+chmod +x "$UPSTREAM2/helpers/repos.sh" "$UPSTREAM2/helpers/git-retry.sh"
+(
+    cd "$UPSTREAM2"
+    git add docs helpers >/dev/null 2>&1
+    git commit -m "initial" --quiet >/dev/null 2>&1
+    git push --quiet origin HEAD:main >/dev/null 2>&1
+)
+
+git clone --quiet "$REMOTE2" "$WORK2" >/dev/null 2>&1
+(
+    cd "$WORK2"
+    git checkout -q main
+    git config pull.ff only
+    # Local-only commit that ALSO modifies repos.json — conflicts with the
+    # remote change below on rebase.
+    echo '{"repos": [{"name": "Stale", "last_commit_ts": 1}]}' > docs/repos.json
+    git add docs/repos.json >/dev/null 2>&1
+    git commit -m "stale local repos.json change" --quiet >/dev/null 2>&1
+)
+
+# Diverge the remote with a competing repos.json change.
+(
+    cd "$UPSTREAM2"
+    git pull --quiet >/dev/null 2>&1 || true
+    echo '{"repos": [{"name": "Other", "last_commit_ts": 2}]}' > docs/repos.json
+    git add docs/repos.json >/dev/null 2>&1
+    git commit -m "remote competing repos.json change" --quiet >/dev/null 2>&1
+    git push --quiet origin HEAD:main >/dev/null 2>&1
+)
+
+OUTPUT2=$(cd "$WORK2" && GIT_PUSH_RETRY_DELAY_OVERRIDE=0 \
+    ./helpers/repos.sh "ReappliedHost" --skip-rate-limit --project-root "$WORK2" 2>&1 || true)
+
+(cd "$WORK2" && git fetch --quiet 2>/dev/null || true)
+
+# The host's update must reach the remote — it must NOT be silently dropped.
+REMOTE2_JSON=$(cd "$REMOTE2" && git show "main:docs/repos.json" 2>/dev/null || echo "")
+if echo "$REMOTE2_JSON" | grep -q '"ReappliedHost"'; then
+    pass_test "Host update re-applied and pushed after rebase conflict (not dropped)"
+else
+    fail_test "ReappliedHost missing on remote — update was dropped. json='$REMOTE2_JSON' output: $OUTPUT2"
+fi
+
+# The remote's competing commit must be preserved (we reset onto it, not over it).
+REMOTE2_HAS_OTHER=$(echo "$REMOTE2_JSON" | grep -c '"Other"' || true)
+if [ "$REMOTE2_HAS_OTHER" -ge 1 ]; then
+    pass_test "Remote competing repos.json entry preserved through recovery"
+else
+    fail_test "Remote 'Other' entry lost. json='$REMOTE2_JSON'"
+fi
+
+# No unpushed backlog should remain.
+UNPUSHED2=$(cd "$WORK2" && git rev-list --count "origin/main..HEAD" 2>/dev/null || echo "?")
+if [ "$UNPUSHED2" = "0" ]; then
+    pass_test "No unpushed backlog remains after conflict recovery"
+else
+    fail_test "Expected 0 unpushed commits, got: $UNPUSHED2. Output: $OUTPUT2"
+fi
+
+# --------------------------------------------------------------------------
+# Test 3: grq_apply_jitter never shrinks below the base and returns the base
+# unchanged when jitter is disabled (base 0 or ceiling 0) — keeps tests fast
+# and de-syncs the fleet otherwise.
+# --------------------------------------------------------------------------
+echo ""
+echo "Test 3: grq_apply_jitter bounds..."
+# shellcheck disable=SC1090
+. "$GIT_RETRY_LIB"
+
+J0=$(grq_apply_jitter 0)
+if [ "$J0" = "0" ]; then
+    pass_test "grq_apply_jitter 0 returns 0 (instant retries preserved)"
+else
+    fail_test "grq_apply_jitter 0 returned '$J0'"
+fi
+
+J_DISABLED=$(GRQ_PUSH_JITTER_MAX=0 grq_apply_jitter 4)
+if [ "$J_DISABLED" = "4" ]; then
+    pass_test "grq_apply_jitter with ceiling 0 returns base unchanged"
+else
+    fail_test "grq_apply_jitter (ceiling 0) returned '$J_DISABLED'"
+fi
+
+JITTER_OK=true
+for _ in 1 2 3 4 5 6 7 8; do
+    JV=$(GRQ_PUSH_JITTER_MAX=3 grq_apply_jitter 4)
+    if [ "$JV" -lt 4 ] || [ "$JV" -gt 7 ]; then
+        JITTER_OK=false
+        break
+    fi
+done
+if [ "$JITTER_OK" = true ]; then
+    pass_test "grq_apply_jitter stays within [base, base+ceiling]"
+else
+    fail_test "grq_apply_jitter produced out-of-range value '$JV'"
+fi
+
+# --------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
# repos.sh: push retry loop no longer silently drops a host health update

## Summary

Fixed two defects in the `helpers/repos.sh` push retry loop that could lose a
host's health update — surfacing as a stale/unhealthy tile on the dashboard.
Closes #139.

**Defect 1 — the final attempt had no fetch+rebase recovery.** Recovery was
gated by `if [ "$attempt" -lt "$GIT_PUSH_MAX_ATTEMPTS" ]`, so the last attempt
re-pushed a now-stale commit with no fresh base and failed
(`status=failed reason=push-failed`). The loop is now **rebase-before-push**:
every retry fetches and rebases onto the latest remote tip *before* pushing, so
even the final attempt lands on a fresh base. The first attempt still pushes
optimistically (the Step 1 `git pull` already freshened the base), keeping the
common uncontended path a single push. The inter-attempt backoff is now
**jittered** (`grq_apply_jitter`, 0–2s by default) to de-sync a fleet that all
collided at the same instant.

**Defect 2 — the rebase-conflict path silently reported success while
discarding the update.** On a `docs/repos.json` rebase conflict the loop reset
to remote, set `GIT_PUSH_SUCCESS=true` and broke — dropping the update with no
signal. It now resets to the fresh remote tip and **re-applies this host's
update** on top (via the idempotent `update_repos_json_*` helpers, keyed on the
host name) and keeps retrying, so the update reaches the remote. If the update
genuinely cannot be re-applied (e.g. a failure-mode log consumed from stdin is
no longer on disk) it is surfaced as a distinct, non-fatal
`status=update-dropped` instead of being masked as success.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via TDD: the new
regression test fails against the unfixed code (defect 1 → `push-failed`,
defect 2 → host entry missing from remote) and passes after the fix.

```mermaid
flowchart TD
    A[push attempt] --> B{push ok?}
    B -->|yes| Z[success]
    B -->|no| C{first attempt?}
    C -->|yes, retry| D[backoff + jitter]
    C -->|no| E[fetch + rebase BEFORE next push]
    E --> F{rebase ok?}
    F -->|yes| D
    F -->|conflict on repos.json| G[reset to remote tip]
    G --> H[re-apply this host's update]
    H --> I{re-applied?}
    I -->|yes| D
    I -->|remote already current| Z
    I -->|cannot re-apply| J["status=update-dropped (non-fatal, observable)"]
    D --> A
```

Before this change the final attempt skipped box **E**, and box **G** jumped
straight to `success` — silently dropping the update.

## Test Plan

- Added `tests/test-repos-push-final-attempt.sh`:
  - **Defect 1**: a `sleep` shim deterministically advances the remote during
    the final backoff; asserts the host update still reaches the remote, the
    concurrent commit is preserved, no unpushed backlog remains, and the run
    does **not** report `push-failed`.
  - **Defect 2**: a `docs/repos.json` rebase conflict; asserts the host entry
    is re-applied and pushed to the remote (not dropped) and the remote's
    competing entry is preserved.
  - **Jitter**: `grq_apply_jitter` returns the base unchanged for base `0` or
    ceiling `0`, and otherwise stays within `[base, base+ceiling]`.
- Updated `tests/test-graceful-failure-recovery.sh` Test 5 to set
  `GRQ_PUSH_JITTER_MAX=0` so the exact backoff-sequence assertion stays
  deterministic (jitter is intentional new behaviour, covered by the new test).
- Existing suites pass unchanged: `test-repos-push-rebase`, `test-push-retry`,
  `test-push-rebase-quiet`, `test-repos-failure`, `test-stage-failure-health`,
  `test-graceful-failure-recovery`.
- `./quality.sh` passes except the pre-existing, unrelated
  `test-gitleaks-workflow` failure (present on `HEAD` before this change).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr20auvu-af2606`<!-- vibe-worker-issue-139 -->