### PR TITLE
Suppress punycode deprecation in Pages deploy (Issue #146)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,20 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Suppress the Node punycode DEP0040 deprecation warning emitted from
+    # within the GitHub-provided actions (issue #146). We are already on the
+    # latest actions/deploy-pages (v5.0.0); the warning originates in that
+    # external action's bundled dependencies, so we silence it at the Node
+    # runtime via --no-deprecation rather than patching an external action.
+    env:
+      NODE_OPTIONS: --no-deprecation
+    # Declare the canonical github-pages deployment environment recommended by
+    # GitHub for actions/deploy-pages. This makes the deployment observable
+    # (surfaces the published page URL) and is the supported configuration for
+    # Pages deployments.
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/archive/pr-summaries/pr-summary-146.md
+++ b/docs/archive/pr-summaries/pr-summary-146.md
@@ -1,0 +1,69 @@
+# Fix Node punycode deprecation warning in Pages deploy (Issue #146)
+
+## Summary
+
+The GitHub Pages deploy workflow logged a Node `[DEP0040]` deprecation warning
+(`The 'punycode' module is deprecated`) and intermittently failed with
+`Error: Deployment failed, try again later.`
+
+The `punycode` deprecation is emitted by Node from **inside** the
+GitHub-provided `actions/deploy-pages` action. That action is an external
+dependency (`actions/*`, not `stSoftwareAU/*`) and is already pinned to the
+latest release (`v5.0.0` — SHA `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128`), so
+the warning cannot be patched at the action's source from this repo. Instead we
+silence it at the Node runtime with `NODE_OPTIONS: --no-deprecation` on the
+deploy job, which is the supported way to suppress third-party deprecation
+noise.
+
+We also add the canonical `environment: github-pages` declaration that GitHub
+recommends for `actions/deploy-pages`. This is the supported configuration for
+Pages deployments and surfaces the published page URL, making deploys more
+observable — a robustness improvement for the transient
+"Deployment failed, try again later" symptom.
+
+No repository source code changed — this is a CI workflow configuration fix.
+
+Closes #146.
+
+## Changes
+
+- `.github/workflows/deploy.yml`
+  - Add job-level `env: NODE_OPTIONS: --no-deprecation` to suppress the
+    punycode `DEP0040` warning from the pinned GitHub actions.
+  - Add job-level `environment: github-pages` (with the deployment `page_url`)
+    per GitHub's supported Pages deploy configuration.
+- `tests/test-deploy-deprecation-fix.sh` — new test.
+
+```mermaid
+flowchart LR
+    A[push to docs/**] --> B[deploy job]
+    B --> C{NODE_OPTIONS=--no-deprecation}
+    C --> D[Setup Pages]
+    D --> E[Upload artifact]
+    E --> F[Deploy to GitHub Pages]
+    F --> G[environment: github-pages<br/>url = page_url]
+```
+
+## Evidence
+
+This is a CI/workflow-only change with no web UI to screenshot. Verification is
+via the new test plus YAML validation:
+
+- New test `tests/test-deploy-deprecation-fix.sh` parses `deploy.yml` with a
+  real YAML parser and asserts on the parsed structure (not raw text):
+  - `jobs.deploy.env.NODE_OPTIONS` requests `--no-deprecation`.
+  - `jobs.deploy.environment.name` is `github-pages`.
+  - `jobs.deploy.environment.url` references
+    `steps.deployment.outputs.page_url`.
+- The pre-existing `tests/test-deploy-workflow-pinned.sh` still passes, so SHA
+  pinning and version comments remain intact.
+
+## Test Plan
+
+- Added `tests/test-deploy-deprecation-fix.sh` (5 assertions, all pass).
+- Confirmed it fails against the unfixed workflow (3 failing assertions) and
+  passes after the fix — a genuine regression test.
+- Ran `./quality.sh`: the two remaining failures
+  (`test-gitleaks-workflow`, `test-version-consistency`) are pre-existing on a
+  clean checkout and unrelated to this change (verified by stashing the change
+  and re-running both — they fail without it).

--- a/tests/test-deploy-deprecation-fix.sh
+++ b/tests/test-deploy-deprecation-fix.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Test for Issue #146: fix the Node punycode DEP0040 deprecation warning and
+# harden the GitHub Pages deployment.
+#
+# The deprecation warning originates inside the GitHub-provided
+# actions/deploy-pages action (external dependency, already pinned to the
+# latest v5.0.0), so it cannot be patched here. We silence it at the Node
+# runtime with `--no-deprecation` via NODE_OPTIONS, and we add the canonical
+# `environment: github-pages` declaration recommended by GitHub for the deploy
+# action to make deployments more observable/reliable.
+#
+# The test parses the workflow YAML with a real parser and asserts on the
+# resulting structure rather than grepping raw text.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_FILE="$SCRIPT_DIR/../.github/workflows/deploy.yml"
+
+echo "Testing Issue #146: deploy.yml deprecation suppression"
+echo "======================================================"
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail_test() { echo "  FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# Test 1: workflow file exists
+if [ -f "$WORKFLOW_FILE" ]; then
+    pass_test "deploy.yml exists at .github/workflows/deploy.yml"
+else
+    fail_test "deploy.yml is missing from .github/workflows/"
+    echo ""
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    exit 1
+fi
+
+# Test 2: valid YAML
+if python3 -c "import yaml,sys; yaml.safe_load(open('$WORKFLOW_FILE'))" 2>/dev/null; then
+    pass_test "deploy.yml is valid YAML"
+else
+    fail_test "deploy.yml has YAML syntax errors"
+    echo ""
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    exit 1
+fi
+
+# Test 3: the deploy job sets NODE_OPTIONS to suppress deprecation warnings.
+# Assert on the parsed YAML structure: jobs.deploy.env.NODE_OPTIONS must
+# request --no-deprecation (or the broader --no-warnings).
+NODE_OPTIONS_VALUE=$(python3 -c "
+import yaml, sys
+data = yaml.safe_load(open('$WORKFLOW_FILE'))
+job = data.get('jobs', {}).get('deploy', {})
+env = job.get('env', {}) or {}
+print(env.get('NODE_OPTIONS', ''))
+" 2>/dev/null)
+
+if echo "$NODE_OPTIONS_VALUE" | grep -qE '\-\-no-deprecation|\-\-no-warnings'; then
+    pass_test "deploy job sets NODE_OPTIONS to suppress deprecation warnings ('$NODE_OPTIONS_VALUE')"
+else
+    fail_test "deploy job does not set NODE_OPTIONS=--no-deprecation (got: '$NODE_OPTIONS_VALUE')"
+fi
+
+# Test 4: the deploy job declares the canonical github-pages environment.
+ENV_NAME=$(python3 -c "
+import yaml, sys
+data = yaml.safe_load(open('$WORKFLOW_FILE'))
+job = data.get('jobs', {}).get('deploy', {})
+environment = job.get('environment', {})
+if isinstance(environment, dict):
+    print(environment.get('name', ''))
+else:
+    print(environment or '')
+" 2>/dev/null)
+
+if [ "$ENV_NAME" = "github-pages" ]; then
+    pass_test "deploy job declares environment name 'github-pages'"
+else
+    fail_test "deploy job does not declare environment 'github-pages' (got: '$ENV_NAME')"
+fi
+
+# Test 5: the deploy step still exposes the page_url output via the
+# environment url so the deployment remains observable.
+ENV_URL=$(python3 -c "
+import yaml, sys
+data = yaml.safe_load(open('$WORKFLOW_FILE'))
+job = data.get('jobs', {}).get('deploy', {})
+environment = job.get('environment', {})
+if isinstance(environment, dict):
+    print(environment.get('url', ''))
+else:
+    print('')
+" 2>/dev/null)
+
+if echo "$ENV_URL" | grep -q 'steps.deployment.outputs.page_url'; then
+    pass_test "deploy environment url references steps.deployment.outputs.page_url"
+else
+    fail_test "deploy environment url does not reference the deployment page_url (got: '$ENV_URL')"
+fi
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
# Fix Node punycode deprecation warning in Pages deploy (Issue #146)

## Summary

The GitHub Pages deploy workflow logged a Node `[DEP0040]` deprecation warning
(`The 'punycode' module is deprecated`) and intermittently failed with
`Error: Deployment failed, try again later.`

The `punycode` deprecation is emitted by Node from **inside** the
GitHub-provided `actions/deploy-pages` action. That action is an external
dependency (`actions/*`, not `stSoftwareAU/*`) and is already pinned to the
latest release (`v5.0.0` — SHA `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128`), so
the warning cannot be patched at the action's source from this repo. Instead we
silence it at the Node runtime with `NODE_OPTIONS: --no-deprecation` on the
deploy job, which is the supported way to suppress third-party deprecation
noise.

We also add the canonical `environment: github-pages` declaration that GitHub
recommends for `actions/deploy-pages`. This is the supported configuration for
Pages deployments and surfaces the published page URL, making deploys more
observable — a robustness improvement for the transient
"Deployment failed, try again later" symptom.

No repository source code changed — this is a CI workflow configuration fix.

Closes #146.

## Changes

- `.github/workflows/deploy.yml`
  - Add job-level `env: NODE_OPTIONS: --no-deprecation` to suppress the
    punycode `DEP0040` warning from the pinned GitHub actions.
  - Add job-level `environment: github-pages` (with the deployment `page_url`)
    per GitHub's supported Pages deploy configuration.
- `tests/test-deploy-deprecation-fix.sh` — new test.

```mermaid
flowchart LR
    A[push to docs/**] --> B[deploy job]
    B --> C{NODE_OPTIONS=--no-deprecation}
    C --> D[Setup Pages]
    D --> E[Upload artifact]
    E --> F[Deploy to GitHub Pages]
    F --> G[environment: github-pages<br/>url = page_url]
```

## Evidence

This is a CI/workflow-only change with no web UI to screenshot. Verification is
via the new test plus YAML validation:

- New test `tests/test-deploy-deprecation-fix.sh` parses `deploy.yml` with a
  real YAML parser and asserts on the parsed structure (not raw text):
  - `jobs.deploy.env.NODE_OPTIONS` requests `--no-deprecation`.
  - `jobs.deploy.environment.name` is `github-pages`.
  - `jobs.deploy.environment.url` references
    `steps.deployment.outputs.page_url`.
- The pre-existing `tests/test-deploy-workflow-pinned.sh` still passes, so SHA
  pinning and version comments remain intact.

## Test Plan

- Added `tests/test-deploy-deprecation-fix.sh` (5 assertions, all pass).
- Confirmed it fails against the unfixed workflow (3 failing assertions) and
  passes after the fix — a genuine regression test.
- Ran `./quality.sh`: the two remaining failures
  (`test-gitleaks-workflow`, `test-version-consistency`) are pre-existing on a
  clean checkout and unrelated to this change (verified by stashing the change
  and re-running both — they fail without it).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr4k7zua-0d2f11`<!-- vibe-worker-issue-146 -->