### PR TITLE
Per-host health files remove Develop push contention (Issue #140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,26 +59,53 @@ A distributed health monitoring system that tracks the status of multiple hosts 
 - **Health logic**: The dashboard treats the host as unhealthy if **any discovered user** is stale (uses the *oldest* user heartbeat for host health classification).
 - **Logs**: `run.sh` writes only `docs/<HOST>/node-<user>.log` (one file per user). The generic `node.log` is no longer created.
 
-#### Market Feed Repository Freshness:
-- **Manual updates**: Each background task updates `docs/repos.json` immediately after it finishes, recording its latest commit/publish timestamp.
-- **Helper script**: Use `helpers/update_repo_timestamp.sh` to update (or create) the entry for a service.
+#### Market Feed Repository Freshness (per-host files — Issue #140):
+- **Per-host artefacts**: Each background task/host writes **its own** file
+  `docs/hosts/<slug>.json` when it finishes, recording its latest commit/publish
+  timestamp. Because hosts never write to a shared file, concurrent pushes to
+  the shared `Develop` branch no longer conflict on content — a slow/mobile,
+  high-latency host is no longer starved by fast, always-on hosts winning the
+  push race (which previously dropped the slow host's update and made its tile
+  go stale). `<slug>` is the host name with unsafe characters replaced by
+  hyphens (e.g. `Vibe Coder:GRQ-23` → `Vibe-Coder-GRQ-23`); the authoritative
+  human name is stored inside the file.
+- **Manifest**: `docs/hosts/index.json` lists the known host slugs so the static
+  dashboard can discover the per-host files. It is **append-only** — written
+  only when a brand-new host first appears — so an established fleet leaves it
+  untouched and steady-state pushes carry only each host's own file.
+- **Helper script**: Use `helpers/repos.sh <name>` to record a success (or
+  `--failed --log <path>` to record a failure). Example:
   ```bash
   # Record the current run for the dividends service
-  ./helpers/update_repo_timestamp.sh --name "dividends"
-
-  # Back-fill with an explicit unix timestamp
-  ./helpers/update_repo_timestamp.sh --name "FX" --timestamp 1752806400
+  ./helpers/repos.sh "Dividends"
   ```
-- **Output**: `docs/repos.json` keeps a simple list of objects with `name` and `last_commit_ts`. Example:
+- **Per-host file shape**: a single object with `name`, `last_commit_ts`, and
+  any per-host config (`warning_days`/`error_days`/`warning_hours`/`error_hours`/
+  `business_days_only`) plus failure fields when a run fails. Example:
   ```json
-  {
-    "repos": [
-      { "name": "dividends", "last_commit_ts": 1752806400 },
-      { "name": "FX", "last_commit_ts": 1752720000 }
-    ]
-  }
+  { "name": "Vibe Coder:GRQ-23", "last_commit_ts": 1752806400, "warning_hours": 4, "error_hours": 8 }
   ```
-- **Visualisation**: `docs/dashboard.js` and `docs/simple.html` fetch `docs/repos.json` and classify warning/error states (36h/72h thresholds) entirely on the client. The helper script intentionally does no health scoring.
+- **Visualisation**: `docs/dashboard.js` and `docs/simple.html` fetch the
+  manifest, load each per-host file, and **merge them at render time** into the
+  same repos array, then classify warning/error states entirely on the client.
+  If the manifest is unavailable (older deploys) they fall back to the legacy
+  shared `docs/repos.json`.
+
+```mermaid
+flowchart LR
+    subgraph Hosts["Hosts writing concurrently to Develop"]
+        A["Fast host<br/>repos.sh Score"] -->|writes only| FA["docs/hosts/Score.json"]
+        B["Mobile host<br/>repos.sh Vibe Coder:GRQ-23"] -->|writes only| FB["docs/hosts/Vibe-Coder-GRQ-23.json"]
+    end
+    FA --> M["docs/hosts/index.json<br/>(append-only manifest)"]
+    FB --> M
+    M --> D["dashboard.js / simple.html<br/>fetch manifest + per-host files"]
+    D -->|mergeHostRecords| T["Health tiles"]
+```
+
+Because `Score.json` and `Vibe-Coder-GRQ-23.json` are different files, their
+commits rebase cleanly against each other — no host's update is dropped on a
+content conflict, so no tile goes stale from losing the push race.
 
 #### Version Management:
 - **Primary version**: Stored in `run.sh` VERSION variable
@@ -214,7 +241,13 @@ The system uses a simple structure where each hostname is a key:
 }
 ```
 
-### Repo Freshness JSON (`docs/repos.json`)
+### Repo Freshness JSON (per-host files — `docs/hosts/<slug>.json`)
+
+Since Issue #140 each host owns a single file `docs/hosts/<slug>.json` holding
+one object, and `docs/hosts/index.json` lists the slugs. The example below shows
+the union of those objects as the dashboard merges them at render time (the
+legacy shared `docs/repos.json` uses the same object shape and remains as a
+fallback for older deploys):
 
 ```json
 {

--- a/docs/archive/pr-summaries/pr-summary-140.md
+++ b/docs/archive/pr-summaries/pr-summary-140.md
@@ -1,0 +1,106 @@
+# PR Summary — Issue #140: per-host health files remove Develop-branch push contention
+
+## Summary
+
+Health tiles for slow/mobile, high-latency hosts (e.g. `Vibe Coder:GRQ-23`)
+went **stale** because every host wrote its health to the single shared
+`docs/repos.json` on one `Develop` branch. With ~19 hosts pushing to that one
+file, a high-latency host lost the push race on every retry and its whole
+update was dropped, so its `last_commit_ts` never advanced and the tile tripped
+the staleness threshold.
+
+This PR removes the contention by giving **each host its own artefact**:
+
+- `helpers/repos.sh` now writes `docs/hosts/<slug>.json` (one object per host)
+  instead of the shared `docs/repos.json`, and registers the host's slug in an
+  **append-only** manifest `docs/hosts/index.json` (written only when a new host
+  first appears, so an established fleet leaves it untouched).
+- `docs/dashboard.js` and `docs/simple.html` fetch the manifest, load each
+  per-host file, and **merge them at render time** (`mergeHostRecords`). They
+  fall back to the legacy shared `docs/repos.json` when the manifest is absent
+  (older deploys).
+- The existing 25 entries in `docs/repos.json` were migrated into per-host files
+  under `docs/hosts/`, preserving every config field (`warning_days`,
+  `error_hours`, `business_days_only`, …). `docs/repos.json` is retained
+  read-only as the dashboard fallback.
+
+Because per-host files are single-writer, their commits rebase cleanly against
+each other — no host's update is dropped on a content conflict, so a slow host
+is no longer starved by fast ones. The existing push-retry/reapply machinery
+(Issues #117/#139) is retained; the only shared file that can still conflict is
+the rarely-touched manifest, handled by taking the remote copy then
+re-registering this host's slug.
+
+Closes #140.
+
+## Evidence
+
+This is primarily a backend/CLI + client-data-flow change. Playwright MCP was
+not available in this environment, so evidence is captured via the data
+pipeline and tests rather than a screenshot.
+
+**End-to-end merge verified against a live static server** serving `docs/`
+(replicating exactly what the browser does — fetch manifest → fetch each
+per-host file → `mergeHostRecords`):
+
+```
+merged repos: 25
+missing vs legacy: none
+extra vs legacy: none
+GRQ-23 record: {"error_hours":8,"last_commit_ts":1782876486,"name":"Vibe Coder:GRQ-23","warning_hours":4}
+```
+
+The per-host merge reproduces the exact same 25 repos (with config fields
+intact) that the legacy `repos.json` produced, and the fallback path
+(`manifest 404 → repos.json`) was verified to yield 25 repos too.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    subgraph Hosts["Hosts writing concurrently to Develop"]
+        A["Fast host<br/>repos.sh Score"] -->|writes only| FA["docs/hosts/Score.json"]
+        B["Mobile host<br/>repos.sh Vibe Coder:GRQ-23"] -->|writes only| FB["docs/hosts/Vibe-Coder-GRQ-23.json"]
+    end
+    FA --> M["docs/hosts/index.json<br/>(append-only manifest)"]
+    FB --> M
+    M --> D["dashboard.js / simple.html<br/>fetch manifest + per-host files"]
+    D -->|mergeHostRecords| T["Health tiles (no longer stale)"]
+```
+
+## Test Plan
+
+- **New** `tests/test-per-host-health.sh` (8 assertions):
+  - `repos.sh` writes `docs/hosts/<slug>.json` with the authoritative name and
+    registers the slug in the manifest.
+  - Two hosts get independent files and both appear in the manifest.
+  - Re-running a known host does **not** duplicate the manifest entry
+    (append-only, no shared-content churn).
+  - Config fields (`warning_days`/`error_days`/`business_days_only`) survive a
+    success update while `last_commit_ts` advances.
+  - `mergeHostRecords` drops nulls/invalid records and de-duplicates by name
+    (later record wins); returns `[]` for non-array input.
+- **Adapted** existing `repos.sh` tests to assert on the per-host files
+  (documented business-logic change — data moved from `docs/repos.json` to
+  `docs/hosts/<slug>.json`):
+  - `tests/test-repos-failure.sh` — failure fields, log capture, slug
+    sanitisation, retention now read `docs/hosts/<slug>.json`.
+  - `tests/test-repos-status-line.sh` — seeds host files; status-line
+    (skipped/updated/added/…) semantics unchanged.
+  - `tests/test-repos-push-rebase.sh` / `tests/test-repos-push-final-attempt.sh`
+    — the push-retry/rebase/reapply machinery now lands the host's per-host
+    file; the remote's competing `repos.json` commit is still preserved.
+- `./quality.sh`: 54/55 passing. The single failure, `test-gitleaks-workflow`
+  ("Missing gitleaks-action step or GITHUB_TOKEN env"), is **pre-existing and
+  unrelated** — it fails identically on the clean base branch and touches no
+  file in this PR.
+- `shellcheck --severity=warning` clean on `helpers/repos.sh` and the new test.
+- `dashboard.js` and `simple.html` inline scripts syntax-checked.
+
+## Security self-check
+
+- No secrets or hidden files staged; only `docs/hosts/*.json`, dashboard/HTML,
+  `helpers/repos.sh`, tests, README, and version files.
+- Per-host slug is derived by the existing `sanitise_task_slug` allowlist
+  (alphanumeric/`-`/`_`); the dashboard `encodeURIComponent`s the slug before
+  building the fetch URL, and repo names/fields remain HTML-escaped on render.

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.17";
+const VERSION = "1.1.18";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -457,6 +457,28 @@ function getRepoFailureLogUrl(repo) {
     return `./log-viewer.html?file=./${encoded}`;
 }
 
+// Issue #140: merge per-host health records (each loaded from its own
+// docs/hosts/<slug>.json file) into a single repos array for rendering.
+// Invalid/missing records (a host file that failed to load returns null) are
+// dropped; records must be objects carrying a non-empty string `name`. When
+// two records share a name the later one wins (deterministic de-duplication).
+function mergeHostRecords(records) {
+    if (!Array.isArray(records)) {
+        return [];
+    }
+    const byName = new Map();
+    for (const record of records) {
+        if (!record || typeof record !== 'object') {
+            continue;
+        }
+        if (typeof record.name !== 'string' || record.name.trim() === '') {
+            continue;
+        }
+        byName.set(record.name, record);
+    }
+    return Array.from(byName.values());
+}
+
 function getRepoStats(reposOverride) {
     // Accepts an optional array of repos (used by tests). Falls back to the
     // module-scope repoHealthData populated by fetchRepoHealth at runtime.
@@ -481,17 +503,55 @@ function getRepoStats(reposOverride) {
     }, { total: 0, healthy: 0, warning: 0, error: 0, failed: 0 });
 }
 
+// Issue #140: fetch a single host's per-host health file. Returns the parsed
+// record, or null when the file is missing/unreadable so one absent host never
+// breaks the whole dashboard.
+async function fetchHostRecord(slug, timestamp) {
+    const safeSlug = encodeURIComponent(String(slug));
+    const response = await fetch(`./hosts/${safeSlug}.json?t=${timestamp}`);
+    if (!response.ok) {
+        return null;
+    }
+    return response.json();
+}
+
+// Issue #140: load repo health from the per-host files listed in the manifest
+// (docs/hosts/index.json), merging them at render time. Falls back to the
+// legacy shared repos.json when the manifest is unavailable (older deploys).
+async function loadPerHostRepoHealth(timestamp) {
+    try {
+        const manifestResponse = await fetch(`./hosts/index.json?t=${timestamp}`);
+        if (manifestResponse.ok) {
+            const manifest = await manifestResponse.json();
+            const slugs = Array.isArray(manifest.hosts) ? manifest.hosts : [];
+            const settled = await Promise.allSettled(
+                slugs.map((slug) => fetchHostRecord(slug, timestamp))
+            );
+            const records = settled
+                .filter((result) => result.status === 'fulfilled')
+                .map((result) => result.value);
+            return mergeHostRecords(records);
+        }
+    } catch (error) {
+        console.warn('Per-host health manifest unavailable, falling back to repos.json:', error);
+    }
+    // Legacy fallback: the single shared repos.json.
+    const response = await fetch(`./repos.json?t=${timestamp}`);
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const legacy = await response.json();
+    return mergeHostRecords(Array.isArray(legacy?.repos) ? legacy.repos : []);
+}
+
 async function fetchRepoHealth(timestamp = Date.now(), force = false) {
     const now = Date.now();
     if (!force && now - lastRepoRefresh < 5 * 60 * 1000) {
         return;
     }
     try {
-        const response = await fetch(`./repos.json?t=${timestamp}`);
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        repoHealthData = await response.json();
+        const repos = await loadPerHostRepoHealth(timestamp);
+        repoHealthData = { repos };
         lastRepoRefresh = now;
         renderRepoHealth();
     } catch (error) {

--- a/docs/hosts/ATO.json
+++ b/docs/hosts/ATO.json
@@ -1,0 +1,6 @@
+{
+  "error_days": 15,
+  "last_commit_ts": 1782885585,
+  "name": "ATO",
+  "warning_days": 10
+}

--- a/docs/hosts/Commodities.json
+++ b/docs/hosts/Commodities.json
@@ -1,0 +1,6 @@
+{
+  "error_days": 4,
+  "last_commit_ts": 1782904648,
+  "name": "Commodities",
+  "warning_days": 2
+}

--- a/docs/hosts/Company-Reports.json
+++ b/docs/hosts/Company-Reports.json
@@ -1,0 +1,9 @@
+{
+  "last_commit_ts": 1782826869,
+  "last_failure_exit_code": 1,
+  "last_failure_log": "logs/Company-Reports/20260613-085504.log",
+  "last_failure_message": "Push failed for GRQ-companyreports; no changes to commit or git push error; partial data pushed to GRQ-companyreports",
+  "last_failure_ts": 1781340904,
+  "name": "Company Reports",
+  "warning_days": 1.5
+}

--- a/docs/hosts/Discovery-Snapshot.json
+++ b/docs/hosts/Discovery-Snapshot.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782740250,
+  "name": "Discovery Snapshot"
+}

--- a/docs/hosts/Dividends.json
+++ b/docs/hosts/Dividends.json
@@ -1,0 +1,6 @@
+{
+  "error_days": 5,
+  "last_commit_ts": 1782868418,
+  "name": "Dividends",
+  "warning_days": 3
+}

--- a/docs/hosts/FX.json
+++ b/docs/hosts/FX.json
@@ -1,0 +1,7 @@
+{
+  "business_days_only": true,
+  "error_days": 4,
+  "last_commit_ts": 1782909612,
+  "name": "FX",
+  "warning_days": 1.5
+}

--- a/docs/hosts/Insiders.json
+++ b/docs/hosts/Insiders.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782869356,
+  "name": "Insiders"
+}

--- a/docs/hosts/Listings.json
+++ b/docs/hosts/Listings.json
@@ -1,0 +1,6 @@
+{
+  "error_days": 15,
+  "last_commit_ts": 1782903914,
+  "name": "Listings",
+  "warning_days": 10
+}

--- a/docs/hosts/Portfolio.json
+++ b/docs/hosts/Portfolio.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1779565421,
+  "name": "Portfolio"
+}

--- a/docs/hosts/Quality.json
+++ b/docs/hosts/Quality.json
@@ -1,0 +1,7 @@
+{
+  "last_commit_ts": 1782847873,
+  "last_failure_exit_code": 17,
+  "last_failure_log": "logs/Quality/20260417-025717.log",
+  "last_failure_ts": 1776394637,
+  "name": "Quality"
+}

--- a/docs/hosts/S3-Sync.json
+++ b/docs/hosts/S3-Sync.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782728158,
+  "name": "S3 Sync"
+}

--- a/docs/hosts/Score.json
+++ b/docs/hosts/Score.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782889638,
+  "name": "Score"
+}

--- a/docs/hosts/ScoreClient-alison.json
+++ b/docs/hosts/ScoreClient-alison.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782889863,
+  "name": "ScoreClient:alison"
+}

--- a/docs/hosts/ScoreClient-luke.json
+++ b/docs/hosts/ScoreClient-luke.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782889765,
+  "name": "ScoreClient:luke"
+}

--- a/docs/hosts/ScoreClient-simon.json
+++ b/docs/hosts/ScoreClient-simon.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782889967,
+  "name": "ScoreClient:simon"
+}

--- a/docs/hosts/Scorer.json
+++ b/docs/hosts/Scorer.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782892829,
+  "name": "Scorer"
+}

--- a/docs/hosts/Sentiment.json
+++ b/docs/hosts/Sentiment.json
@@ -1,0 +1,5 @@
+{
+  "last_commit_ts": 1782885901,
+  "name": "Sentiment",
+  "warning_days": 1.5
+}

--- a/docs/hosts/Shareprices.json
+++ b/docs/hosts/Shareprices.json
@@ -1,0 +1,9 @@
+{
+  "last_commit_ts": 1782872799,
+  "last_failure_exit_code": 1,
+  "last_failure_log": "logs/Shareprices/20260614-102101.log",
+  "last_failure_message": "Push failed for GRQ-shareprices2026Q2; no price data committed/pushed or git push error",
+  "last_failure_ts": 1781432461,
+  "name": "Shareprices",
+  "warning_days": 1.5
+}

--- a/docs/hosts/Training-Data.json
+++ b/docs/hosts/Training-Data.json
@@ -1,0 +1,5 @@
+{
+  "last_commit_ts": 1781402088,
+  "name": "Training Data",
+  "warning_days": 1.5
+}

--- a/docs/hosts/Validation.json
+++ b/docs/hosts/Validation.json
@@ -1,0 +1,4 @@
+{
+  "last_commit_ts": 1782892815,
+  "name": "Validation"
+}

--- a/docs/hosts/Vibe-Coder-GRQ-23.json
+++ b/docs/hosts/Vibe-Coder-GRQ-23.json
@@ -1,0 +1,6 @@
+{
+  "error_hours": 8,
+  "last_commit_ts": 1782876486,
+  "name": "Vibe Coder:GRQ-23",
+  "warning_hours": 4
+}

--- a/docs/hosts/Vibe-Coder-GRQ-25.json
+++ b/docs/hosts/Vibe-Coder-GRQ-25.json
@@ -1,0 +1,6 @@
+{
+  "error_hours": 8,
+  "last_commit_ts": 1782905865,
+  "name": "Vibe Coder:GRQ-25",
+  "warning_hours": 4
+}

--- a/docs/hosts/Vibe-Coder-GRQ-3.json
+++ b/docs/hosts/Vibe-Coder-GRQ-3.json
@@ -1,0 +1,6 @@
+{
+  "error_hours": 8,
+  "last_commit_ts": 1782908793,
+  "name": "Vibe Coder:GRQ-3",
+  "warning_hours": 4
+}

--- a/docs/hosts/Vibe-Coder-Mac-Ultra-M2.json
+++ b/docs/hosts/Vibe-Coder-Mac-Ultra-M2.json
@@ -1,0 +1,6 @@
+{
+  "error_hours": 8,
+  "last_commit_ts": 1782909190,
+  "name": "Vibe Coder:Mac-Ultra-M2",
+  "warning_hours": 4
+}

--- a/docs/hosts/WorldUncertainty.json
+++ b/docs/hosts/WorldUncertainty.json
@@ -1,0 +1,5 @@
+{
+  "last_commit_ts": 1782908429,
+  "name": "WorldUncertainty",
+  "warning_days": 1.5
+}

--- a/docs/hosts/index.json
+++ b/docs/hosts/index.json
@@ -1,0 +1,29 @@
+{
+  "hosts": [
+    "ATO",
+    "Commodities",
+    "Company-Reports",
+    "Discovery-Snapshot",
+    "Dividends",
+    "FX",
+    "Insiders",
+    "Listings",
+    "Portfolio",
+    "Quality",
+    "S3-Sync",
+    "Score",
+    "ScoreClient-alison",
+    "ScoreClient-luke",
+    "ScoreClient-simon",
+    "Scorer",
+    "Sentiment",
+    "Shareprices",
+    "Training-Data",
+    "Validation",
+    "Vibe-Coder-GRQ-23",
+    "Vibe-Coder-GRQ-25",
+    "Vibe-Coder-GRQ-3",
+    "Vibe-Coder-Mac-Ultra-M2",
+    "WorldUncertainty"
+  ]
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.17" rel="stylesheet">
+    <link href="./styles.css?v=1.1.18" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -107,14 +107,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.17"></script>
+    <script src="./dashboard.js?v=1.1.18"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.17')
+                navigator.serviceWorker.register('./sw.js?v=1.1.18')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/simple.html
+++ b/docs/simple.html
@@ -57,25 +57,61 @@
                 .replace(/'/g, '&#039;');
         }
 
+        // Issue #140: merge per-host health records into a repos array,
+        // dropping nulls/invalid records and de-duplicating by name.
+        function mergeHostRecords(records) {
+            if (!Array.isArray(records)) return [];
+            const byName = new Map();
+            for (const record of records) {
+                if (!record || typeof record !== 'object') continue;
+                if (typeof record.name !== 'string' || record.name.trim() === '') continue;
+                byName.set(record.name, record);
+            }
+            return Array.from(byName.values());
+        }
+
+        // Issue #140: load repo health from the per-host manifest, falling back
+        // to the legacy shared repos.json when the manifest is unavailable.
+        async function loadPerHostRepos(timestamp) {
+            try {
+                const manifestResponse = await fetch(`./hosts/index.json?t=${timestamp}`);
+                if (manifestResponse.ok) {
+                    const manifest = await manifestResponse.json();
+                    const slugs = Array.isArray(manifest.hosts) ? manifest.hosts : [];
+                    const settled = await Promise.allSettled(slugs.map(async (slug) => {
+                        const r = await fetch(`./hosts/${encodeURIComponent(String(slug))}.json?t=${timestamp}`);
+                        return r.ok ? r.json() : null;
+                    }));
+                    const records = settled
+                        .filter((s) => s.status === 'fulfilled')
+                        .map((s) => s.value);
+                    return mergeHostRecords(records);
+                }
+            } catch (error) {
+                console.warn('Per-host manifest unavailable, falling back to repos.json', error);
+            }
+            const repoResponse = await fetch(`./repos.json?t=${timestamp}`);
+            if (!repoResponse.ok) {
+                console.warn('Repo health data unavailable', repoResponse.status);
+                return [];
+            }
+            const legacy = await repoResponse.json();
+            return mergeHostRecords(Array.isArray(legacy.repos) ? legacy.repos : []);
+        }
+
         async function checkHealth() {
             try {
                 // Add timestamp to force fresh fetch and bypass cache
                 const timestamp = new Date().getTime();
-                const [hostsResponse, repoResponse] = await Promise.all([
-                    fetch(`./index.json?t=${timestamp}`),
-                    fetch(`./repos.json?t=${timestamp}`)
-                ]);
+                const hostsResponse = await fetch(`./index.json?t=${timestamp}`);
                 if (!hostsResponse.ok) {
                     throw new Error(`HTTP error! status: ${hostsResponse.status}`);
                 }
                 const data = await hostsResponse.json();
-                let repoData = { repos: [] };
-                if (repoResponse.ok) {
-                    repoData = await repoResponse.json();
-                } else {
-                    console.warn('Repo health data unavailable', repoResponse.status);
-                }
-                
+                // Issue #140: repo health merged from per-host files (manifest),
+                // falling back to the legacy shared repos.json.
+                const repoData = { repos: await loadPerHostRepos(timestamp) };
+
                 // Convert to array of [hostname, data] pairs
                 const hosts = Object.entries(data);
                 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.17
+// Version: 1.1.18
 
-const CACHE_NAME = 'grq-health-v1.1.17';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.17';
+const CACHE_NAME = 'grq-health-v1.1.18';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.18';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.17',
+  './dashboard.js?v=1.1.18',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/helpers/repos.sh
+++ b/helpers/repos.sh
@@ -235,7 +235,21 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-REPOS_JSON="${PROJECT_ROOT}/docs/repos.json"
+# Issue #140: each host writes its own artefact under docs/hosts/ instead of
+# the single shared docs/repos.json, so concurrent hosts never touch the same
+# file. Non-conflicting per-host files rebase cleanly, so a slow/high-latency
+# host is no longer starved by fast ones losing the push race on shared
+# content. The dashboard merges the per-host files (and the manifest) at render
+# time. docs/repos.json is retained read-only as a legacy fallback and is no
+# longer written here.
+#   HOST_JSON    docs/hosts/<slug>.json  — this host's own health record
+#   HOSTS_INDEX  docs/hosts/index.json   — manifest of known host slugs, only
+#                                          appended to when a new host appears
+HOSTS_DIR="${PROJECT_ROOT}/docs/hosts"
+HOSTS_INDEX="${HOSTS_DIR}/index.json"
+# HOST_SLUG / HOST_JSON are populated once REPO_NAME is validated below.
+HOST_SLUG=""
+HOST_JSON=""
 
 # Validate the repo name before proceeding
 if [ -z "$REPO_NAME" ]; then
@@ -267,8 +281,35 @@ if [ -n "$LOG_PATH" ]; then
     fi
 fi
 
+# Issue #140: resolve this host's per-host artefact path. The slug is reused as
+# both the filename and the manifest entry; the authoritative human name is
+# stored inside the file so slug sanitisation never loses it.
+HOST_SLUG=$(sanitise_task_slug "$REPO_NAME")
+HOST_JSON="${HOSTS_DIR}/${HOST_SLUG}.json"
+
 # Get current UTC timestamp (Unix timestamp)
 CURRENT_TS=$(date +%s)
+
+# Issue #140: register this host's slug in the manifest (docs/hosts/index.json)
+# so the static dashboard can discover the per-host files. The manifest is only
+# written when the slug is missing, so an established fleet leaves it untouched
+# and steady-state pushes carry only the host's own file (no shared-content
+# contention).
+register_host_in_manifest() {
+    if ! command -v jq &> /dev/null; then
+        return 0
+    fi
+    mkdir -p "$HOSTS_DIR"
+    if [ ! -f "$HOSTS_INDEX" ]; then
+        echo '{"hosts": []}' > "$HOSTS_INDEX"
+    fi
+    # Only rewrite when the slug is not already present — keeps the shared
+    # manifest static for known hosts.
+    if ! jq -e --arg slug "$HOST_SLUG" '(.hosts // []) | index($slug)' "$HOSTS_INDEX" > /dev/null 2>&1; then
+        jq --arg slug "$HOST_SLUG" '.hosts = (((.hosts // []) + [$slug]) | unique)' \
+            "$HOSTS_INDEX" > "${HOSTS_INDEX}.tmp" && mv "${HOSTS_INDEX}.tmp" "$HOSTS_INDEX"
+    fi
+}
 
 # Function to store the failure log file and enforce retention
 store_failure_log() {
@@ -314,7 +355,11 @@ store_failure_log() {
     echo "logs/${task_slug}/${log_filename}"
 }
 
-# Function to update repos.json for a successful run
+# Issue #140: update this host's per-host file (docs/hosts/<slug>.json) for a
+# successful run. The file holds a single object with the host's name plus its
+# live fields; any config fields already present (warning_days, error_hours,
+# business_days_only, …) are preserved because we read-modify-write the whole
+# object. Function name kept for the push-retry reapply path.
 update_repos_json_success() {
     # Check if jq is available
     if ! command -v jq &> /dev/null; then
@@ -322,23 +367,18 @@ update_repos_json_success() {
         exit 1
     fi
 
-    # Ensure repos.json exists with proper structure
-    if [ ! -f "$REPOS_JSON" ]; then
-        echo "{\"repos\": []}" > "$REPOS_JSON"
+    mkdir -p "$HOSTS_DIR"
+
+    # Read the host's current last_commit_ts (if any) for the rate-limit check.
+    local last_update_ts=""
+    if [ -f "$HOST_JSON" ]; then
+        last_update_ts=$(jq -r '.last_commit_ts // empty' "$HOST_JSON" 2>/dev/null || echo "")
     fi
 
-    # Read current repos array
-    REPOS=$(jq -c '.repos // []' "$REPOS_JSON")
-
-    # Check if repo already exists and get its last commit timestamp
-    EXISTING_REPO=$(echo "$REPOS" | jq -r ".[] | select(.name == \"${REPO_NAME}\") | .name // empty")
-    LAST_UPDATE_TS=$(echo "$REPOS" | jq -r ".[] | select(.name == \"${REPO_NAME}\") | .last_commit_ts // empty")
-
-    # If repo exists, check if it was updated within the last hour (3600 seconds)
-    if [ "$SKIP_RATE_LIMIT" = false ] && [ -n "$EXISTING_REPO" ] && [ -n "$LAST_UPDATE_TS" ]; then
-        TIME_DIFF=$((CURRENT_TS - LAST_UPDATE_TS))
+    # If the host was updated within the last hour (3600 seconds), skip.
+    if [ "$SKIP_RATE_LIMIT" = false ] && [ -n "$last_update_ts" ] && [ "$last_update_ts" -gt 0 ] 2>/dev/null; then
+        TIME_DIFF=$((CURRENT_TS - last_update_ts))
         if [ "$TIME_DIFF" -lt 3600 ]; then
-            # Updated within the last hour, skip update
             MINUTES_AGO=$((TIME_DIFF / 60))
             echo "Skipping update for '${REPO_NAME}' - last updated ${MINUTES_AGO} minutes ago (within 1 hour threshold)"
             RUN_STATUS="skipped"
@@ -347,30 +387,27 @@ update_repos_json_success() {
         fi
     fi
 
-    # Proceed with update (either new repo or last update was more than 1 hour ago)
-    if [ -n "$EXISTING_REPO" ]; then
-        # Update existing repo
-        jq --arg name "$REPO_NAME" \
-           --arg ts "$CURRENT_TS" \
-           '.repos |= map(if .name == $name then .last_commit_ts = ($ts | tonumber) else . end)' \
-           "$REPOS_JSON" > "${REPOS_JSON}.tmp" && mv "${REPOS_JSON}.tmp" "$REPOS_JSON"
+    if [ -f "$HOST_JSON" ]; then
+        # Update existing per-host file, preserving name and any config fields.
+        jq --arg name "$REPO_NAME" --arg ts "$CURRENT_TS" \
+           '.name = $name | .last_commit_ts = ($ts | tonumber)' \
+           "$HOST_JSON" > "${HOST_JSON}.tmp" && mv "${HOST_JSON}.tmp" "$HOST_JSON"
         echo "Updated repo '${REPO_NAME}' with timestamp ${CURRENT_TS}"
         RUN_STATUS="updated"
         RUN_REASON="success"
     else
-        # Add new repo
-        NEW_REPO="{\"name\": \"${REPO_NAME}\", \"last_commit_ts\": ${CURRENT_TS}}"
-
-        jq --argjson new_repo "$NEW_REPO" \
-           '.repos += [$new_repo]' \
-           "$REPOS_JSON" > "${REPOS_JSON}.tmp" && mv "${REPOS_JSON}.tmp" "$REPOS_JSON"
+        jq -n --arg name "$REPO_NAME" --arg ts "$CURRENT_TS" \
+           '{name: $name, last_commit_ts: ($ts | tonumber)}' > "$HOST_JSON"
         echo "Added repo '${REPO_NAME}' with timestamp ${CURRENT_TS}"
         RUN_STATUS="added"
         RUN_REASON="success"
     fi
+
+    register_host_in_manifest
 }
 
-# Function to update repos.json for a failed run
+# Issue #140: update this host's per-host file for a failed run. Failure fields
+# are written without touching last_commit_ts (or any config fields).
 update_repos_json_failure() {
     local log_relative_path="$1"
 
@@ -380,21 +417,12 @@ update_repos_json_failure() {
         exit 1
     fi
 
-    # Ensure repos.json exists with proper structure
-    if [ ! -f "$REPOS_JSON" ]; then
-        echo "{\"repos\": []}" > "$REPOS_JSON"
-    fi
+    mkdir -p "$HOSTS_DIR"
 
-    # Read current repos array
-    REPOS=$(jq -c '.repos // []' "$REPOS_JSON")
-
-    # Check if repo already exists
-    EXISTING_REPO=$(echo "$REPOS" | jq -r ".[] | select(.name == \"${REPO_NAME}\") | .name // empty")
-
-    if [ -n "$EXISTING_REPO" ]; then
-        # Update existing repo with failure fields (do NOT touch last_commit_ts)
+    if [ -f "$HOST_JSON" ]; then
+        # Update existing per-host file with failure fields (keep last_commit_ts).
         local jq_filter
-        jq_filter='.repos |= map(if .name == $name then .last_failure_ts = ($ts | tonumber) | .last_failure_log = $log'
+        jq_filter='.name = $name | .last_failure_ts = ($ts | tonumber) | .last_failure_log = $log'
 
         local jq_args=()
         jq_args+=(--arg name "$REPO_NAME")
@@ -411,12 +439,10 @@ update_repos_json_failure() {
             jq_args+=(--arg message "$FAILURE_MESSAGE")
         fi
 
-        jq_filter="$jq_filter"' else . end)'
-
-        jq "${jq_args[@]}" "$jq_filter" "$REPOS_JSON" > "${REPOS_JSON}.tmp" && mv "${REPOS_JSON}.tmp" "$REPOS_JSON"
+        jq "${jq_args[@]}" "$jq_filter" "$HOST_JSON" > "${HOST_JSON}.tmp" && mv "${HOST_JSON}.tmp" "$HOST_JSON"
         echo "Updated repo '${REPO_NAME}' with failure at timestamp ${CURRENT_TS}"
     else
-        # Add new repo entry with failure fields (no last_commit_ts since it never succeeded)
+        # New per-host file with failure fields (last_commit_ts 0 — never succeeded).
         local new_entry
         new_entry=$(jq -n --arg name "$REPO_NAME" --arg ts "$CURRENT_TS" --arg log "$log_relative_path" \
             '{name: $name, last_commit_ts: 0, last_failure_ts: ($ts | tonumber), last_failure_log: $log}')
@@ -428,10 +454,11 @@ update_repos_json_failure() {
             new_entry=$(echo "$new_entry" | jq --arg msg "$FAILURE_MESSAGE" '. + {last_failure_message: $msg}')
         fi
 
-        jq --argjson new_repo "$new_entry" '.repos += [$new_repo]' \
-            "$REPOS_JSON" > "${REPOS_JSON}.tmp" && mv "${REPOS_JSON}.tmp" "$REPOS_JSON"
+        echo "$new_entry" > "$HOST_JSON"
         echo "Added repo '${REPO_NAME}' with failure at timestamp ${CURRENT_TS}"
     fi
+
+    register_host_in_manifest
 }
 
 # Main logic: decide between success and failure modes
@@ -477,12 +504,16 @@ else
 
     # Check if we're in a merge state
     if [ -f "${PROJECT_ROOT}/.git/MERGE_HEAD" ]; then
-        # Check if repos.json is conflicted
-        if git diff --name-only --diff-filter=U 2>/dev/null | grep -q "^docs/repos.json$"; then
-            # For repos.json conflicts, take remote version (we'll update it next)
-            git checkout --theirs "${REPOS_JSON}" 2>/dev/null
-            git add "${REPOS_JSON}" 2>/dev/null
+        # Issue #140: per-host files are single-writer so they do not conflict;
+        # the only shared file is the manifest (docs/hosts/index.json). On a
+        # manifest conflict, take the remote copy then re-register this host's
+        # slug on top so no host is lost. Our own per-host file is uncommitted
+        # and re-staged in Step 2.
+        if git diff --name-only --diff-filter=U 2>/dev/null | grep -q "^docs/hosts/index.json$"; then
+            git checkout --theirs "${HOSTS_INDEX}" 2>/dev/null
+            git add "${HOSTS_INDEX}" 2>/dev/null
             git commit --no-edit --quiet 2>/dev/null || git merge --abort 2>/dev/null
+            register_host_in_manifest
         else
             # Abort merge for other conflicts
             git merge --abort 2>/dev/null
@@ -504,12 +535,13 @@ else
     fi
 
     if [ "$GIT_PULL_SUCCESS" = false ]; then
-        echo "Warning: Could not resolve git state, will attempt to update repos.json anyway"
+        echo "Warning: Could not resolve git state, will attempt to update host files anyway"
     fi
 fi
 
-# Step 2: Stage all changed files (repos.json and any log files)
-FILES_TO_ADD=("${REPOS_JSON}")
+# Step 2: Stage this host's per-host file, the manifest, and any log files
+# (Issue #140). The shared docs/repos.json is no longer written here.
+FILES_TO_ADD=("${HOST_JSON}" "${HOSTS_INDEX}")
 if [ "$FAILED_MODE" = true ]; then
     # Also stage the logs directory
     TASK_SLUG=$(sanitise_task_slug "$REPO_NAME")
@@ -527,12 +559,12 @@ for f in "${FILES_TO_ADD[@]}"; do
 done
 
 # Re-apply this host's health update onto the current working tree and commit
-# it (Issue #139 defect 2). Used by the push loop after a rebase conflict on
-# the shared docs/repos.json forces a hard reset to the remote tip: rather
-# than discarding this host's update (and silently reporting success), we
-# regenerate the entry on top of the fresh base and re-commit it so it can be
-# pushed. The update_repos_json_* helpers are idempotent and keyed on the host
-# name, so re-running them on the fresh base cannot itself conflict.
+# it (Issue #139 defect 2). Used by the push loop after a rebase conflict (now
+# only possible on the shared manifest) forces a hard reset to the remote tip:
+# rather than discarding this host's update (and silently reporting success),
+# we regenerate the per-host file on top of the fresh base and re-commit it so
+# it can be pushed. The update_repos_json_* helpers are idempotent and keyed on
+# the host slug, so re-running them on the fresh base cannot itself conflict.
 # Returns:
 #   0 — re-applied and committed a fresh local commit ready to push
 #   2 — nothing to commit (remote already carries this host's update)
@@ -544,7 +576,7 @@ reapply_health_update() {
         # stdin log ("-") cannot be reproduced, so surface a dropped update.
         if [ "$LOG_PATH" != "-" ] && [ -f "$LOG_PATH" ]; then
             LOG_RELATIVE_PATH=$(store_failure_log)
-            FILES_TO_ADD=("${REPOS_JSON}")
+            FILES_TO_ADD=("${HOST_JSON}" "${HOSTS_INDEX}")
             local reapply_slug reapply_log_dir
             reapply_slug=$(sanitise_task_slug "$REPO_NAME")
             reapply_log_dir="${PROJECT_ROOT}/docs/logs/${reapply_slug}"

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ fi
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.17"
+VERSION="1.1.18"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/test-per-host-health.sh
+++ b/tests/test-per-host-health.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Test for Issue #140: per-host health files remove Develop-branch push
+# contention.
+#
+# Covers the write path (helpers/repos.sh writes docs/hosts/<slug>.json plus an
+# append-only manifest docs/hosts/index.json) and the read path (dashboard.js
+# mergeHostRecords merges the per-host files at render time).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOS_SCRIPT="$SCRIPT_DIR/../helpers/repos.sh"
+# shellcheck source=./extract-functions.sh
+source "$SCRIPT_DIR/extract-functions.sh"
+
+echo "Testing Issue #140: per-host health files"
+echo "========================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+setup_test_env() {
+    local test_dir="$TMPDIR_BASE/test_$$_$RANDOM"
+    mkdir -p "$test_dir/docs/hosts" "$test_dir/helpers"
+    cp "$REPOS_SCRIPT" "$test_dir/helpers/repos.sh"
+    if [ -f "$SCRIPT_DIR/../helpers/git-retry.sh" ]; then
+        cp "$SCRIPT_DIR/../helpers/git-retry.sh" "$test_dir/helpers/git-retry.sh"
+    fi
+    chmod +x "$test_dir/helpers/repos.sh"
+    echo "$test_dir"
+}
+
+# --------------------------------------------------------------------------
+# Test 1: A new host writes its own file and registers itself in the manifest.
+# --------------------------------------------------------------------------
+echo "Test 1: new host writes docs/hosts/<slug>.json + manifest..."
+TEST_DIR=$(setup_test_env)
+
+bash "$TEST_DIR/helpers/repos.sh" --dry-run --skip-rate-limit --project-root "$TEST_DIR" "Vibe Coder:GRQ-23" 2>/dev/null
+
+HOST_FILE="$TEST_DIR/docs/hosts/Vibe-Coder-GRQ-23.json"
+if [ -f "$HOST_FILE" ] && [ "$(jq -r '.name' "$HOST_FILE")" = "Vibe Coder:GRQ-23" ]; then
+    pass_test "per-host file created with authoritative name"
+else
+    fail_test "per-host file missing or wrong name"
+fi
+
+if [ "$(jq -r '.hosts | index("Vibe-Coder-GRQ-23")' "$TEST_DIR/docs/hosts/index.json")" != "null" ]; then
+    pass_test "host slug registered in manifest"
+else
+    fail_test "host slug not registered in manifest"
+fi
+
+# --------------------------------------------------------------------------
+# Test 2: Two different hosts never share a file; both appear in the manifest.
+# --------------------------------------------------------------------------
+echo "Test 2: two hosts get independent files + manifest entries..."
+TEST_DIR=$(setup_test_env)
+
+bash "$TEST_DIR/helpers/repos.sh" --dry-run --skip-rate-limit --project-root "$TEST_DIR" "GRQ-A" 2>/dev/null
+bash "$TEST_DIR/helpers/repos.sh" --dry-run --skip-rate-limit --project-root "$TEST_DIR" "GRQ-B" 2>/dev/null
+
+if [ -f "$TEST_DIR/docs/hosts/GRQ-A.json" ] && [ -f "$TEST_DIR/docs/hosts/GRQ-B.json" ]; then
+    pass_test "each host wrote its own file (no shared file)"
+else
+    fail_test "expected a separate file per host"
+fi
+
+MANIFEST_COUNT=$(jq '.hosts | length' "$TEST_DIR/docs/hosts/index.json")
+if [ "$MANIFEST_COUNT" -eq 2 ]; then
+    pass_test "manifest lists both hosts ($MANIFEST_COUNT)"
+else
+    fail_test "manifest should list 2 hosts (got: $MANIFEST_COUNT)"
+fi
+
+# --------------------------------------------------------------------------
+# Test 3: Re-running an existing host does NOT duplicate the manifest entry
+# (the shared manifest stays static for known hosts — no content contention).
+# --------------------------------------------------------------------------
+echo "Test 3: manifest is append-only (no duplicate on re-run)..."
+bash "$TEST_DIR/helpers/repos.sh" --dry-run --skip-rate-limit --project-root "$TEST_DIR" "GRQ-A" 2>/dev/null
+MANIFEST_COUNT_AFTER=$(jq '.hosts | length' "$TEST_DIR/docs/hosts/index.json")
+if [ "$MANIFEST_COUNT_AFTER" -eq 2 ]; then
+    pass_test "re-run did not duplicate the manifest entry (still $MANIFEST_COUNT_AFTER)"
+else
+    fail_test "manifest count changed on re-run (got: $MANIFEST_COUNT_AFTER)"
+fi
+
+# --------------------------------------------------------------------------
+# Test 4: Config fields (warning_hours/error_hours) survive a success update.
+# --------------------------------------------------------------------------
+echo "Test 4: config fields preserved through an update..."
+TEST_DIR=$(setup_test_env)
+cat > "$TEST_DIR/docs/hosts/FX.json" <<'ENDJSON'
+{"name": "FX", "last_commit_ts": 1, "warning_days": 1.5, "error_days": 4, "business_days_only": true}
+ENDJSON
+
+bash "$TEST_DIR/helpers/repos.sh" --dry-run --skip-rate-limit --project-root "$TEST_DIR" "FX" 2>/dev/null
+
+PRESERVED=$(jq -r '[.warning_days, .error_days, .business_days_only] | @csv' "$TEST_DIR/docs/hosts/FX.json")
+UPDATED_TS=$(jq -r '.last_commit_ts' "$TEST_DIR/docs/hosts/FX.json")
+if [ "$PRESERVED" = "1.5,4,true" ] && [ "$UPDATED_TS" -gt 1 ]; then
+    pass_test "config preserved and last_commit_ts advanced"
+else
+    fail_test "config not preserved (fields: $PRESERVED, ts: $UPDATED_TS)"
+fi
+
+# --------------------------------------------------------------------------
+# Test 5 (dashboard): mergeHostRecords drops nulls/invalid and dedupes by name.
+# --------------------------------------------------------------------------
+echo "Test 5: mergeHostRecords merges per-host records..."
+JS_OUTPUT=$(run_js_test '
+    const merged = mergeHostRecords([
+        { name: "GRQ-23", last_commit_ts: 100 },
+        null,                       // a host file that failed to load
+        "not-an-object",           // malformed payload
+        { last_commit_ts: 5 },      // missing name -> dropped
+        { name: "", last_commit_ts: 5 }, // blank name -> dropped
+        { name: "GRQ-23", last_commit_ts: 200 } // later record wins
+    ]);
+    const byName = Object.fromEntries(merged.map((r) => [r.name, r.last_commit_ts]));
+    const ok = merged.length === 1 && byName["GRQ-23"] === 200;
+    console.log("TEST_RESULT:merge:" + (ok ? "PASS" : "FAIL") + ":count=" + merged.length + " ts=" + byName["GRQ-23"]);
+' 2>&1) || true
+
+if echo "$JS_OUTPUT" | grep -q "TEST_RESULT:merge:PASS:"; then
+    pass_test "mergeHostRecords filters invalid records and dedupes by name"
+else
+    fail_test "mergeHostRecords wrong result ($JS_OUTPUT)"
+fi
+
+# --------------------------------------------------------------------------
+# Test 6 (dashboard): a non-array input yields an empty list (defensive).
+# --------------------------------------------------------------------------
+echo "Test 6: mergeHostRecords tolerates non-array input..."
+JS_OUTPUT2=$(run_js_test '
+    const a = mergeHostRecords(undefined).length === 0;
+    const b = mergeHostRecords(null).length === 0;
+    const c = mergeHostRecords({}).length === 0;
+    console.log("TEST_RESULT:defensive:" + ((a && b && c) ? "PASS" : "FAIL") + ":a=" + a + " b=" + b + " c=" + c);
+' 2>&1) || true
+
+if echo "$JS_OUTPUT2" | grep -q "TEST_RESULT:defensive:PASS:"; then
+    pass_test "mergeHostRecords returns [] for non-array input"
+else
+    fail_test "mergeHostRecords did not handle non-array input ($JS_OUTPUT2)"
+fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "========================================="
+echo "Passed: $PASS_COUNT  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test-repos-failure.sh
+++ b/tests/test-repos-failure.sh
@@ -2,6 +2,10 @@
 # Test for Issue #76: Failure reporting in repos.sh
 # Verifies that --failed --log flags work correctly, log retention is enforced,
 # and task name sanitisation prevents path traversal and shell injection.
+#
+# Issue #140: health data now lives in per-host files under docs/hosts/ rather
+# than the single shared docs/repos.json. Assertions read the host file
+# (docs/hosts/<slug>.json) directly.
 
 set -e
 
@@ -31,17 +35,13 @@ trap 'rm -rf "$TMPDIR_BASE"' EXIT
 
 setup_test_env() {
     local test_dir="$TMPDIR_BASE/test_$$_$RANDOM"
-    mkdir -p "$test_dir/docs" "$test_dir/helpers"
+    mkdir -p "$test_dir/docs/hosts" "$test_dir/helpers"
 
-    # Create a minimal repos.json
-    cat > "$test_dir/docs/repos.json" <<'ENDJSON'
+    # Issue #140: seed the per-host file for "Quality".
+    cat > "$test_dir/docs/hosts/Quality.json" <<'ENDJSON'
 {
-  "repos": [
-    {
-      "name": "Quality",
-      "last_commit_ts": 1776265324
-    }
-  ]
+  "name": "Quality",
+  "last_commit_ts": 1776265324
 }
 ENDJSON
 
@@ -50,6 +50,12 @@ ENDJSON
     chmod +x "$test_dir/helpers/repos.sh"
 
     echo "$test_dir"
+}
+
+# Issue #140: read a field from a host's per-host file (docs/hosts/<slug>.json).
+host_field() {
+    local test_dir="$1" slug="$2" expr="$3"
+    jq -r "$expr" "$test_dir/docs/hosts/${slug}.json" 2>/dev/null
 }
 
 # --------------------------------------------------------------------------
@@ -61,7 +67,7 @@ TEST_DIR=$(setup_test_env)
 # Use --dry-run to test without git operations
 bash "$TEST_DIR/helpers/repos.sh" --dry-run --project-root "$TEST_DIR" "Quality" 2>/dev/null
 
-UPDATED_TS=$(jq '.repos[] | select(.name == "Quality") | .last_commit_ts' "$TEST_DIR/docs/repos.json")
+UPDATED_TS=$(host_field "$TEST_DIR" "Quality" '.last_commit_ts')
 if [ "$UPDATED_TS" -gt 1776265324 ] 2>/dev/null; then
     pass_test "success call updated last_commit_ts"
 else
@@ -69,7 +75,7 @@ else
 fi
 
 # Verify no failure fields exist
-FAILURE_TS=$(jq '.repos[] | select(.name == "Quality") | .last_failure_ts // empty' "$TEST_DIR/docs/repos.json")
+FAILURE_TS=$(host_field "$TEST_DIR" "Quality" '.last_failure_ts // empty')
 if [ -z "$FAILURE_TS" ]; then
     pass_test "success call does not add last_failure_ts"
 else
@@ -90,7 +96,7 @@ echo "Another line of errors" >> "$LOG_FILE"
 bash "$TEST_DIR/helpers/repos.sh" --dry-run --project-root "$TEST_DIR" "Quality" --failed --log "$LOG_FILE" 2>/dev/null
 
 # Check last_failure_ts was set
-FAILURE_TS=$(jq '.repos[] | select(.name == "Quality") | .last_failure_ts // empty' "$TEST_DIR/docs/repos.json")
+FAILURE_TS=$(host_field "$TEST_DIR" "Quality" '.last_failure_ts // empty')
 if [ -n "$FAILURE_TS" ] && [ "$FAILURE_TS" -gt 0 ] 2>/dev/null; then
     pass_test "--failed sets last_failure_ts ($FAILURE_TS)"
 else
@@ -98,7 +104,7 @@ else
 fi
 
 # Check last_failure_log was set
-FAILURE_LOG=$(jq -r '.repos[] | select(.name == "Quality") | .last_failure_log // empty' "$TEST_DIR/docs/repos.json")
+FAILURE_LOG=$(host_field "$TEST_DIR" "Quality" '.last_failure_log // empty')
 if [[ "$FAILURE_LOG" == logs/Quality/* ]]; then
     pass_test "--failed sets last_failure_log ($FAILURE_LOG)"
 else
@@ -118,7 +124,7 @@ else
 fi
 
 # Check last_commit_ts was NOT updated
-COMMIT_TS=$(jq '.repos[] | select(.name == "Quality") | .last_commit_ts' "$TEST_DIR/docs/repos.json")
+COMMIT_TS=$(host_field "$TEST_DIR" "Quality" '.last_commit_ts')
 if [ "$COMMIT_TS" -eq 1776265324 ]; then
     pass_test "--failed does not update last_commit_ts"
 else
@@ -133,7 +139,7 @@ TEST_DIR=$(setup_test_env)
 
 echo "stdin error log content" | bash "$TEST_DIR/helpers/repos.sh" --dry-run --project-root "$TEST_DIR" "Quality" --failed --log - 2>/dev/null
 
-FAILURE_LOG=$(jq -r '.repos[] | select(.name == "Quality") | .last_failure_log // empty' "$TEST_DIR/docs/repos.json")
+FAILURE_LOG=$(host_field "$TEST_DIR" "Quality" '.last_failure_log // empty')
 if [ -n "$FAILURE_LOG" ] && [ -f "$TEST_DIR/docs/$FAILURE_LOG" ]; then
     LOG_CONTENT=$(cat "$TEST_DIR/docs/$FAILURE_LOG")
     if [[ "$LOG_CONTENT" == *"stdin error log content"* ]]; then
@@ -154,12 +160,12 @@ LOG_FILE="$TMPDIR_BASE/run2.log"
 echo "test log" > "$LOG_FILE"
 
 # Test with colon in name (e.g., "ScoreClient:luke")
-cat > "$TEST_DIR/docs/repos.json" <<'ENDJSON'
-{"repos": [{"name": "ScoreClient:luke", "last_commit_ts": 1776265324}]}
+cat > "$TEST_DIR/docs/hosts/ScoreClient-luke.json" <<'ENDJSON'
+{"name": "ScoreClient:luke", "last_commit_ts": 1776265324}
 ENDJSON
 
 bash "$TEST_DIR/helpers/repos.sh" --dry-run --project-root "$TEST_DIR" "ScoreClient:luke" --failed --log "$LOG_FILE" 2>/dev/null
-FAILURE_LOG=$(jq -r '.repos[] | select(.name == "ScoreClient:luke") | .last_failure_log // empty' "$TEST_DIR/docs/repos.json")
+FAILURE_LOG=$(host_field "$TEST_DIR" "ScoreClient-luke" '.last_failure_log // empty')
 if [[ "$FAILURE_LOG" == logs/ScoreClient-luke/* ]]; then
     pass_test "colon sanitised to hyphen in slug"
 else
@@ -167,12 +173,12 @@ else
 fi
 
 # Test with spaces in name (e.g., "Vibe Coder:GRQ-23")
-cat > "$TEST_DIR/docs/repos.json" <<'ENDJSON'
-{"repos": [{"name": "Vibe Coder:GRQ-23", "last_commit_ts": 1776265324}]}
+cat > "$TEST_DIR/docs/hosts/Vibe-Coder-GRQ-23.json" <<'ENDJSON'
+{"name": "Vibe Coder:GRQ-23", "last_commit_ts": 1776265324}
 ENDJSON
 
 bash "$TEST_DIR/helpers/repos.sh" --dry-run --project-root "$TEST_DIR" "Vibe Coder:GRQ-23" --failed --log "$LOG_FILE" 2>/dev/null
-FAILURE_LOG=$(jq -r '.repos[] | select(.name == "Vibe Coder:GRQ-23") | .last_failure_log // empty' "$TEST_DIR/docs/repos.json")
+FAILURE_LOG=$(host_field "$TEST_DIR" "Vibe-Coder-GRQ-23" '.last_failure_log // empty')
 if [[ "$FAILURE_LOG" == logs/Vibe-Coder-GRQ-23/* ]]; then
     pass_test "spaces and colons sanitised in slug"
 else
@@ -249,14 +255,14 @@ echo "test" > "$LOG_FILE"
 
 bash "$TEST_DIR/helpers/repos.sh" --dry-run --project-root "$TEST_DIR" "Quality" --failed --log "$LOG_FILE" --exit-code 42 --message "3 shellcheck errors" 2>/dev/null
 
-EXIT_CODE=$(jq '.repos[] | select(.name == "Quality") | .last_failure_exit_code // empty' "$TEST_DIR/docs/repos.json")
+EXIT_CODE=$(host_field "$TEST_DIR" "Quality" '.last_failure_exit_code // empty')
 if [ "$EXIT_CODE" = "42" ]; then
     pass_test "--exit-code recorded correctly"
 else
     fail_test "--exit-code not recorded (got: $EXIT_CODE)"
 fi
 
-MESSAGE=$(jq -r '.repos[] | select(.name == "Quality") | .last_failure_message // empty' "$TEST_DIR/docs/repos.json")
+MESSAGE=$(host_field "$TEST_DIR" "Quality" '.last_failure_message // empty')
 if [ "$MESSAGE" = "3 shellcheck errors" ]; then
     pass_test "--message recorded correctly"
 else

--- a/tests/test-repos-push-final-attempt.sh
+++ b/tests/test-repos-push-final-attempt.sh
@@ -128,11 +128,11 @@ OUTPUT1=$(cd "$WORK1" && \
 # The host's health update must have reached the remote despite the remote
 # moving during the final backoff. On the unfixed code the final attempt
 # re-pushes a stale commit and fails, so the entry never lands.
-REMOTE1_JSON=$(cd "$REMOTE1" && git show "main:docs/repos.json" 2>/dev/null || echo "")
-if echo "$REMOTE1_JSON" | grep -q '"FinalAttemptRepo"'; then
+REMOTE1_HOST=$(cd "$REMOTE1" && git show "main:docs/hosts/FinalAttemptRepo.json" 2>/dev/null || echo "")
+if echo "$REMOTE1_HOST" | grep -q '"FinalAttemptRepo"'; then
     pass_test "Host update reached remote after remote moved during final backoff"
 else
-    fail_test "FinalAttemptRepo missing on remote. json='$REMOTE1_JSON' output: $OUTPUT1"
+    fail_test "FinalAttemptRepo missing on remote. host file='$REMOTE1_HOST' output: $OUTPUT1"
 fi
 
 # The concurrent commit that landed during the backoff must be preserved
@@ -213,15 +213,18 @@ OUTPUT2=$(cd "$WORK2" && GIT_PUSH_RETRY_DELAY_OVERRIDE=0 \
 
 (cd "$WORK2" && git fetch --quiet 2>/dev/null || true)
 
-# The host's update must reach the remote — it must NOT be silently dropped.
-REMOTE2_JSON=$(cd "$REMOTE2" && git show "main:docs/repos.json" 2>/dev/null || echo "")
-if echo "$REMOTE2_JSON" | grep -q '"ReappliedHost"'; then
+# Issue #140: the host's update lands in its own per-host file — it must NOT
+# be silently dropped after the rebase conflict.
+REMOTE2_HOST=$(cd "$REMOTE2" && git show "main:docs/hosts/ReappliedHost.json" 2>/dev/null || echo "")
+if echo "$REMOTE2_HOST" | grep -q '"ReappliedHost"'; then
     pass_test "Host update re-applied and pushed after rebase conflict (not dropped)"
 else
-    fail_test "ReappliedHost missing on remote — update was dropped. json='$REMOTE2_JSON' output: $OUTPUT2"
+    fail_test "ReappliedHost missing on remote — update was dropped. host file='$REMOTE2_HOST' output: $OUTPUT2"
 fi
 
-# The remote's competing commit must be preserved (we reset onto it, not over it).
+# The remote's competing repos.json commit must be preserved (we reset onto it,
+# not over it) — repos.sh no longer touches repos.json, so it stays intact.
+REMOTE2_JSON=$(cd "$REMOTE2" && git show "main:docs/repos.json" 2>/dev/null || echo "")
 REMOTE2_HAS_OTHER=$(echo "$REMOTE2_JSON" | grep -c '"Other"' || true)
 if [ "$REMOTE2_HAS_OTHER" -ge 1 ]; then
     pass_test "Remote competing repos.json entry preserved through recovery"

--- a/tests/test-repos-push-rebase.sh
+++ b/tests/test-repos-push-rebase.sh
@@ -131,13 +131,13 @@ else
     fail_test "Expected local and remote HEADs to match. local=$WORK_HEAD_AFTER remote=$REMOTE_HEAD_AFTER. Output: $OUTPUT"
 fi
 
-# repos.json on the remote should contain TestRepo entry (the local commit
-# survived the rebase and was pushed).
-REMOTE_REPOS_JSON=$(cd "${TEST1_BASE}/remote.git" && git show "main:docs/repos.json" 2>/dev/null || echo "")
-if echo "$REMOTE_REPOS_JSON" | grep -q '"TestRepo"'; then
+# Issue #140: the per-host file on the remote should contain the TestRepo
+# entry (the local commit survived the rebase and was pushed).
+REMOTE_HOST_JSON=$(cd "${TEST1_BASE}/remote.git" && git show "main:docs/hosts/TestRepo.json" 2>/dev/null || echo "")
+if echo "$REMOTE_HOST_JSON" | grep -q '"TestRepo"'; then
     pass_test "TestRepo entry is present on remote (push succeeded after rebase)"
 else
-    fail_test "TestRepo not found on remote. repos.json contents: $REMOTE_REPOS_JSON"
+    fail_test "TestRepo not found on remote. host file contents: $REMOTE_HOST_JSON"
 fi
 
 # remote_only.txt from the divergent commit must still exist (rebase didn't

--- a/tests/test-repos-status-line.sh
+++ b/tests/test-repos-status-line.sh
@@ -36,16 +36,13 @@ trap 'rm -rf "$TMPDIR_BASE"' EXIT
 
 setup_test_env() {
     local test_dir="$TMPDIR_BASE/test_$$_$RANDOM"
-    mkdir -p "$test_dir/docs" "$test_dir/helpers"
+    mkdir -p "$test_dir/docs/hosts" "$test_dir/helpers"
 
-    cat > "$test_dir/docs/repos.json" <<'ENDJSON'
+    # Issue #140: per-host file replaces the shared repos.json entry.
+    cat > "$test_dir/docs/hosts/Quality.json" <<'ENDJSON'
 {
-  "repos": [
-    {
-      "name": "Quality",
-      "last_commit_ts": 1776265324
-    }
-  ]
+  "name": "Quality",
+  "last_commit_ts": 1776265324
 }
 ENDJSON
 
@@ -66,8 +63,8 @@ TEST_DIR=$(setup_test_env)
 
 # Set last_commit_ts to now (so it falls inside the 1-hour window)
 NOW=$(date +%s)
-cat > "$TEST_DIR/docs/repos.json" <<ENDJSON
-{"repos": [{"name": "Quality", "last_commit_ts": ${NOW}}]}
+cat > "$TEST_DIR/docs/hosts/Quality.json" <<ENDJSON
+{"name": "Quality", "last_commit_ts": ${NOW}}
 ENDJSON
 
 STDERR_FILE="$TMPDIR_BASE/skip_stderr_$$"
@@ -87,8 +84,8 @@ echo "Test 2: existing-repo update -> status=updated reason=success..."
 TEST_DIR=$(setup_test_env)
 
 # last_commit_ts well in the past so rate-limit does not trigger
-cat > "$TEST_DIR/docs/repos.json" <<'ENDJSON'
-{"repos": [{"name": "Quality", "last_commit_ts": 1}]}
+cat > "$TEST_DIR/docs/hosts/Quality.json" <<'ENDJSON'
+{"name": "Quality", "last_commit_ts": 1}
 ENDJSON
 
 STDERR_FILE="$TMPDIR_BASE/upd_stderr_$$"
@@ -176,8 +173,8 @@ fi
 # --------------------------------------------------------------------------
 echo "Test 7: existing stdout messages preserved (back-compat)..."
 TEST_DIR=$(setup_test_env)
-cat > "$TEST_DIR/docs/repos.json" <<'ENDJSON'
-{"repos": [{"name": "Quality", "last_commit_ts": 1}]}
+cat > "$TEST_DIR/docs/hosts/Quality.json" <<'ENDJSON'
+{"name": "Quality", "last_commit_ts": 1}
 ENDJSON
 
 STDOUT_FILE="$TMPDIR_BASE/back_stdout_$$"
@@ -193,8 +190,8 @@ fi
 
 # Rate-limit skip stdout message is also preserved
 NOW=$(date +%s)
-cat > "$TEST_DIR/docs/repos.json" <<ENDJSON
-{"repos": [{"name": "Quality", "last_commit_ts": ${NOW}}]}
+cat > "$TEST_DIR/docs/hosts/Quality.json" <<ENDJSON
+{"name": "Quality", "last_commit_ts": ${NOW}}
 ENDJSON
 STDOUT_FILE="$TMPDIR_BASE/back2_stdout_$$"
 bash "$TEST_DIR/helpers/repos.sh" --dry-run --project-root "$TEST_DIR" "Quality" \
@@ -212,8 +209,8 @@ fi
 # --------------------------------------------------------------------------
 echo "Test 8: status line quotes repo name with spaces/colons..."
 TEST_DIR=$(setup_test_env)
-cat > "$TEST_DIR/docs/repos.json" <<'ENDJSON'
-{"repos": [{"name": "Vibe Coder:GRQ-23", "last_commit_ts": 1}]}
+cat > "$TEST_DIR/docs/hosts/Vibe-Coder-GRQ-23.json" <<'ENDJSON'
+{"name": "Vibe Coder:GRQ-23", "last_commit_ts": 1}
 ENDJSON
 
 STDERR_FILE="$TMPDIR_BASE/spaces_stderr_$$"


### PR DESCRIPTION
# PR Summary — Issue #140: per-host health files remove Develop-branch push contention

## Summary

Health tiles for slow/mobile, high-latency hosts (e.g. `Vibe Coder:GRQ-23`)
went **stale** because every host wrote its health to the single shared
`docs/repos.json` on one `Develop` branch. With ~19 hosts pushing to that one
file, a high-latency host lost the push race on every retry and its whole
update was dropped, so its `last_commit_ts` never advanced and the tile tripped
the staleness threshold.

This PR removes the contention by giving **each host its own artefact**:

- `helpers/repos.sh` now writes `docs/hosts/<slug>.json` (one object per host)
  instead of the shared `docs/repos.json`, and registers the host's slug in an
  **append-only** manifest `docs/hosts/index.json` (written only when a new host
  first appears, so an established fleet leaves it untouched).
- `docs/dashboard.js` and `docs/simple.html` fetch the manifest, load each
  per-host file, and **merge them at render time** (`mergeHostRecords`). They
  fall back to the legacy shared `docs/repos.json` when the manifest is absent
  (older deploys).
- The existing 25 entries in `docs/repos.json` were migrated into per-host files
  under `docs/hosts/`, preserving every config field (`warning_days`,
  `error_hours`, `business_days_only`, …). `docs/repos.json` is retained
  read-only as the dashboard fallback.

Because per-host files are single-writer, their commits rebase cleanly against
each other — no host's update is dropped on a content conflict, so a slow host
is no longer starved by fast ones. The existing push-retry/reapply machinery
(Issues #117/#139) is retained; the only shared file that can still conflict is
the rarely-touched manifest, handled by taking the remote copy then
re-registering this host's slug.

Closes #140.

## Evidence

This is primarily a backend/CLI + client-data-flow change. Playwright MCP was
not available in this environment, so evidence is captured via the data
pipeline and tests rather than a screenshot.

**End-to-end merge verified against a live static server** serving `docs/`
(replicating exactly what the browser does — fetch manifest → fetch each
per-host file → `mergeHostRecords`):

```
merged repos: 25
missing vs legacy: none
extra vs legacy: none
GRQ-23 record: {"error_hours":8,"last_commit_ts":1782876486,"name":"Vibe Coder:GRQ-23","warning_hours":4}
```

The per-host merge reproduces the exact same 25 repos (with config fields
intact) that the legacy `repos.json` produced, and the fallback path
(`manifest 404 → repos.json`) was verified to yield 25 repos too.

### Data flow

```mermaid
flowchart LR
    subgraph Hosts["Hosts writing concurrently to Develop"]
        A["Fast host<br/>repos.sh Score"] -->|writes only| FA["docs/hosts/Score.json"]
        B["Mobile host<br/>repos.sh Vibe Coder:GRQ-23"] -->|writes only| FB["docs/hosts/Vibe-Coder-GRQ-23.json"]
    end
    FA --> M["docs/hosts/index.json<br/>(append-only manifest)"]
    FB --> M
    M --> D["dashboard.js / simple.html<br/>fetch manifest + per-host files"]
    D -->|mergeHostRecords| T["Health tiles (no longer stale)"]
```

## Test Plan

- **New** `tests/test-per-host-health.sh` (8 assertions):
  - `repos.sh` writes `docs/hosts/<slug>.json` with the authoritative name and
    registers the slug in the manifest.
  - Two hosts get independent files and both appear in the manifest.
  - Re-running a known host does **not** duplicate the manifest entry
    (append-only, no shared-content churn).
  - Config fields (`warning_days`/`error_days`/`business_days_only`) survive a
    success update while `last_commit_ts` advances.
  - `mergeHostRecords` drops nulls/invalid records and de-duplicates by name
    (later record wins); returns `[]` for non-array input.
- **Adapted** existing `repos.sh` tests to assert on the per-host files
  (documented business-logic change — data moved from `docs/repos.json` to
  `docs/hosts/<slug>.json`):
  - `tests/test-repos-failure.sh` — failure fields, log capture, slug
    sanitisation, retention now read `docs/hosts/<slug>.json`.
  - `tests/test-repos-status-line.sh` — seeds host files; status-line
    (skipped/updated/added/…) semantics unchanged.
  - `tests/test-repos-push-rebase.sh` / `tests/test-repos-push-final-attempt.sh`
    — the push-retry/rebase/reapply machinery now lands the host's per-host
    file; the remote's competing `repos.json` commit is still preserved.
- `./quality.sh`: 54/55 passing. The single failure, `test-gitleaks-workflow`
  ("Missing gitleaks-action step or GITHUB_TOKEN env"), is **pre-existing and
  unrelated** — it fails identically on the clean base branch and touches no
  file in this PR.
- `shellcheck --severity=warning` clean on `helpers/repos.sh` and the new test.
- `dashboard.js` and `simple.html` inline scripts syntax-checked.

## Security self-check

- No secrets or hidden files staged; only `docs/hosts/*.json`, dashboard/HTML,
  `helpers/repos.sh`, tests, README, and version files.
- Per-host slug is derived by the existing `sanitise_task_slug` allowlist
  (alphanumeric/`-`/`_`); the dashboard `encodeURIComponent`s the slug before
  building the fetch URL, and repo names/fields remain HTML-escaped on render.
