### PR TITLE
Fix Pages deploy race: cancel superseded deployments (Issue #148)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,17 @@ permissions:
   pages: write
   id-token: write
 
+# The health monitor pushes docs/** updates to Develop very frequently (many
+# hosts, every few minutes), so deploy runs overlap. With cancel-in-progress
+# false these queued deployments race on the Pages backend and a superseded
+# deployment reports "Deployment failed, try again later." (issue #148).
+# Setting cancel-in-progress true lets a newer run cancel an older in-flight
+# deployment in the shared "pages" group, so only the latest — and freshest —
+# health data deploys. The dashboard always wants the most recent data, so
+# cancelling a superseded deploy is the desired behaviour.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:

--- a/docs/archive/pr-summaries/pr-summary-148.md
+++ b/docs/archive/pr-summaries/pr-summary-148.md
@@ -1,0 +1,78 @@
+# PR Summary — Issue #148: Deployment action fails
+
+## Summary
+
+The **Deploy to GitHub Pages** workflow was intermittently failing with
+`##[error]Deployment failed, try again later.` at the `actions/deploy-pages`
+step.
+
+Root cause: the health monitor pushes `docs/**` updates to the `Develop` branch
+very frequently (many hosts, every few minutes). Each push triggers the deploy
+workflow, so runs overlap. The concurrency block used
+`cancel-in-progress: false`, which let queued deployments run and race on the
+GitHub Pages backend — when a newer deployment supersedes an older in-flight
+one, the older run is marked failed and reports "Deployment failed, try again
+later.".
+
+Fix: set `cancel-in-progress: true` in the shared `pages` concurrency group so a
+newer run cancels an older in-flight deployment. Only the latest — and freshest
+— health data deploys, which removes the race. The dashboard always wants the
+most recent data, so cancelling a superseded deploy is the desired behaviour.
+
+Closes #148.
+
+## Evidence
+
+This is a CI/workflow (YAML) change with no web interface to screenshot. Evidence
+is the failing run and the parser-based tests.
+
+Observed failure (run `28687107830`, and 6 more failures on 2026-07-03):
+
+```
+Created deployment for 0f7809c5..., ID: 0f7809c5...
+Getting Pages deployment status...
+##[error]Deployment failed, try again later.
+```
+
+Deployment flow before and after the fix:
+
+```mermaid
+flowchart TD
+    subgraph Before["Before — cancel-in-progress: false"]
+        A1[Push docs update A] --> D1[Deploy A in-flight]
+        B1[Push docs update B] --> D2[Deploy B]
+        D1 -. superseded on Pages backend .-> F1["A: Deployment failed,<br/>try again later"]
+        D2 --> S1[B deployed]
+    end
+    subgraph After["After — cancel-in-progress: true"]
+        A2[Push docs update A] --> D3[Deploy A in-flight]
+        B2[Push docs update B] --> C2[Cancel Deploy A]
+        C2 --> D4[Deploy B]
+        D4 --> S2[B deployed — no race]
+    end
+```
+
+## Test Plan
+
+- Added `tests/test-deploy-concurrency.sh` (parses `deploy.yml` with a real YAML
+  parser — no source grepping):
+  - deploy.yml exists and is valid YAML
+  - a concurrency `group` is declared (`pages`)
+  - `cancel-in-progress` is `true` (the regression guard for this fix)
+- Verified TDD: the new test failed against the old `cancel-in-progress: false`
+  workflow and passes after the change.
+- Existing `tests/test-deploy-deprecation-fix.sh` and
+  `tests/test-deploy-workflow-pinned.sh` still pass — SHA pinning,
+  `NODE_OPTIONS`, and the `github-pages` environment declaration are unchanged.
+
+## Out of scope
+
+`./quality.sh` reports two pre-existing failures unrelated to this issue (they
+fail on the base branch with this change stashed, and neither touches the deploy
+concurrency behaviour):
+
+- `test-gitleaks-workflow` — gitleaks workflow config drift.
+- `test-version-consistency` — `sw.js` pinned to version 1.1.19 while `run.sh`
+  is 1.1.17.
+
+These were left untouched per the change-scope guidance.

--- a/tests/test-deploy-concurrency.sh
+++ b/tests/test-deploy-concurrency.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Test for Issue #148: the GitHub Pages deployment action fails with
+# "Deployment failed, try again later.".
+#
+# Root cause: the health monitor pushes docs/** updates to the Develop branch
+# very frequently (many hosts, every few minutes). Each push triggers the
+# deploy workflow. With concurrency `cancel-in-progress: false`, overlapping
+# deployments queue and race on the GitHub Pages backend — a deployment that
+# is superseded by a newer one is marked "failed" and the run reports
+# "Deployment failed, try again later.".
+#
+# Fix: set `cancel-in-progress: true` so a newer run cancels an older in-flight
+# deployment in the shared "pages" concurrency group. Only the latest (freshest)
+# deployment runs, which removes the race. The dashboard always deploys the most
+# recent health data, so cancelling a superseded deploy is the desired behaviour.
+#
+# The test parses the workflow YAML with a real parser and asserts on the
+# resulting structure rather than grepping raw text.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_FILE="$SCRIPT_DIR/../.github/workflows/deploy.yml"
+
+echo "Testing Issue #148: deploy.yml concurrency prevents Pages race"
+echo "============================================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail_test() { echo "  FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# Test 1: workflow file exists
+if [ -f "$WORKFLOW_FILE" ]; then
+    pass_test "deploy.yml exists at .github/workflows/deploy.yml"
+else
+    fail_test "deploy.yml is missing from .github/workflows/"
+    echo ""
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    exit 1
+fi
+
+# Test 2: valid YAML
+if python3 -c "import yaml,sys; yaml.safe_load(open('$WORKFLOW_FILE'))" 2>/dev/null; then
+    pass_test "deploy.yml is valid YAML"
+else
+    fail_test "deploy.yml has YAML syntax errors"
+    echo ""
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    exit 1
+fi
+
+# Test 3: a concurrency group is declared so deployments are serialised into a
+# single "pages" group rather than running fully in parallel.
+CONCURRENCY_GROUP=$(python3 -c "
+import yaml
+data = yaml.safe_load(open('$WORKFLOW_FILE'))
+concurrency = data.get('concurrency', {})
+if isinstance(concurrency, dict):
+    print(concurrency.get('group', ''))
+else:
+    print(concurrency or '')
+" 2>/dev/null)
+
+if [ -n "$CONCURRENCY_GROUP" ]; then
+    pass_test "deploy job declares a concurrency group ('$CONCURRENCY_GROUP')"
+else
+    fail_test "deploy job does not declare a concurrency group"
+fi
+
+# Test 4: cancel-in-progress is true so a newer deploy supersedes an older
+# in-flight one — the fix for the "Deployment failed, try again later." race.
+CANCEL_IN_PROGRESS=$(python3 -c "
+import yaml
+data = yaml.safe_load(open('$WORKFLOW_FILE'))
+concurrency = data.get('concurrency', {})
+val = concurrency.get('cancel-in-progress', None) if isinstance(concurrency, dict) else None
+# Normalise Python bool to a lowercase string.
+print(str(val).lower())
+" 2>/dev/null)
+
+if [ "$CANCEL_IN_PROGRESS" = "true" ]; then
+    pass_test "deploy concurrency sets cancel-in-progress: true (prevents Pages deploy race)"
+else
+    fail_test "deploy concurrency cancel-in-progress must be true, got: '$CANCEL_IN_PROGRESS'"
+fi
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
# PR Summary — Issue #148: Deployment action fails

## Summary

The **Deploy to GitHub Pages** workflow was intermittently failing with
`##[error]Deployment failed, try again later.` at the `actions/deploy-pages`
step.

Root cause: the health monitor pushes `docs/**` updates to the `Develop` branch
very frequently (many hosts, every few minutes). Each push triggers the deploy
workflow, so runs overlap. The concurrency block used
`cancel-in-progress: false`, which let queued deployments run and race on the
GitHub Pages backend — when a newer deployment supersedes an older in-flight
one, the older run is marked failed and reports "Deployment failed, try again
later.".

Fix: set `cancel-in-progress: true` in the shared `pages` concurrency group so a
newer run cancels an older in-flight deployment. Only the latest — and freshest
— health data deploys, which removes the race. The dashboard always wants the
most recent data, so cancelling a superseded deploy is the desired behaviour.

Closes #148.

## Evidence

This is a CI/workflow (YAML) change with no web interface to screenshot. Evidence
is the failing run and the parser-based tests.

Observed failure (run `28687107830`, and 6 more failures on 2026-07-03):

```
Created deployment for 0f7809c5..., ID: 0f7809c5...
Getting Pages deployment status...
##[error]Deployment failed, try again later.
```

Deployment flow before and after the fix:

```mermaid
flowchart TD
    subgraph Before["Before — cancel-in-progress: false"]
        A1[Push docs update A] --> D1[Deploy A in-flight]
        B1[Push docs update B] --> D2[Deploy B]
        D1 -. superseded on Pages backend .-> F1["A: Deployment failed,<br/>try again later"]
        D2 --> S1[B deployed]
    end
    subgraph After["After — cancel-in-progress: true"]
        A2[Push docs update A] --> D3[Deploy A in-flight]
        B2[Push docs update B] --> C2[Cancel Deploy A]
        C2 --> D4[Deploy B]
        D4 --> S2[B deployed — no race]
    end
```

## Test Plan

- Added `tests/test-deploy-concurrency.sh` (parses `deploy.yml` with a real YAML
  parser — no source grepping):
  - deploy.yml exists and is valid YAML
  - a concurrency `group` is declared (`pages`)
  - `cancel-in-progress` is `true` (the regression guard for this fix)
- Verified TDD: the new test failed against the old `cancel-in-progress: false`
  workflow and passes after the change.
- Existing `tests/test-deploy-deprecation-fix.sh` and
  `tests/test-deploy-workflow-pinned.sh` still pass — SHA pinning,
  `NODE_OPTIONS`, and the `github-pages` environment declaration are unchanged.

## Out of scope

`./quality.sh` reports two pre-existing failures unrelated to this issue (they
fail on the base branch with this change stashed, and neither touches the deploy
concurrency behaviour):

- `test-gitleaks-workflow` — gitleaks workflow config drift.
- `test-version-consistency` — `sw.js` pinned to version 1.1.19 while `run.sh`
  is 1.1.17.

These were left untouched per the change-scope guidance.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr5nwtyk-47bd17`<!-- vibe-worker-issue-148 -->