### PR TITLE
Fail fast on protected-branch (GH006) heartbeat push rejections (Issue #143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ Because `Score.json` and `Vibe-Coder-GRQ-23.json` are different files, their
 commits rebase cleanly against each other — no host's update is dropped on a
 content conflict, so no tile goes stale from losing the push race.
 
+#### Protected-branch rejection is non-retryable (Issue #143):
+When the health heartbeat pushes to a **protected** branch and the host's
+GitHub account cannot bypass the required status checks, GitHub declines the
+push at the server hook with `GH006` (`protected branch hook declined` /
+`required status checks are expected`). This is **not** a transient conflict:
+every retry is rejected identically, so `helpers/repos.sh` detects the GH006
+signature via `grq_is_protected_branch_error` (`helpers/git-retry.sh`), stops
+after the **first** attempt instead of burning the full 5-attempt / ~80s retry
+budget, and emits a distinct status line:
+
+```text
+repos.sh status=failed reason=protected-branch name='Vibe Coder:GRQ-23'
+```
+
+The distinct `reason=protected-branch` lets the fleet tell a policy problem
+(the account needs bypass permission, or the health-data path needs exemption
+from the required checks — an admin decision) apart from an ordinary
+`reason=push-failed` contention/network failure.
+
 #### Version Management:
 - **Primary version**: Stored in `run.sh` VERSION variable
 - **Auto-sync**: `./update_version.sh` updates all HTML/JS files

--- a/docs/archive/pr-summaries/pr-summary-143.md
+++ b/docs/archive/pr-summaries/pr-summary-143.md
@@ -40,15 +40,29 @@ Closes #143.
 
 ## Evidence
 
-Backend/CLI change — no web UI to screenshot. Verified via the new automated
-test plus a confirmation that the test genuinely fails against the unfixed code
-(6 assertions fail: `reason=push-failed` and 5 push attempts) and passes after
-the fix (1 push attempt, `reason=protected-branch`).
+**Backend/CLI change — no web UI to screenshot.** The issue is labelled
+`needs-screenshot`, but the fix is entirely in the push path
+(`helpers/repos.sh` / `helpers/git-retry.sh`); the dashboard is unchanged apart
+from the routine version cache-buster, and a host rejected on the protected
+branch still classifies as *in error* on its tile — the mitigation changes *how
+fast the push gives up and how the failure is labelled*, not any pixel. Playwright
+MCP browser tools and a headless browser binary were both unavailable in this
+run, so — per the Error Recovery "Screenshot failures" guidance — evidence is
+the automated test suite plus a live CLI demonstration rather than a screenshot.
+The static dashboard was served locally (`helpers/server.ts`) and confirmed to
+still render (`<title>GRQ Health Status</title>`, version `1.1.19`).
 
-New status line on a protected-branch rejection:
+Captured test + live-run output:
+[`docs/evidence/issue-143-protected-branch-test-output.txt`](../../evidence/issue-143-protected-branch-test-output.txt)
+
+Live run of `repos.sh` against a `git` shim that declines every push with the
+GH006 signature — one attempt, distinct reason, non-zero exit:
 
 ```text
+Warning: git push failed (attempt 1/5): remote: error: GH006: Protected branch update failed ...
+ERROR: git push rejected by protected branch (GH006) after 1 attempt(s); required status checks cannot be bypassed by this account
 repos.sh status=failed reason=protected-branch name='Vibe Coder:GRQ-23'
+Total git push attempts made: 1 (fail-fast = 1, not 5)
 ```
 
 Retry behaviour before vs after:

--- a/docs/archive/pr-summaries/pr-summary-143.md
+++ b/docs/archive/pr-summaries/pr-summary-143.md
@@ -1,0 +1,82 @@
+## Summary
+
+The fleet's end-of-run health heartbeat (`helpers/repos.sh "Vibe Coder:<host>"`)
+pushes directly to the protected branch. A host whose GitHub account has only
+**`write`** permission cannot bypass the branch's required status checks, so
+GitHub declines the push at the server hook with `GH006`
+(`protected branch hook declined` / `required status checks are expected`).
+This is **not** a transient conflict — every retry is rejected identically — yet
+the old code burned the full 5-attempt / ~80s retry budget every cycle and then
+reported the generic `reason=push-failed`, indistinguishable from ordinary
+`docs/repos.json` contention or a network blip.
+
+This change adds the **code mitigation** the issue explicitly requested: detect
+the GH006 signature as a **non-retryable** outcome, fail fast after the first
+attempt, and report a distinct `reason=protected-branch` status line so a policy
+problem is told apart from ordinary contention.
+
+- `helpers/git-retry.sh` — new `grq_is_protected_branch_error` classifies
+  GH006 / `protected branch hook declined` / `required status check` stderr as
+  a protected-branch rejection.
+- `helpers/repos.sh` — the push retry loop stops immediately on a
+  protected-branch rejection (no rebase+retry, which cannot help) and the exit
+  status line carries `reason=protected-branch` instead of `push-failed`. The
+  run still exits non-zero so the failure remains observable, and the local
+  clone is still reset to the remote.
+- `README.md` — documents the non-retryable protected-branch behaviour.
+- Version bumped `1.1.18` → `1.1.19` (`run.sh` + synced dashboard assets).
+
+**Scope note (admin/policy decision remains):** the mitigation makes the
+failure fast and clearly labelled; it does **not** make write-only heartbeats
+land. Choosing where the heartbeat lands — candidate fixes in the issue:
+(1) grant the health-writer accounts bypass on the protected branch,
+(2) exempt the `docs/hosts/**` + `docs/repos.json` path from the required
+status checks, or (3) publish health data off the protected branch — is an
+admin-only branch-protection decision that cannot be made in code. The distinct
+`reason=protected-branch` signal is what lets operators recognise when that
+decision is needed.
+
+Closes #143.
+
+## Evidence
+
+Backend/CLI change — no web UI to screenshot. Verified via the new automated
+test plus a confirmation that the test genuinely fails against the unfixed code
+(6 assertions fail: `reason=push-failed` and 5 push attempts) and passes after
+the fix (1 push attempt, `reason=protected-branch`).
+
+New status line on a protected-branch rejection:
+
+```text
+repos.sh status=failed reason=protected-branch name='Vibe Coder:GRQ-23'
+```
+
+Retry behaviour before vs after:
+
+```mermaid
+flowchart TD
+    P[git push to protected branch] --> R{stderr matches GH006 /<br/>protected branch hook declined?}
+    R -->|No| B[backoff + fetch/rebase, retry<br/>up to 5 attempts]
+    R -->|Yes<br/>Issue #143| F[stop after 1st attempt<br/>reason=protected-branch<br/>exit non-zero]
+    B --> E[reason=push-failed after ~80s]
+```
+
+## Test Plan
+
+- Added `tests/test-repos-protected-branch.sh`:
+  - **Part A** — `grq_is_protected_branch_error` unit coverage: detects the full
+    GH006 reproduction, the `protected branch hook declined` phrasing, and the
+    `required status checks are expected` phrasing (happy path); does **not**
+    match a non-fast-forward rejection, empty stderr, or a rate-limit message
+    (error/edge paths).
+  - **Part B** — integration: a mock `git` shim declines every push with the
+    GH006 signature; asserts `repos.sh` makes exactly **1** push attempt (no
+    retry), emits `reason=protected-branch`, does **not** emit
+    `reason=push-failed`, and exits non-zero.
+- Regression evidence: the new test fails (6/10 assertions) against the pre-fix
+  code and passes (10/10) after the fix.
+- Existing related suites still pass: `test-push-retry.sh`,
+  `test-repos-push-final-attempt.sh`, `test-repos-status-line.sh`.
+- `./quality.sh` — all suites pass except the pre-existing, unrelated
+  `test-gitleaks-workflow` failure (missing gitleaks-action step in the
+  workflow YAML), which is untouched by this change.

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.18";
+const VERSION = "1.1.19";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;

--- a/docs/evidence/issue-143-protected-branch-test-output.txt
+++ b/docs/evidence/issue-143-protected-branch-test-output.txt
@@ -1,0 +1,38 @@
+Testing Issue #143: protected-branch (GH006) push is non-retryable
+=================================================================
+
+Part A: grq_is_protected_branch_error classification...
+  PASS: Detects the GH006 protected-branch rejection
+  PASS: Detects 'protected branch hook declined'
+  PASS: Detects 'required status checks are expected'
+  PASS: Non-fast-forward rejection is NOT classified as protected-branch
+  PASS: Empty stderr is not classified as protected-branch
+  PASS: Rate-limit message is not classified as protected-branch
+
+Part B: repos.sh fails fast with reason=protected-branch...
+  PASS: Protected-branch rejection stopped after a single push attempt (no retry)
+  PASS: Status line reports reason=protected-branch
+  PASS: Did not report the generic reason=push-failed
+  PASS: repos.sh exits non-zero on a protected-branch rejection
+
+Results: 10 passed, 0 failed
+===== Live demonstration: repos.sh against a GH006-rejecting remote =====
+Added repo 'Vibe Coder:GRQ-23' with timestamp 1782986915
+Warning: git push failed (attempt 1/5): remote: error: GH006: Protected branch update failed for refs/heads/main.
+remote: - 4 of 4 required status checks are expected.
+ ! [remote rejected]     main -> main (protected branch hook declined)
+Error: push rejected by protected branch (GH006); this account cannot bypass the required status checks. Not retrying.
+ERROR: git push rejected by protected branch (GH006) after 1 attempt(s); required status checks cannot be bypassed by this account
+Last git push stderr:
+  remote: error: GH006: Protected branch update failed for refs/heads/main.
+  remote: - 4 of 4 required status checks are expected.
+   ! [remote rejected]     main -> main (protected branch hook declined)
+Branch status (git status --porcelain=v2 --branch):
+  # branch.oid 2b90dcbef7b8d813177d39d99ffa21c203a7bbfe
+  # branch.head main
+  # branch.upstream origin/main
+  # branch.ab +1 -0
+HEAD is now at f2c3a00 init
+Info: reset local clone to origin/main and cleaned working tree
+repos.sh status=failed reason=protected-branch name='Vibe Coder:GRQ-23'
+Total git push attempts made: 1 (fail-fast = 1, not 5)

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.18" rel="stylesheet">
+    <link href="./styles.css?v=1.1.19" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -107,14 +107,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.18"></script>
+    <script src="./dashboard.js?v=1.1.19"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.18')
+                navigator.serviceWorker.register('./sw.js?v=1.1.19')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.18
+// Version: 1.1.19
 
-const CACHE_NAME = 'grq-health-v1.1.18';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.18';
+const CACHE_NAME = 'grq-health-v1.1.19';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.19';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.18',
+  './dashboard.js?v=1.1.19',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/helpers/git-retry.sh
+++ b/helpers/git-retry.sh
@@ -22,6 +22,15 @@
 #                              the text matches a non-fast-forward / "fetch
 #                              first" push rejection (the expected outcome of a
 #                              concurrent push to the shared branch; #2754).
+#   grq_is_protected_branch_error — given stderr text on stdin, returns 0 if
+#                              the text matches a protected-branch rejection
+#                              (GH006 / "protected branch hook declined" /
+#                              "required status checks are expected"; #143).
+#                              This is NON-retryable: a write-only fleet account
+#                              cannot bypass required status checks, so every
+#                              retry fails identically. Callers fail fast with a
+#                              distinct reason=protected-branch instead of
+#                              burning the full retry budget every cycle.
 #   grq_rate_limit_sleep_secs — when called after a detected rate limit,
 #                              echoes how many seconds to sleep before the
 #                              next attempt. Honours
@@ -108,6 +117,19 @@ grq_is_rate_limit_error() {
 # (true) when the text looks like a non-fast-forward rejection, 1 otherwise.
 grq_is_non_fast_forward_error() {
     grep -Eiq "\[rejected\]|fetch first|non-fast-forward|updates were rejected|tip of your current branch is behind"
+}
+
+# Detect a protected-branch push rejection in arbitrary stderr text on stdin.
+# GitHub declines the push at the server hook with GH006 when the account
+# lacks permission to bypass the branch's required status checks / pull-request
+# rules. Unlike a non-fast-forward rejection, this is NOT recoverable by
+# fetch+rebase+retry — a write-only fleet account (Issue #143) will be rejected
+# identically on every one of the 5 attempts, burning ~80s of retry budget each
+# cycle. Callers treat a match as a terminal, non-retryable outcome and fail
+# fast with reason=protected-branch. Returns 0 (true) on a protected-branch
+# rejection, 1 otherwise.
+grq_is_protected_branch_error() {
+    grep -Eiq "GH006|protected branch (update failed|hook declined)|required status check|cannot force-update the branch|changes must be made through a pull request"
 }
 
 # Compute how long to sleep when a rate-limit response was detected.

--- a/helpers/repos.sh
+++ b/helpers/repos.sh
@@ -28,7 +28,11 @@ set -euo pipefail
 #     repos.sh status=<status> reason=<reason> name='<repo_name>'
 #   Statuses: skipped | updated | added | failed-recorded | failed | unknown
 #   Reasons : rate-limited | success | failure-recorded | push-failed |
-#             validation-failed | unknown
+#             protected-branch | validation-failed | unknown
+#   The protected-branch reason (Issue #143) marks a non-retryable GH006
+#   rejection: the host's account cannot bypass the required status checks on
+#   the protected branch, so the push is abandoned after the first attempt
+#   instead of exhausting the retry budget.
 #   Callers that suppress stdout (e.g. runWithTimeout(..., { quiet: true }))
 #   can capture stderr to distinguish pushed/skipped/failed outcomes
 #   without parsing localised user-facing messages.
@@ -626,6 +630,9 @@ reapply_health_update() {
 # observable. If an update genuinely cannot be re-applied it is surfaced as a
 # non-fatal status=update-dropped rather than masked as success.
 PUSH_FINAL_STATUS=0
+# Issue #143: the reason reported when the push ultimately fails. Defaults to
+# push-failed; a protected-branch (GH006) rejection overrides it below.
+PUSH_FINAL_REASON="push-failed"
 UPDATE_DROPPED=false
 if [ "$STAGED_SOMETHING" = true ]; then
     if ! git diff --cached --quiet 2>/dev/null; then
@@ -643,6 +650,10 @@ if [ "$STAGED_SOMETHING" = true ]; then
             GIT_PUSH_MAX_ATTEMPTS=$(grq_max_push_attempts 2>/dev/null || echo 5)
             LEGACY_DELAY="${GIT_PUSH_RETRY_DELAY_OVERRIDE:-}"
             GIT_PUSH_SUCCESS=false
+            # Issue #143: set true when the push is rejected by a protected
+            # branch (GH006). This is non-retryable, so we stop immediately
+            # and report a distinct reason=protected-branch.
+            PROTECTED_BRANCH_REJECTED=false
             LAST_PUSH_STDERR=""
             PUSH_STDERR_FILE=$(mktemp 2>/dev/null || echo "/tmp/repos_push_stderr.$$")
 
@@ -705,6 +716,17 @@ if [ "$STAGED_SOMETHING" = true ]; then
                 LAST_PUSH_STDERR=$(cat "$PUSH_STDERR_FILE" 2>/dev/null || echo "")
                 echo "Warning: git push failed (attempt ${attempt}/${GIT_PUSH_MAX_ATTEMPTS}): ${LAST_PUSH_STDERR}"
 
+                # Issue #143: a protected-branch rejection (GH006) is NOT
+                # recoverable by rebase+retry — a write-only fleet account will
+                # be declined identically on every attempt. Stop immediately and
+                # flag it so the failure is reported as reason=protected-branch
+                # instead of burning the full 5-attempt / ~80s retry budget.
+                if echo "$LAST_PUSH_STDERR" | grq_is_protected_branch_error; then
+                    echo "Error: push rejected by protected branch (GH006); this account cannot bypass the required status checks. Not retrying."
+                    PROTECTED_BRANCH_REJECTED=true
+                    break
+                fi
+
                 # No further attempts remain — stop. The freshest rebase+push
                 # already happened on this final attempt (defect 1 fix).
                 if [ "$attempt" -ge "$GIT_PUSH_MAX_ATTEMPTS" ]; then
@@ -736,7 +758,13 @@ if [ "$STAGED_SOMETHING" = true ]; then
             done
 
             if [ "$GIT_PUSH_SUCCESS" = false ] && [ "$UPDATE_DROPPED" = false ]; then
-                echo "ERROR: git push failed after ${GIT_PUSH_MAX_ATTEMPTS} attempts"
+                if [ "$PROTECTED_BRANCH_REJECTED" = true ]; then
+                    # Issue #143: non-retryable protected-branch rejection.
+                    PUSH_FINAL_REASON="protected-branch"
+                    echo "ERROR: git push rejected by protected branch (GH006) after ${attempt} attempt(s); required status checks cannot be bypassed by this account"
+                else
+                    echo "ERROR: git push failed after ${GIT_PUSH_MAX_ATTEMPTS} attempts"
+                fi
                 if [ -n "$LAST_PUSH_STDERR" ]; then
                     echo "Last git push stderr:"
                     echo "$LAST_PUSH_STDERR" | sed 's/^/  /'
@@ -781,7 +809,9 @@ set -euo pipefail
 # Surface push failure as a non-zero exit so the worker can observe it.
 if [ "$PUSH_FINAL_STATUS" -ne 0 ]; then
     RUN_STATUS="failed"
-    RUN_REASON="push-failed"
+    # Issue #143: distinguish a non-retryable protected-branch (GH006)
+    # rejection from a generic exhausted-retries push failure.
+    RUN_REASON="${PUSH_FINAL_REASON:-push-failed}"
     exit "$PUSH_FINAL_STATUS"
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ fi
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.18"
+VERSION="1.1.19"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/test-repos-protected-branch.sh
+++ b/tests/test-repos-protected-branch.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+# Test for Issue #143: a protected-branch (GH006) push rejection is a
+# non-retryable outcome.
+#
+# A write-only fleet account cannot bypass the required status checks on the
+# protected branch, so every one of the 5 push attempts is declined
+# identically — burning ~80s of retry budget every cycle. The fix detects the
+# GH006 / "protected branch hook declined" / "required status checks are
+# expected" signature and:
+#   1. stops after the FIRST push attempt (no retry), and
+#   2. reports a distinct status line reason=protected-branch instead of the
+#      generic push-failed.
+#
+# Two layers are covered:
+#   Part A — grq_is_protected_branch_error() classifies stderr correctly
+#            (happy path, non-matching error path, edge cases).
+#   Part B — helpers/repos.sh fails fast with reason=protected-branch and does
+#            NOT exhaust the retry budget when the remote declines the push.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOS_SCRIPT="$SCRIPT_DIR/../helpers/repos.sh"
+GIT_RETRY_LIB="$SCRIPT_DIR/../helpers/git-retry.sh"
+
+# shellcheck disable=SC1090
+. "$GIT_RETRY_LIB"
+
+echo "Testing Issue #143: protected-branch (GH006) push is non-retryable"
+echo "================================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+export GIT_AUTHOR_NAME="Test"
+export GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="Test"
+export GIT_COMMITTER_EMAIL="test@example.com"
+
+# --------------------------------------------------------------------------
+# Part A: grq_is_protected_branch_error classification
+# --------------------------------------------------------------------------
+echo "Part A: grq_is_protected_branch_error classification..."
+
+# Happy path — the exact GH006 signature from the live reproduction.
+GH006_STDERR='remote: error: GH006: Protected branch update failed for refs/heads/Develop.
+remote: - 4 of 4 required status checks are expected.
+ ! [remote rejected]     Develop -> Develop (protected branch hook declined)
+error: failed to push some refs'
+
+if echo "$GH006_STDERR" | grq_is_protected_branch_error; then
+    pass_test "Detects the GH006 protected-branch rejection"
+else
+    fail_test "Failed to detect GH006 protected-branch rejection"
+fi
+
+# Detect the "protected branch hook declined" phrasing on its own.
+if echo "protected branch hook declined" | grq_is_protected_branch_error; then
+    pass_test "Detects 'protected branch hook declined'"
+else
+    fail_test "Failed to detect 'protected branch hook declined'"
+fi
+
+# Detect the required-status-checks phrasing on its own.
+if echo "4 of 4 required status checks are expected" | grq_is_protected_branch_error; then
+    pass_test "Detects 'required status checks are expected'"
+else
+    fail_test "Failed to detect 'required status checks are expected'"
+fi
+
+# Error path — a non-fast-forward rejection is a DIFFERENT, retryable outcome
+# and must NOT be misclassified as a protected-branch rejection.
+NFF_STDERR=' ! [rejected]        Develop -> Develop (fetch first)
+error: failed to push some refs to origin
+hint: Updates were rejected because the remote contains work that you do not have'
+if echo "$NFF_STDERR" | grq_is_protected_branch_error; then
+    fail_test "Non-fast-forward rejection wrongly classified as protected-branch"
+else
+    pass_test "Non-fast-forward rejection is NOT classified as protected-branch"
+fi
+
+# Edge case — empty stderr must not match.
+if echo "" | grq_is_protected_branch_error; then
+    fail_test "Empty stderr wrongly classified as protected-branch"
+else
+    pass_test "Empty stderr is not classified as protected-branch"
+fi
+
+# Edge case — a plain rate-limit message must not match.
+if echo "You have exceeded a secondary rate limit" | grq_is_protected_branch_error; then
+    fail_test "Rate-limit message wrongly classified as protected-branch"
+else
+    pass_test "Rate-limit message is not classified as protected-branch"
+fi
+
+# --------------------------------------------------------------------------
+# Part B: repos.sh fails fast (no retries) with reason=protected-branch
+# --------------------------------------------------------------------------
+echo ""
+echo "Part B: repos.sh fails fast with reason=protected-branch..."
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+REMOTE="${TMPDIR_BASE}/remote.git"
+UPSTREAM="${TMPDIR_BASE}/upstream"
+WORK="${TMPDIR_BASE}/work"
+
+git init --bare --initial-branch=main "$REMOTE" >/dev/null 2>&1
+git clone --quiet "$REMOTE" "$UPSTREAM" >/dev/null 2>&1
+mkdir -p "$UPSTREAM/docs" "$UPSTREAM/helpers"
+echo '{"repos": []}' > "$UPSTREAM/docs/repos.json"
+cp "$REPOS_SCRIPT" "$UPSTREAM/helpers/repos.sh"
+cp "$GIT_RETRY_LIB" "$UPSTREAM/helpers/git-retry.sh"
+chmod +x "$UPSTREAM/helpers/repos.sh" "$UPSTREAM/helpers/git-retry.sh"
+(
+    cd "$UPSTREAM"
+    git add docs helpers >/dev/null 2>&1
+    git commit -m "initial" --quiet >/dev/null 2>&1
+    git push --quiet origin HEAD:main >/dev/null 2>&1
+)
+
+git clone --quiet "$REMOTE" "$WORK" >/dev/null 2>&1
+(
+    cd "$WORK"
+    git checkout -q main
+    git config pull.ff only
+)
+
+# Mock git shim: every `git push` is declined with the GH006 signature and the
+# invocation is counted. All other git subcommands delegate to the real git so
+# staging, commit, fetch and rebase behave normally.
+SHIM_DIR="${TMPDIR_BASE}/shim"
+mkdir -p "$SHIM_DIR"
+PUSH_COUNT_FILE="${TMPDIR_BASE}/push_count"
+echo "0" > "$PUSH_COUNT_FILE"
+REAL_GIT=$(command -v git)
+
+cat > "${SHIM_DIR}/git" <<MOCKEOF
+#!/bin/bash
+PUSH_COUNT_FILE="${PUSH_COUNT_FILE}"
+REAL_GIT="${REAL_GIT}"
+# Find the git subcommand, skipping any leading global -c/-C options.
+sub=""
+for a in "\$@"; do
+    case "\$a" in
+        -*) continue ;;
+        *) sub="\$a"; break ;;
+    esac
+done
+if [ "\$sub" = "push" ]; then
+    count=\$(cat "\$PUSH_COUNT_FILE")
+    count=\$((count + 1))
+    echo "\$count" > "\$PUSH_COUNT_FILE"
+    {
+        echo "remote: error: GH006: Protected branch update failed for refs/heads/main."
+        echo "remote: - 4 of 4 required status checks are expected."
+        echo " ! [remote rejected]     main -> main (protected branch hook declined)"
+        echo "error: failed to push some refs to origin"
+    } >&2
+    exit 1
+fi
+exec "\$REAL_GIT" "\$@"
+MOCKEOF
+chmod +x "${SHIM_DIR}/git"
+
+set +e
+OUTPUT=$(cd "$WORK" && \
+    PATH="${SHIM_DIR}:$PATH" \
+    GIT_PUSH_RETRY_DELAY_OVERRIDE=0 \
+    ./helpers/repos.sh "GRQ-23" --skip-rate-limit --project-root "$WORK" 2>&1)
+REPOS_EXIT=$?
+set -e
+
+FINAL_PUSH_COUNT=$(cat "$PUSH_COUNT_FILE")
+
+# Only ONE push attempt should have been made — the GH006 rejection is
+# non-retryable, so the loop must stop immediately.
+if [ "$FINAL_PUSH_COUNT" -eq 1 ]; then
+    pass_test "Protected-branch rejection stopped after a single push attempt (no retry)"
+else
+    fail_test "Expected exactly 1 push attempt, got: $FINAL_PUSH_COUNT. Output: $OUTPUT"
+fi
+
+# The status line must carry the distinct reason=protected-branch.
+if echo "$OUTPUT" | grep -q "reason=protected-branch"; then
+    pass_test "Status line reports reason=protected-branch"
+else
+    fail_test "Expected reason=protected-branch in status line. Output: $OUTPUT"
+fi
+
+# It must NOT masquerade as the generic push-failed reason.
+if echo "$OUTPUT" | grep -q "reason=push-failed"; then
+    fail_test "Protected-branch rejection wrongly reported as reason=push-failed. Output: $OUTPUT"
+else
+    pass_test "Did not report the generic reason=push-failed"
+fi
+
+# The run must still exit non-zero so the failure is observable.
+if [ "$REPOS_EXIT" -ne 0 ]; then
+    pass_test "repos.sh exits non-zero on a protected-branch rejection"
+else
+    fail_test "Expected non-zero exit, got: $REPOS_EXIT. Output: $OUTPUT"
+fi
+
+# Summary
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The fleet's end-of-run health heartbeat (`helpers/repos.sh "Vibe Coder:<host>"`)
pushes directly to the protected branch. A host whose GitHub account has only
**`write`** permission cannot bypass the branch's required status checks, so
GitHub declines the push at the server hook with `GH006`
(`protected branch hook declined` / `required status checks are expected`).
This is **not** a transient conflict — every retry is rejected identically — yet
the old code burned the full 5-attempt / ~80s retry budget every cycle and then
reported the generic `reason=push-failed`, indistinguishable from ordinary
`docs/repos.json` contention or a network blip.

This change adds the **code mitigation** the issue explicitly requested: detect
the GH006 signature as a **non-retryable** outcome, fail fast after the first
attempt, and report a distinct `reason=protected-branch` status line so a policy
problem is told apart from ordinary contention.

- `helpers/git-retry.sh` — new `grq_is_protected_branch_error` classifies
  GH006 / `protected branch hook declined` / `required status check` stderr as
  a protected-branch rejection.
- `helpers/repos.sh` — the push retry loop stops immediately on a
  protected-branch rejection (no rebase+retry, which cannot help) and the exit
  status line carries `reason=protected-branch` instead of `push-failed`. The
  run still exits non-zero so the failure remains observable, and the local
  clone is still reset to the remote.
- `README.md` — documents the non-retryable protected-branch behaviour.
- Version bumped `1.1.18` → `1.1.19` (`run.sh` + synced dashboard assets).

**Scope note (admin/policy decision remains):** the mitigation makes the
failure fast and clearly labelled; it does **not** make write-only heartbeats
land. Choosing where the heartbeat lands — candidate fixes in the issue:
(1) grant the health-writer accounts bypass on the protected branch,
(2) exempt the `docs/hosts/**` + `docs/repos.json` path from the required
status checks, or (3) publish health data off the protected branch — is an
admin-only branch-protection decision that cannot be made in code. The distinct
`reason=protected-branch` signal is what lets operators recognise when that
decision is needed.

Closes #143.

## Evidence

**Backend/CLI change — no web UI to screenshot.** The issue is labelled
`needs-screenshot`, but the fix is entirely in the push path
(`helpers/repos.sh` / `helpers/git-retry.sh`); the dashboard is unchanged apart
from the routine version cache-buster, and a host rejected on the protected
branch still classifies as *in error* on its tile — the mitigation changes *how
fast the push gives up and how the failure is labelled*, not any pixel. Playwright
MCP browser tools and a headless browser binary were both unavailable in this
run, so — per the Error Recovery "Screenshot failures" guidance — evidence is
the automated test suite plus a live CLI demonstration rather than a screenshot.
The static dashboard was served locally (`helpers/server.ts`) and confirmed to
still render (`<title>GRQ Health Status</title>`, version `1.1.19`).

Captured test + live-run output:
[`docs/evidence/issue-143-protected-branch-test-output.txt`](../../evidence/issue-143-protected-branch-test-output.txt)

Live run of `repos.sh` against a `git` shim that declines every push with the
GH006 signature — one attempt, distinct reason, non-zero exit:

```text
Warning: git push failed (attempt 1/5): remote: error: GH006: Protected branch update failed ...
ERROR: git push rejected by protected branch (GH006) after 1 attempt(s); required status checks cannot be bypassed by this account
repos.sh status=failed reason=protected-branch name='Vibe Coder:GRQ-23'
Total git push attempts made: 1 (fail-fast = 1, not 5)
```

Retry behaviour before vs after:

```mermaid
flowchart TD
    P[git push to protected branch] --> R{stderr matches GH006 /<br/>protected branch hook declined?}
    R -->|No| B[backoff + fetch/rebase, retry<br/>up to 5 attempts]
    R -->|Yes<br/>Issue #143| F[stop after 1st attempt<br/>reason=protected-branch<br/>exit non-zero]
    B --> E[reason=push-failed after ~80s]
```

## Test Plan

- Added `tests/test-repos-protected-branch.sh`:
  - **Part A** — `grq_is_protected_branch_error` unit coverage: detects the full
    GH006 reproduction, the `protected branch hook declined` phrasing, and the
    `required status checks are expected` phrasing (happy path); does **not**
    match a non-fast-forward rejection, empty stderr, or a rate-limit message
    (error/edge paths).
  - **Part B** — integration: a mock `git` shim declines every push with the
    GH006 signature; asserts `repos.sh` makes exactly **1** push attempt (no
    retry), emits `reason=protected-branch`, does **not** emit
    `reason=push-failed`, and exits non-zero.
- Regression evidence: the new test fails (6/10 assertions) against the pre-fix
  code and passes (10/10) after the fix.
- Existing related suites still pass: `test-push-retry.sh`,
  `test-repos-push-final-attempt.sh`, `test-repos-status-line.sh`.
- `./quality.sh` — all suites pass except the pre-existing, unrelated
  `test-gitleaks-workflow` failure (missing gitleaks-action step in the
  workflow YAML), which is untouched by this change.
