### PR TITLE
feat: holiday-aware staleness — skip market holidays in business-days counting (Issue #155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,17 @@ The dashboard calculates status from `last_commit_ts`:
 
 **Weekend-aware repos (Issue #67)**: Repos that only receive data on weekdays (e.g., FX market feeds that run Monday–Friday) can set `"business_days_only": true` to skip weekends when calculating staleness, even with explicit thresholds. Without this flag, explicit thresholds count calendar days/hours. With it, only business days are counted, preventing false alarms on Monday mornings.
 
+**Holiday-aware staleness (Issue #155)**: Business-days counting also skips US (NYSE) and AU (ASX) market holidays, so a public holiday that extends a weekend — e.g. a Monday public holiday — does not burn into a repo's staleness budget. The consequence is asymmetric by design: mid-week silence, where every elapsed day is a trading day, accrues staleness faster and alerts sooner than a holiday-extended weekend gap of the same wall-clock length. The holiday calendar is the `MARKET_HOLIDAYS` set in `docs/dashboard.js` (UTC ISO dates, observed in-lieu where the actual date lands on a weekend) and needs annual maintenance as new years' schedules are published. No config change is required — any `business_days_only` repo inherits holiday skipping automatically.
+
+```mermaid
+flowchart LR
+    A[Day since last commit] --> B{Weekend?}
+    B -- Yes --> S[Skip: no staleness]
+    B -- No --> C{Market holiday?}
+    C -- Yes --> S
+    C -- No --> D[Count as 1 business day]
+```
+
 **Hour-grain thresholds (Issue #105)**: Repos that report frequently — for example Vibe Coders that should check in every hour — can specify `warning_hours` and/or `error_hours` instead of (or in addition to) the day-based thresholds. When either hour field is set it takes precedence over `warning_days`/`error_days`, and the elapsed time is compared in calendar hours so dead workers are flagged within hours rather than waiting ~24h for the day-grain check.
 
 ```json

--- a/docs/archive/pr-summaries/pr-summary-155.md
+++ b/docs/archive/pr-summaries/pr-summary-155.md
@@ -1,0 +1,87 @@
+# PR Summary — Issue #155: Holiday-aware staleness
+
+## Summary
+
+Made GRQ-health market-holiday aware so that a public holiday which extends a
+weekend (e.g. a Monday holiday) no longer burns into a repo's staleness budget.
+Business-days counting (`business_days_only`, Issues #47/#67) already skipped
+weekends; it now also skips US (NYSE) and AU (ASX) market holidays. The result is
+the asymmetry the issue asked for: **mid-week silence — where every elapsed day is
+a trading day — accrues staleness faster and alerts sooner than a
+holiday-extended weekend gap of the same wall-clock length.**
+
+Changes:
+
+- Added a `MARKET_HOLIDAYS` calendar (union of US NYSE + AU ASX, 2025–2027, UTC
+  ISO dates, observed in-lieu where the actual date falls on a weekend) and an
+  `isMarketHoliday(date)` helper in `docs/dashboard.js`.
+- `countBusinessDays()` now skips holidays as well as weekends. Any
+  `business_days_only` repo (e.g. `FX`) inherits holiday skipping automatically —
+  no config change required.
+- Documented the behaviour in `README.md` with a decision flowchart.
+- Bumped version to 1.1.18 (`update_version.sh`) to keep `run.sh` and
+  `docs/dashboard.js` in sync per the version-consistency gate.
+
+Design note: the issue's second bullet (a separate mid-week weighting multiplier)
+was explicitly "consider… open to design". The existing business-days mechanism
+already delivers the mid-week-vs-weekend asymmetry; extending it to holidays
+completes that signal without a parallel weighting system that would overlap with
+the #154 calendar thresholds. Kept in scope accordingly.
+
+Closes #155.
+
+## Evidence
+
+Backend/CLI change with no web UI to screenshot. Verified via the new unit test
+suite driving the real pure functions through deno.
+
+```mermaid
+flowchart LR
+    A[Day since last commit] --> B{Weekend?}
+    B -- Yes --> S[Skip: no staleness]
+    B -- No --> C{Market holiday?}
+    C -- Yes --> S
+    C -- No --> D[Count as 1 business day]
+```
+
+Test run (`./tests/test-holiday-aware-staleness.sh`):
+
+```
+Test 1: isMarketHoliday recognises US and AU holidays...
+  PASS: au-holiday-recognised: 2026-01-26 is a holiday
+  PASS: us-holiday-recognised: 2026-11-26 is a holiday
+  PASS: ordinary-day-not-holiday: 2026-03-04 is not a holiday
+Test 2: countBusinessDays skips holidays...
+  PASS: count-skips-holiday: 1 business day across holiday-extended weekend
+  PASS: count-plain-midweek: 3 business days mid-week
+Test 3: business_days_only repo healthy across holiday-extended weekend...
+  PASS: holiday-weekend-healthy: healthy across holiday-extended weekend
+  PASS: midweek-more-suspicious: mid-week silence flagged warning
+Results: 7 passed, 0 failed
+```
+
+## Test Plan
+
+Added `tests/test-holiday-aware-staleness.sh` (TDD — written failing first, then
+implemented):
+
+- `isMarketHoliday()` recognises an AU holiday (Australia Day 2026-01-26), a US
+  holiday (Thanksgiving 2026-11-26), and rejects an ordinary trading day.
+- `countBusinessDays()` returns 1 across a holiday-extended weekend
+  (Fri 2026-01-23 → Tue 2026-01-27, Monday = Australia Day) vs a control of 3
+  for a plain mid-week span.
+- `getRepoStatus()` keeps a `business_days_only` repo healthy across the
+  holiday-extended weekend, while the same-length mid-week gap is flagged —
+  proving mid-week silence is treated as more suspicious.
+
+Existing weekend/threshold suites (`test-weekend-aware-repos.sh`,
+`test-staleness-weekend-thresholds.sh`, `test-stale-threshold.sh`) continue to
+pass — their March-2026 dates contain no holidays, so behaviour is unchanged.
+
+## Known pre-existing failure (out of scope)
+
+`./quality.sh` reports one failing test, `test-gitleaks-workflow.sh`
+("Missing gitleaks-action step or GITHUB_TOKEN env"). This fails identically on
+the clean baseline (verified via `git stash`) — it is a GitHub-workflow config
+check unrelated to staleness logic and to this issue, so it was left untouched
+per change-scope discipline. All other 58 checks pass.

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.17";
+const VERSION = "1.1.18";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -276,8 +276,44 @@ function buildIdleWorkerWarning(data) {
     return idleStatus.reason;
 }
 
+// Issue #155: Market-holiday calendar (US NYSE + AU ASX). A public holiday that
+// extends a weekend (e.g. a Monday public holiday) should not burn into a repo's
+// staleness budget, so business-days counting skips these dates as well as
+// weekends. This makes mid-week silence — every day of which is a trading day —
+// more suspicious than a holiday-extended weekend of the same wall-clock length.
+// Dates are UTC ISO (YYYY-MM-DD), observed (in-lieu) where the actual date falls
+// on a weekend. This is the union of both exchanges; overlaps (New Year, Good
+// Friday, Christmas) are naturally de-duplicated by the Set. Maintain annually.
+const MARKET_HOLIDAYS = new Set([
+    // 2025 — US NYSE
+    '2025-01-01', '2025-01-20', '2025-02-17', '2025-04-18', '2025-05-26',
+    '2025-06-19', '2025-07-04', '2025-09-01', '2025-11-27', '2025-12-25',
+    // 2025 — AU ASX
+    '2025-01-27', '2025-04-21', '2025-04-25', '2025-06-09', '2025-12-26',
+    // 2026 — US NYSE
+    '2026-01-01', '2026-01-19', '2026-02-16', '2026-04-03', '2026-05-25',
+    '2026-06-19', '2026-07-03', '2026-09-07', '2026-11-26', '2026-12-25',
+    // 2026 — AU ASX
+    '2026-01-26', '2026-04-06', '2026-04-25', '2026-06-08', '2026-12-28',
+    // 2027 — US NYSE
+    '2027-01-01', '2027-01-18', '2027-02-15', '2027-03-26', '2027-05-31',
+    '2027-06-18', '2027-07-05', '2027-09-06', '2027-11-25', '2027-12-24',
+    // 2027 — AU ASX
+    '2027-01-26', '2027-03-29', '2027-04-26', '2027-06-14', '2027-12-27',
+    '2027-12-28'
+]);
+
+// True when a Date (interpreted in UTC) falls on a US or AU market holiday.
+function isMarketHoliday(date) {
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    return MARKET_HOLIDAYS.has(`${year}-${month}-${day}`);
+}
+
 // Count business days (weekdays only) between two unix timestamps (Issue #47)
-// Weekends (Saturday=6, Sunday=0) are skipped so they don't count toward staleness
+// Weekends (Saturday=6, Sunday=0) and market holidays (Issue #155) are skipped
+// so they don't count toward staleness.
 function countBusinessDays(fromTs, toTs) {
     if (toTs <= fromTs) return 0;
 
@@ -293,7 +329,9 @@ function countBusinessDays(fromTs, toTs) {
     let cursor = new Date(fromMidnight.getTime() + msPerDay); // start the day after fromTs
     while (cursor <= toMidnight) {
         const day = cursor.getUTCDay(); // 0=Sun, 6=Sat
-        if (day !== 0 && day !== 6) {
+        // Skip weekends and market holidays (Issue #155) — a holiday that
+        // extends a weekend must not accrue staleness.
+        if (day !== 0 && day !== 6 && !isMarketHoliday(cursor)) {
             count++;
         }
         cursor = new Date(cursor.getTime() + msPerDay);

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.17" rel="stylesheet">
+    <link href="./styles.css?v=1.1.18" rel="stylesheet">
 </head>
 <body>
     <div class="container-fluid py-4">
@@ -107,14 +107,14 @@
 
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="./dashboard.js?v=1.1.17"></script>
+    <script src="./dashboard.js?v=1.1.18"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.17')
+                navigator.serviceWorker.register('./sw.js?v=1.1.18')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,15 +1,15 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.19
+// Version: 1.1.18
 
-const CACHE_NAME = 'grq-health-v1.1.19';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.19';
+const CACHE_NAME = 'grq-health-v1.1.18';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.18';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
   './',
   './index.html',
   './styles.css',
-  './dashboard.js?v=1.1.19',
+  './dashboard.js?v=1.1.18',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ fi
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.17"
+VERSION="1.1.18"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/test-holiday-aware-staleness.sh
+++ b/tests/test-holiday-aware-staleness.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Test for Issue #155: Holiday-aware staleness.
+#
+# business_days_only counting (Issue #47/#67) already skips weekends so that
+# mid-week silence accrues staleness faster than a weekend gap. A market
+# holiday that extends a weekend (e.g. a Monday public holiday) should be
+# treated the same way — it must NOT burn into a repo's staleness budget.
+#
+# These tests exercise the new market-holiday calendar (US NYSE + AU ASX):
+#   - isMarketHoliday() recognises US and AU market holidays (and only those)
+#   - countBusinessDays() skips holidays as well as weekends
+#   - getRepoStatus() keeps a business_days_only repo healthy across a
+#     holiday-extended weekend that plain calendar counting would flag.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/extract-functions.sh"
+
+echo "Testing Issue #155: Holiday-aware staleness"
+echo "==========================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+run_and_check() {
+    local test_name="$1"
+    local js_code="$2"
+    local output
+    output=$(run_js_test "$js_code" 2>&1) || true
+    local result
+    result=$(echo "$output" | grep "^TEST_RESULT:${test_name}:" | head -1)
+    if [[ "$result" == *":PASS:"* ]]; then
+        local detail
+        detail=$(echo "$result" | cut -d: -f4-)
+        pass_test "$test_name: $detail"
+    else
+        local detail
+        detail=$(echo "$result" | cut -d: -f4-)
+        if [ -z "$detail" ]; then
+            detail="no output (full: $output)"
+        fi
+        fail_test "$test_name: $detail"
+    fi
+}
+
+# ============================================================
+# Test 1: isMarketHoliday recognises US and AU market holidays
+# ============================================================
+echo "Test 1: isMarketHoliday recognises US and AU holidays..."
+
+run_and_check "au-holiday-recognised" '
+    // AU: Australia Day (observed) Mon 2026-01-26
+    const d = new Date(Date.UTC(2026, 0, 26));
+    if (isMarketHoliday(d) === true) {
+        console.log("TEST_RESULT:au-holiday-recognised:PASS:2026-01-26 is a holiday");
+    } else {
+        console.log("TEST_RESULT:au-holiday-recognised:FAIL:expected holiday");
+    }
+'
+
+run_and_check "us-holiday-recognised" '
+    // US: Thanksgiving Thu 2026-11-26
+    const d = new Date(Date.UTC(2026, 10, 26));
+    if (isMarketHoliday(d) === true) {
+        console.log("TEST_RESULT:us-holiday-recognised:PASS:2026-11-26 is a holiday");
+    } else {
+        console.log("TEST_RESULT:us-holiday-recognised:FAIL:expected holiday");
+    }
+'
+
+run_and_check "ordinary-day-not-holiday" '
+    // An ordinary mid-week trading day.
+    const d = new Date(Date.UTC(2026, 2, 4)); // Wed 2026-03-04
+    if (isMarketHoliday(d) === false) {
+        console.log("TEST_RESULT:ordinary-day-not-holiday:PASS:2026-03-04 is not a holiday");
+    } else {
+        console.log("TEST_RESULT:ordinary-day-not-holiday:FAIL:expected non-holiday");
+    }
+'
+
+# ============================================================
+# Test 2: countBusinessDays skips holidays as well as weekends
+# ============================================================
+echo ""
+echo "Test 2: countBusinessDays skips holidays..."
+
+# Fri 2026-01-23 -> Tue 2026-01-27. Days after Friday: Sat, Sun (weekend),
+# Mon 2026-01-26 (Australia Day holiday), Tue 2026-01-27 (trading).
+# Only Tuesday counts => 1 business day (would be 2 without holiday skipping).
+run_and_check "count-skips-holiday" '
+    const fri = Date.UTC(2026, 0, 23) / 1000;
+    const tue = Date.UTC(2026, 0, 27) / 1000;
+    const n = countBusinessDays(fri, tue);
+    if (n === 1) {
+        console.log("TEST_RESULT:count-skips-holiday:PASS:1 business day across holiday-extended weekend");
+    } else {
+        console.log("TEST_RESULT:count-skips-holiday:FAIL:expected 1, got " + n);
+    }
+'
+
+# Control: a plain mid-week span with no holiday counts every weekday.
+# Mon 2026-03-02 -> Thu 2026-03-05 = Tue, Wed, Thu = 3 business days.
+run_and_check "count-plain-midweek" '
+    const mon = Date.UTC(2026, 2, 2) / 1000;
+    const thu = Date.UTC(2026, 2, 5) / 1000;
+    const n = countBusinessDays(mon, thu);
+    if (n === 3) {
+        console.log("TEST_RESULT:count-plain-midweek:PASS:3 business days mid-week");
+    } else {
+        console.log("TEST_RESULT:count-plain-midweek:FAIL:expected 3, got " + n);
+    }
+'
+
+# ============================================================
+# Test 3: getRepoStatus stays healthy across a holiday-extended weekend
+# ============================================================
+echo ""
+echo "Test 3: business_days_only repo healthy across holiday-extended weekend..."
+
+# FX-like repo: warning_days 1.5, business_days_only true.
+# Last commit Fri 2026-01-23 noon, checked Tue 2026-01-27 morning.
+# 1 business day (Mon is Australia Day) < 1.5 => healthy.
+run_and_check "holiday-weekend-healthy" '
+    const fridayNoon = Date.UTC(2026, 0, 23) / 1000 + 43200;
+    const tuesMorn = Date.UTC(2026, 0, 27) / 1000 + 36000;
+    const repo = {
+        name: "FX",
+        last_commit_ts: fridayNoon,
+        warning_days: 1.5,
+        error_days: 4,
+        business_days_only: true
+    };
+    const status = getRepoStatus(repo, tuesMorn);
+    if (status === "healthy") {
+        console.log("TEST_RESULT:holiday-weekend-healthy:PASS:healthy across holiday-extended weekend");
+    } else {
+        console.log("TEST_RESULT:holiday-weekend-healthy:FAIL:expected healthy, got " + status);
+    }
+'
+
+# Mid-week contrast: same repo, silence Mon 2026-03-02 -> Fri 2026-03-06 (no
+# holidays). 4 business days > error_days? No, error 4 => not >. Use warning:
+# Tue/Wed/Thu/Fri = 4 business days > warning 1.5 => at least warning. This
+# proves mid-week silence of the same wall-clock length is treated as MORE
+# suspicious than the holiday-extended weekend above (which stayed healthy).
+run_and_check "midweek-more-suspicious" '
+    const monNoon = Date.UTC(2026, 2, 2) / 1000 + 43200;
+    const friMorn = Date.UTC(2026, 2, 6) / 1000 + 36000;
+    const repo = {
+        name: "FX",
+        last_commit_ts: monNoon,
+        warning_days: 1.5,
+        error_days: 4,
+        business_days_only: true
+    };
+    const status = getRepoStatus(repo, friMorn);
+    if (status !== "healthy") {
+        console.log("TEST_RESULT:midweek-more-suspicious:PASS:mid-week silence flagged " + status);
+    } else {
+        console.log("TEST_RESULT:midweek-more-suspicious:FAIL:expected non-healthy, got healthy");
+    }
+'
+
+# ============================================================
+echo ""
+echo "==========================================="
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi
+echo "All Issue #155 holiday-aware tests passed!"


### PR DESCRIPTION
# PR Summary — Issue #155: Holiday-aware staleness

## Summary

Made GRQ-health market-holiday aware so that a public holiday which extends a
weekend (e.g. a Monday holiday) no longer burns into a repo's staleness budget.
Business-days counting (`business_days_only`, Issues #47/#67) already skipped
weekends; it now also skips US (NYSE) and AU (ASX) market holidays. The result is
the asymmetry the issue asked for: **mid-week silence — where every elapsed day is
a trading day — accrues staleness faster and alerts sooner than a
holiday-extended weekend gap of the same wall-clock length.**

Changes:

- Added a `MARKET_HOLIDAYS` calendar (union of US NYSE + AU ASX, 2025–2027, UTC
  ISO dates, observed in-lieu where the actual date falls on a weekend) and an
  `isMarketHoliday(date)` helper in `docs/dashboard.js`.
- `countBusinessDays()` now skips holidays as well as weekends. Any
  `business_days_only` repo (e.g. `FX`) inherits holiday skipping automatically —
  no config change required.
- Documented the behaviour in `README.md` with a decision flowchart.
- Bumped version to 1.1.18 (`update_version.sh`) to keep `run.sh` and
  `docs/dashboard.js` in sync per the version-consistency gate.

Design note: the issue's second bullet (a separate mid-week weighting multiplier)
was explicitly "consider… open to design". The existing business-days mechanism
already delivers the mid-week-vs-weekend asymmetry; extending it to holidays
completes that signal without a parallel weighting system that would overlap with
the #154 calendar thresholds. Kept in scope accordingly.

Closes #155.

## Evidence

Backend/CLI change with no web UI to screenshot. Verified via the new unit test
suite driving the real pure functions through deno.

```mermaid
flowchart LR
    A[Day since last commit] --> B{Weekend?}
    B -- Yes --> S[Skip: no staleness]
    B -- No --> C{Market holiday?}
    C -- Yes --> S
    C -- No --> D[Count as 1 business day]
```

Test run (`./tests/test-holiday-aware-staleness.sh`):

```
Test 1: isMarketHoliday recognises US and AU holidays...
  PASS: au-holiday-recognised: 2026-01-26 is a holiday
  PASS: us-holiday-recognised: 2026-11-26 is a holiday
  PASS: ordinary-day-not-holiday: 2026-03-04 is not a holiday
Test 2: countBusinessDays skips holidays...
  PASS: count-skips-holiday: 1 business day across holiday-extended weekend
  PASS: count-plain-midweek: 3 business days mid-week
Test 3: business_days_only repo healthy across holiday-extended weekend...
  PASS: holiday-weekend-healthy: healthy across holiday-extended weekend
  PASS: midweek-more-suspicious: mid-week silence flagged warning
Results: 7 passed, 0 failed
```

## Test Plan

Added `tests/test-holiday-aware-staleness.sh` (TDD — written failing first, then
implemented):

- `isMarketHoliday()` recognises an AU holiday (Australia Day 2026-01-26), a US
  holiday (Thanksgiving 2026-11-26), and rejects an ordinary trading day.
- `countBusinessDays()` returns 1 across a holiday-extended weekend
  (Fri 2026-01-23 → Tue 2026-01-27, Monday = Australia Day) vs a control of 3
  for a plain mid-week span.
- `getRepoStatus()` keeps a `business_days_only` repo healthy across the
  holiday-extended weekend, while the same-length mid-week gap is flagged —
  proving mid-week silence is treated as more suspicious.

Existing weekend/threshold suites (`test-weekend-aware-repos.sh`,
`test-staleness-weekend-thresholds.sh`, `test-stale-threshold.sh`) continue to
pass — their March-2026 dates contain no holidays, so behaviour is unchanged.

## Known pre-existing failure (out of scope)

`./quality.sh` reports one failing test, `test-gitleaks-workflow.sh`
("Missing gitleaks-action step or GITHUB_TOKEN env"). This fails identically on
the clean baseline (verified via `git stash`) — it is a GitHub-workflow config
check unrelated to staleness logic and to this issue, so it was left untouched
per change-scope discipline. All other 58 checks pass.
