### PR TITLE
Add a WCAG contrast regression guard covering every .host-card variant in dark mode (#172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,34 @@ survives and the text stays readable. `tests/test-dark-mode-table.sh` asserts
 ≥4.5:1 contrast between the resolved MIA surface and both `--card-text` and
 `--muted-color`.
 
+#### The host-card contrast sweep (Issue #172)
+
+That same fault shipped three times (#165, #169, #171) before a human spotted it
+on a phone screenshot, so the check no longer names variants.
+`tests/test-dark-mode-host-cards.sh` runs `tests/dark-mode-card-check.js`, which
+**enumerates** every `.host-card.<variant>` rule in `docs/styles.css` and
+measures each one — no test edit is needed when a variant is added.
+
+```mermaid
+flowchart LR
+    A[docs/styles.css] --> B[enumerate .host-card variants]
+    B --> C{dark override?}
+    C -->|yes| D["[data-theme=dark] rule background"]
+    C -->|no| E[base rule background]
+    D --> F[composite layers + gradient stops<br/>over the dark --card-bg]
+    E --> F
+    F --> G{">= 4.5:1 vs --card-text<br/>and --muted-color?"}
+    G -->|no| H[TEST_RESULT ... FAIL]
+    G -->|yes| I[TEST_RESULT ... PASS]
+```
+
+A translucent `rgba()` wash is composited before the ratio is computed, and
+every stop of a multi-stop gradient is measured, so a gradient that starts dark
+and ends light still fails. Enumerating zero variants is itself a failure, so a
+stylesheet rename cannot turn the guard green by vacuity. The fixtures in
+`tests/fixtures/dark-mode-cards/` are the checker's own self-test: known-good
+and known-bad variants it must keep telling apart.
+
 ### Emoji Legend
 
 - 💀 Dead machines (in Silicon Heaven)

--- a/docs/archive/pr-summaries/pr-summary-172.md
+++ b/docs/archive/pr-summaries/pr-summary-172.md
@@ -1,0 +1,105 @@
+## Summary
+
+Adds a WCAG contrast regression guard that covers **every** `.host-card` variant
+in dark mode, rather than the three the existing checker names. Closes #172.
+
+The same defect shipped three times — #165 (Bootstrap `.table`), #169 (`.mia`)
+and #171 (`.mobile`, `.outdated-macos`): a component hardcodes a light
+background, survives the `[data-theme="dark"]` switch, and the dark palette's
+light text renders on it unreadably. Each was found by a human looking at a
+phone screenshot because nothing in the suite covered the class of defect.
+
+- `tests/dark-mode-card-check.js` **enumerates** the `.host-card.<variant>`
+  rules in `docs/styles.css` (base cascade and dark theme, ignoring `::before` /
+  `::after` decoration rules) and measures each one. A variant added later is
+  covered with no test edit.
+- For each variant it resolves the background the dark theme actually applies —
+  the `[data-theme="dark"] .host-card.<variant>` override if present, else the
+  base variant rule, else the inherited `.host-card` background — composites
+  every background layer and **every gradient stop** over the dark `--card-bg`,
+  and asserts ≥ 4.5:1 against `--card-text` and `--muted-color`.
+- Translucent `rgba(...)` washes are composited before the ratio is computed,
+  never treated as opaque; the `0.98` alpha on the old light gradients is the
+  whole reason the defect is subtle.
+- Discovering **zero** variants is itself a `FAIL`, and the discovered count is
+  reported in the `TEST_RESULT` detail, so a stylesheet rename or a CSS-parsing
+  regression cannot turn the guard green by vacuity.
+- `tests/test-dark-mode-host-cards.sh` is the shell harness, following the
+  existing `TEST_RESULT:<name>:<PASS|FAIL>:<detail>` convention. It is picked up
+  automatically by `./quality.sh`, which globs `tests/test-*.sh`.
+- CSS parsing and colour maths move to `tests/css-colour-lib.js`, shared by the
+  new sweep and the existing `tests/dark-mode-table-check.js` (behaviour of the
+  latter is unchanged — all 26 of its results still pass).
+
+**Ordering:** both fix sub-issues (#170, #171) have already landed on
+`milestone/169-tinas-macbook-unreadable-in-dark-mode`, so this test is green on
+the branch it targets. Nothing needs quarantining. Its positive control against
+`Develop` is below.
+
+## Evidence
+
+No UI change — this PR adds tests and documentation only, so there is nothing to
+screenshot. The dashboard renders identically before and after; the evidence is
+the checker's behaviour.
+
+```mermaid
+flowchart LR
+    A[docs/styles.css] --> B[enumerate .host-card variants]
+    B --> C{dark override?}
+    C -->|yes| D["[data-theme=dark] rule background"]
+    C -->|no| E[base rule background]
+    D --> F[composite layers + gradient stops<br/>over the dark --card-bg]
+    E --> F
+    F --> G{">= 4.5:1 vs --card-text<br/>and --muted-color?"}
+    G -->|no| H[TEST_RESULT ... FAIL]
+    G -->|yes| I[TEST_RESULT ... PASS]
+```
+
+**Positive control — the checker run against the current `Develop` tree** (the
+acceptance criterion that it goes red there, flagging exactly the three unfixed
+variants):
+
+```
+TEST_RESULT:dark-mode-host-cards-variants-discovered:PASS:enumerated 8 .host-card variants from the stylesheet: critical, dead, healthy, historical, mia, mobile, outdated-macos, warning
+TEST_RESULT:dark-mode-host-cards-mia-card-text:FAIL:--card-text on .host-card.mia (.host-card.mia) 1.12:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
+TEST_RESULT:dark-mode-host-cards-mia-muted-color:FAIL:--muted-color on .host-card.mia (.host-card.mia) 2.38:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
+TEST_RESULT:dark-mode-host-cards-mobile-card-text:FAIL:--card-text on .host-card.mobile (.host-card.mobile) 1.01:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
+TEST_RESULT:dark-mode-host-cards-mobile-muted-color:FAIL:--muted-color on .host-card.mobile (.host-card.mobile) 2.15:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
+TEST_RESULT:dark-mode-host-cards-outdated-macos-card-text:FAIL:--card-text on .host-card.outdated-macos (.host-card.outdated-macos) 1.09:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
+TEST_RESULT:dark-mode-host-cards-outdated-macos-muted-color:FAIL:--muted-color on .host-card.outdated-macos (.host-card.outdated-macos) 2.32:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
+```
+
+**On this branch** (both fixes landed) all 8 variants pass, e.g.:
+
+```
+PASS: dark-mode-host-cards-mia-card-text — --card-text on .host-card.mia ([data-theme="dark"] .host-card.mia) 10.24:1 at worst of 4 stop(s), layer 1 stop 3 (needs >= 4.5)
+PASS: dark-mode-host-cards-warning-card-text — --card-text on .host-card.warning (.host-card) 12.24:1 at worst of 1 stop(s), stop 1 (needs >= 4.5)
+```
+
+`./quality.sh`: 63/63 passed, including `test-dark-mode-host-cards` and the
+unchanged `test-dark-mode-table`.
+
+## Test Plan
+
+New — `tests/test-dark-mode-host-cards.sh` (27 assertions, three stages):
+
+1. **The real stylesheet** — every enumerated `.host-card` variant in
+   `docs/styles.css` must meet 4.5:1 against `--card-text` and `--muted-color`.
+2. **Self-test of the detector** against
+   `tests/fixtures/dark-mode-cards/variants.css`, which pins the verdicts the
+   checker must produce:
+   - `fixture-good` (dark wash over `var(--card-bg)`) → PASS
+   - `fixture-light` (light gradient, no dark override) → FAIL — the unfixed
+     defect
+   - `fixture-tail-light` (gradient starting dark, ending near-white) → FAIL —
+     fails only if every stop is evaluated
+   - `fixture-alpha-wash` (`rgba(255,255,255,0.04)`) → PASS — passes only if
+     alpha is composited rather than treated as opaque
+   - `fixture-alpha-solid` (`rgba(255,255,255,0.98)`) → FAIL
+   - `.host-card.fixture-good::before` must not be enumerated as a variant
+3. **Guard-degradation** against `tests/fixtures/dark-mode-cards/no-cards.css` —
+   discovering zero variants must report FAIL, not a clean sweep.
+
+Unchanged — `tests/test-dark-mode-table.sh` still passes all 26 results after
+its helpers moved to `tests/css-colour-lib.js`. No existing test was removed or
+modified.

--- a/helpers/repo-health-snippet.sh
+++ b/helpers/repo-health-snippet.sh
@@ -97,11 +97,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 repo-health-snippet.sh is a sourceable library, not a runnable script.
 
 Usage:
-    source /path/to/GRQ-health/helpers/repo-health-snippet.sh
+    $ source /path/to/GRQ-health/helpers/repo-health-snippet.sh
 
-    LOG_FILE="$HOME/logs/quality.log"
-    ./quality.sh >"$LOG_FILE" 2>&1
-    report_repo_health "Quality" "$LOG_FILE" || exit $?
+    $ LOG_FILE="$HOME/logs/quality.log"
+    $ ./quality.sh >"$LOG_FILE" 2>&1
+    $ report_repo_health "Quality" "$LOG_FILE" || exit $?
 
 See helpers/REPO_HEALTH_SNIPPET.md for copy-paste patterns.
 USAGE

--- a/run.sh
+++ b/run.sh
@@ -680,7 +680,7 @@ get_system_info() {
         local script_version="$VERSION"
         if [ -f /etc/os-release ]; then
             # Modern Linux systems - source the file and get proper version info
-            source /etc/os-release
+            source /etc/os-release  # skip: Linux-only file, guarded by the [ -f ] test above
             os_info="${NAME:-}"
             # Use VERSION_ID for version number, fallback to VERSION for descriptive version
             # Note: VERSION from /etc/os-release might overwrite script's VERSION, so we restore it after
@@ -695,7 +695,7 @@ get_system_info() {
             VERSION="$script_version"
         elif [ -f /etc/lsb-release ]; then
             # Ubuntu/Debian
-            source /etc/lsb-release
+            source /etc/lsb-release  # skip: Linux-only file, guarded by the [ -f ] test above
             os_info="${DISTRIB_ID:-}"
             os_version="${DISTRIB_RELEASE:-}"
             # Restore script's VERSION variable (in case it was somehow affected)

--- a/tests/css-colour-lib.js
+++ b/tests/css-colour-lib.js
@@ -1,0 +1,135 @@
+// Shared CSS-parsing and WCAG colour helpers for the dark-mode checkers.
+//
+// Extracted from tests/dark-mode-table-check.js (Issues #165/#170/#171) so the
+// generalised host-card sweep in tests/dark-mode-card-check.js (Issue #172) can
+// reuse the same parsing and colour maths rather than duplicating it.
+
+// --- Minimal CSS helpers ---------------------------------------------------
+
+// Comments must go first — otherwise they get swept into the selector capture.
+export function stripComments(css) {
+    return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+// Every `selectors { body }` pair in the stylesheet, selectors whitespace-normalised.
+export function* rules(css) {
+    for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+        yield {
+            selectors: match[1].split(",").map((s) => s.trim().replace(/\s+/g, " ")),
+            body: match[2],
+        };
+    }
+}
+
+// Return the declaration block for an exact selector, or null when absent.
+export function ruleBody(css, selector) {
+    for (const rule of rules(css)) {
+        if (rule.selectors.includes(selector)) return rule.body;
+    }
+    return null;
+}
+
+export function declarations(body) {
+    const out = {};
+    for (const decl of (body ?? "").split(";")) {
+        const idx = decl.indexOf(":");
+        if (idx === -1) continue;
+        out[decl.slice(0, idx).trim()] = decl.slice(idx + 1).trim()
+            .replace(/\s*!important\s*$/, "");
+    }
+    return out;
+}
+
+// Resolve `var(--x)` references against a palette, one hop at a time, so rules
+// may reuse the existing custom properties instead of colour literals.
+export function makeResolver(palette) {
+    return function resolveValue(value, depth = 0) {
+        if (!value || depth > 5) return value;
+        const varMatch = value.match(/^var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)$/);
+        if (!varMatch) return value;
+        const referenced = palette[varMatch[1]] ?? varMatch[2];
+        return resolveValue(referenced?.trim(), depth + 1);
+    };
+}
+
+// Split a `background` shorthand into its top-level layers, keeping the commas
+// inside `linear-gradient(...)` with their gradient. Layers are listed
+// top-most first, as CSS paints them.
+export function splitLayers(value) {
+    const layers = [];
+    let depth = 0;
+    let current = "";
+    for (const ch of value ?? "") {
+        if (ch === "(") depth++;
+        else if (ch === ")") depth--;
+        if (ch === "," && depth === 0) {
+            layers.push(current.trim());
+            current = "";
+        } else {
+            current += ch;
+        }
+    }
+    if (current.trim()) layers.push(current.trim());
+    return layers;
+}
+
+// --- Colour maths (WCAG 2.1 relative luminance and contrast) ---------------
+
+export function parseColour(value) {
+    if (!value) return null;
+    const v = value.trim().toLowerCase();
+    let m = v.match(/^#([0-9a-f]{3})$/);
+    if (m) {
+        const [r, g, b] = m[1].split("").map((c) => parseInt(c + c, 16));
+        return { r, g, b, a: 1 };
+    }
+    m = v.match(/^#([0-9a-f]{6})$/);
+    if (m) {
+        return {
+            r: parseInt(m[1].slice(0, 2), 16),
+            g: parseInt(m[1].slice(2, 4), 16),
+            b: parseInt(m[1].slice(4, 6), 16),
+            a: 1,
+        };
+    }
+    m = v.match(/^rgba?\(([^)]+)\)$/);
+    if (m) {
+        const parts = m[1].split(/[,/]/).map((p) => parseFloat(p.trim()));
+        if (parts.length < 3 || parts.some(Number.isNaN)) return null;
+        return { r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1 };
+    }
+    return null;
+}
+
+// Composite a possibly translucent colour over an opaque backdrop.
+export function flatten(colour, backdrop) {
+    if (colour.a >= 1) return colour;
+    return {
+        r: colour.r * colour.a + backdrop.r * (1 - colour.a),
+        g: colour.g * colour.a + backdrop.g * (1 - colour.a),
+        b: colour.b * colour.a + backdrop.b * (1 - colour.a),
+        a: 1,
+    };
+}
+
+export function luminance(colour) {
+    const channel = (c) => {
+        const s = c / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * channel(colour.r) + 0.7152 * channel(colour.g) + 0.0722 * channel(colour.b);
+}
+
+export function contrast(a, b) {
+    const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+// Largest per-channel difference between two opaque colours.
+export function channelDelta(a, b) {
+    return Math.max(Math.abs(a.r - b.r), Math.abs(a.g - b.g), Math.abs(a.b - b.b));
+}
+
+export function report(name, ok, detail) {
+    console.log(`TEST_RESULT:${name}:${ok ? "PASS" : "FAIL"}:${detail}`);
+}

--- a/tests/dark-mode-card-check.js
+++ b/tests/dark-mode-card-check.js
@@ -1,0 +1,178 @@
+// Issue #172: WCAG contrast regression guard for *every* .host-card variant in
+// dark mode.
+//
+// #161 introduced the dark palette; #165, #170 and #171 each fixed the same
+// fault afterwards — a component that hardcodes a light background survives the
+// `[data-theme="dark"]` switch, and the dark palette's light text then renders
+// on it unreadably. This checker generalises that class of test: it *enumerates*
+// the `.host-card.<variant>` rules present in docs/styles.css instead of working
+// from a fixed list, so a variant added later is covered without a test edit.
+//
+// For each variant it resolves the background the dark theme actually applies —
+// the `[data-theme="dark"]` override when present, otherwise whatever the base
+// rules leave in place — composites every layer and every gradient stop over the
+// dark page surface, and asserts WCAG 2.1 AA (4.5:1) against `--card-text` and
+// `--muted-color`.
+//
+// Usage: deno run --allow-read=<css> dark-mode-card-check.js <path-to-css>
+// Prints TEST_RESULT:<name>:<PASS|FAIL>:<detail> lines for the shell harness.
+
+import {
+    contrast,
+    declarations,
+    flatten,
+    luminance,
+    makeResolver,
+    parseColour,
+    report,
+    ruleBody,
+    rules,
+    splitLayers,
+    stripComments,
+} from "./css-colour-lib.js";
+
+const cssPath = Deno.args[0];
+if (!cssPath) {
+    console.error("usage: dark-mode-card-check.js <path-to-styles.css>");
+    Deno.exit(2);
+}
+const css = stripComments(await Deno.readTextFile(cssPath));
+
+const DARK = '[data-theme="dark"]';
+const NAME = "dark-mode-host-cards";
+const AA = 4.5;
+
+const darkPalette = declarations(ruleBody(css, DARK) ?? "");
+const resolve = makeResolver(darkPalette);
+
+// --- Variant enumeration ---------------------------------------------------
+
+// Every `.host-card.<variant>` rule in the stylesheet, whether it appears in the
+// base cascade or only under the dark theme. Pseudo-element decoration rules
+// (`.host-card.mia::before`) and compound selectors paint no card surface, so
+// only the bare variant selector counts.
+function discoverVariants() {
+    const found = new Set();
+    for (const rule of rules(css)) {
+        for (const selector of rule.selectors) {
+            const bare = selector.startsWith(`${DARK} `)
+                ? selector.slice(DARK.length + 1)
+                : selector;
+            const match = bare.match(/^\.host-card\.([\w-]+)$/);
+            if (match) found.add(match[1]);
+        }
+    }
+    return [...found].sort();
+}
+
+const variants = discoverVariants();
+report(
+    `${NAME}-variants-discovered`,
+    variants.length > 0,
+    variants.length > 0
+        ? `enumerated ${variants.length} .host-card variants from the stylesheet: ${
+            variants.join(", ")
+        }`
+        : "no .host-card.<variant> rules found — the sweep would pass by vacuity",
+);
+
+// --- Colours the dark theme resolves to ------------------------------------
+
+// The dark page surface every card is composited over.
+const pageSurface = parseColour(resolve(darkPalette["--card-bg"]));
+const textColours = [
+    ["card-text", parseColour(resolve(darkPalette["--card-text"]))],
+    ["muted-color", parseColour(resolve(darkPalette["--muted-color"]))],
+];
+
+// Fail loud rather than silently skipping the sweep when the palette moves.
+if (pageSurface === null || textColours.some(([, colour]) => colour === null)) {
+    report(
+        `${NAME}-dark-palette-resolves`,
+        false,
+        `${DARK} must define parseable --card-bg, --card-text and --muted-color`,
+    );
+    Deno.exit(0);
+}
+
+// The background the dark theme actually applies to a variant, and where it
+// came from. A variant with no surface of its own inherits the base `.host-card`
+// background, which is what makes an unfixed light literal show up here.
+function effectiveBackground(variant) {
+    const sources = [
+        [`${DARK} .host-card.${variant}`, ruleBody(css, `${DARK} .host-card.${variant}`)],
+        [`.host-card.${variant}`, ruleBody(css, `.host-card.${variant}`)],
+        [`${DARK} .host-card`, ruleBody(css, `${DARK} .host-card`)],
+        [".host-card", ruleBody(css, ".host-card")],
+    ];
+    for (const [selector, body] of sources) {
+        if (body === null) continue;
+        const decls = declarations(body);
+        const value = decls["background"] ?? decls["background-color"];
+        if (value) return { selector, value };
+    }
+    return null;
+}
+
+// Every colour a surface paints, each composited over what sits beneath it:
+// layers bottom-up (CSS lists them top-most first) and gradients stop by stop,
+// so a gradient that starts dark and ends light is still measured at its light
+// end. Translucent layers are composited, never treated as opaque — these
+// backgrounds are `rgba(...)` washes whose alpha is the whole point.
+function surfaceStops(value) {
+    const layers = splitLayers(value);
+    const stops = [];
+    let backdrop = pageSurface;
+    for (let i = layers.length - 1; i >= 0; i--) {
+        const tokens = layers[i].match(/#[0-9a-fA-F]{3,8}\b|rgba?\([^)]*\)|var\(\s*--[\w-]+\s*\)/g);
+        const colours = (tokens ?? []).map((t) => parseColour(resolve(t))).filter((c) => c !== null);
+        if (colours.length === 0) continue;
+        const flats = colours.map((colour, idx) => ({
+            colour: flatten(colour, backdrop),
+            label: layers.length > 1 ? `layer ${i + 1} stop ${idx + 1}` : `stop ${idx + 1}`,
+        }));
+        stops.push(...flats);
+        // Worst case for light text is the lightest thing showing through.
+        backdrop = flats.reduce(
+            (worst, s) => luminance(s.colour) > luminance(worst) ? s.colour : worst,
+            flats[0].colour,
+        );
+    }
+    return stops;
+}
+
+// --- The sweep -------------------------------------------------------------
+
+for (const variant of variants) {
+    const background = effectiveBackground(variant);
+    const stops = background ? surfaceStops(background.value) : [];
+
+    if (stops.length === 0) {
+        for (const [label] of textColours) {
+            report(
+                `${NAME}-${variant}-${label}`,
+                false,
+                background === null
+                    ? `.host-card.${variant} resolves to no background at all in dark mode`
+                    : `.host-card.${variant} background from ${background.selector} is unparseable`,
+            );
+        }
+        continue;
+    }
+
+    for (const [label, textColour] of textColours) {
+        // Every stop is measured; the worst one decides the verdict.
+        let worst = null;
+        for (const stop of stops) {
+            const ratio = contrast(flatten(textColour, stop.colour), stop.colour);
+            if (worst === null || ratio < worst.ratio) worst = { ratio, label: stop.label };
+        }
+        report(
+            `${NAME}-${variant}-${label}`,
+            worst.ratio >= AA,
+            `--${label} on .host-card.${variant} (${background.selector}) ` +
+                `${worst.ratio.toFixed(2)}:1 at worst of ${stops.length} stop(s), ` +
+                `${worst.label} (needs >= ${AA})`,
+        );
+    }
+}

--- a/tests/dark-mode-table-check.js
+++ b/tests/dark-mode-table-check.js
@@ -5,102 +5,34 @@
 // Usage: deno run --allow-read=<css> dark-mode-table-check.js <path-to-css>
 // Prints TEST_RESULT:<name>:<PASS|FAIL>:<detail> lines for the shell harness.
 
+// The CSS parsing and colour maths live in tests/css-colour-lib.js so the
+// generalised host-card sweep (Issue #172) shares them rather than copying them.
+import {
+    channelDelta,
+    contrast,
+    declarations,
+    flatten,
+    luminance,
+    makeResolver,
+    parseColour,
+    report,
+    ruleBody as ruleBodyIn,
+    stripComments,
+} from "./css-colour-lib.js";
+
 const cssPath = Deno.args[0];
 if (!cssPath) {
     console.error("usage: dark-mode-table-check.js <path-to-styles.css>");
     Deno.exit(2);
 }
-// Strip comments first — otherwise they get swept into the selector capture.
-const css = (await Deno.readTextFile(cssPath)).replace(/\/\*[\s\S]*?\*\//g, "");
+const css = stripComments(await Deno.readTextFile(cssPath));
 
-// --- Minimal CSS helpers ---------------------------------------------------
-
-// Return the declaration block for an exact selector, or null when absent.
-function ruleBody(selector) {
-    // Selectors are matched literally against the text preceding each `{`.
-    for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-        const selectors = match[1].split(",").map((s) => s.trim().replace(/\s+/g, " "));
-        if (selectors.includes(selector)) return match[2];
-    }
-    return null;
-}
-
-function declarations(body) {
-    const out = {};
-    for (const decl of body.split(";")) {
-        const idx = decl.indexOf(":");
-        if (idx === -1) continue;
-        out[decl.slice(0, idx).trim()] = decl.slice(idx + 1).trim();
-    }
-    return out;
-}
+const ruleBody = (selector) => ruleBodyIn(css, selector);
 
 // Resolve `var(--x)` references against the dark palette block, one hop at a
 // time, so the table rules may reuse the existing dark custom properties.
 const darkPalette = declarations(ruleBody('[data-theme="dark"]') ?? "");
-function resolveValue(value, depth = 0) {
-    if (!value || depth > 5) return value;
-    const varMatch = value.match(/^var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)$/);
-    if (!varMatch) return value;
-    const referenced = darkPalette[varMatch[1]] ?? varMatch[2];
-    return resolveValue(referenced?.trim(), depth + 1);
-}
-
-// --- Colour maths (WCAG 2.1 relative luminance and contrast) ---------------
-
-function parseColour(value) {
-    if (!value) return null;
-    const v = value.trim().toLowerCase();
-    let m = v.match(/^#([0-9a-f]{3})$/);
-    if (m) {
-        const [r, g, b] = m[1].split("").map((c) => parseInt(c + c, 16));
-        return { r, g, b, a: 1 };
-    }
-    m = v.match(/^#([0-9a-f]{6})$/);
-    if (m) {
-        return {
-            r: parseInt(m[1].slice(0, 2), 16),
-            g: parseInt(m[1].slice(2, 4), 16),
-            b: parseInt(m[1].slice(4, 6), 16),
-            a: 1,
-        };
-    }
-    m = v.match(/^rgba?\(([^)]+)\)$/);
-    if (m) {
-        const parts = m[1].split(/[,/]/).map((p) => parseFloat(p.trim()));
-        if (parts.length < 3 || parts.some(Number.isNaN)) return null;
-        return { r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1 };
-    }
-    return null;
-}
-
-// Composite a possibly translucent colour over an opaque backdrop.
-function flatten(colour, backdrop) {
-    if (colour.a >= 1) return colour;
-    return {
-        r: colour.r * colour.a + backdrop.r * (1 - colour.a),
-        g: colour.g * colour.a + backdrop.g * (1 - colour.a),
-        b: colour.b * colour.a + backdrop.b * (1 - colour.a),
-        a: 1,
-    };
-}
-
-function luminance(colour) {
-    const channel = (c) => {
-        const s = c / 255;
-        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
-    };
-    return 0.2126 * channel(colour.r) + 0.7152 * channel(colour.g) + 0.0722 * channel(colour.b);
-}
-
-function contrast(a, b) {
-    const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
-    return (hi + 0.05) / (lo + 0.05);
-}
-
-function report(name, ok, detail) {
-    console.log(`TEST_RESULT:${name}:${ok ? "PASS" : "FAIL"}:${detail}`);
-}
+const resolveValue = makeResolver(darkPalette);
 
 // Pull every colour token out of a `background` shorthand — including the stops
 // of a linear-gradient and any layered translucent washes — so a surface built
@@ -209,11 +141,6 @@ function checkHostCardVariant(key, selector, label) {
     }
 
     return surface;
-}
-
-// Largest per-channel difference between two opaque colours.
-function channelDelta(a, b) {
-    return Math.max(Math.abs(a.r - b.r), Math.abs(a.g - b.g), Math.abs(a.b - b.b));
 }
 
 const miaSurface = checkHostCardVariant("mia", ".host-card.mia", "MIA card");

--- a/tests/fixtures/dark-mode-cards/no-cards.css
+++ b/tests/fixtures/dark-mode-cards/no-cards.css
@@ -1,0 +1,13 @@
+/* Fixture for Issue #172: a stylesheet with no .host-card variants at all.
+   The checker must report its enumeration as FAILED rather than sweeping zero
+   variants and reporting a clean run. */
+
+[data-theme="dark"] {
+    --card-bg: #23263a;
+    --card-text: #e8e8f2;
+    --muted-color: #9aa0b8;
+}
+
+.panel {
+    background: var(--card-bg);
+}

--- a/tests/fixtures/dark-mode-cards/variants.css
+++ b/tests/fixtures/dark-mode-cards/variants.css
@@ -1,0 +1,62 @@
+/* Fixture for Issue #172: a synthetic stylesheet whose expected verdicts are
+   known, used to prove tests/dark-mode-card-check.js actually detects the
+   defect class rather than passing by vacuity. Not shipped to the dashboard. */
+
+[data-theme="dark"] {
+    --card-bg: #23263a;
+    --card-text: #e8e8f2;
+    --muted-color: #9aa0b8;
+}
+
+.host-card {
+    background: var(--card-bg);
+    color: var(--card-text);
+}
+
+/* PASS — a light base gradient with a dark wash override, the shape the
+   #170/#171 fixes use. */
+.host-card.fixture-good {
+    background: linear-gradient(135deg, rgba(255,255,255,0.98) 0%, rgba(240,255,250,0.98) 100%);
+}
+
+[data-theme="dark"] .host-card.fixture-good {
+    background:
+        linear-gradient(135deg, rgba(32, 201, 151, 0.04) 0%, rgba(32, 201, 151, 0.10) 100%),
+        var(--card-bg);
+}
+
+/* Decoration rules paint no card surface — enumeration must ignore them. */
+.host-card.fixture-good::before {
+    content: "🌐";
+    background: #ffffff;
+}
+
+/* FAIL — the unfixed defect: a light literal with no dark override. */
+.host-card.fixture-light {
+    background: linear-gradient(135deg, rgba(255,255,255,0.98) 0%, rgba(255,248,220,0.98) 100%);
+}
+
+/* FAIL — starts dark and ends near-white, so only a checker that evaluates
+   every gradient stop catches it. */
+.host-card.fixture-tail-light {
+    background: #ffffff;
+}
+
+[data-theme="dark"] .host-card.fixture-tail-light {
+    background: linear-gradient(135deg, rgba(32,201,151,0.05) 0%, rgba(240,255,250,0.98) 100%);
+}
+
+/* PASS — a barely-there white wash. Only correct alpha compositing keeps this
+   dark; treating rgba() as opaque would call it white and fail it. */
+[data-theme="dark"] .host-card.fixture-alpha-wash {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.host-card.fixture-alpha-wash {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+/* FAIL — translucent but at 0.98, so compositing barely darkens it. */
+.host-card.fixture-alpha-solid {
+    background: rgba(255, 255, 255, 0.98);
+}

--- a/tests/test-dark-mode-host-cards.sh
+++ b/tests/test-dark-mode-host-cards.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Test for Issue #172: a WCAG contrast regression guard covering every
+# .host-card variant in dark mode.
+#
+# #161 introduced the dark palette, and #165, #170 and #171 then fixed the same
+# fault three times over: a component hardcodes a light background, survives the
+# `[data-theme="dark"]` switch, and the dark palette's light text renders on it
+# unreadably. Each instance was found by a human looking at a phone screenshot,
+# because nothing in the suite covered the class of defect.
+#
+# tests/dark-mode-card-check.js closes that gap by *enumerating* the
+# `.host-card.<variant>` rules in docs/styles.css rather than working from a
+# fixed list, resolving the background the dark theme actually applies to each
+# one (gradient stop by gradient stop, translucent layers composited over the
+# dark page surface) and asserting WCAG 2.1 AA against --card-text and
+# --muted-color. A new variant with a light background and no dark override
+# fails here without any edit to this test.
+#
+# Two self-tests keep the guard honest:
+#   * tests/fixtures/dark-mode-cards/variants.css has known-good and known-bad
+#     variants, so a checker that stopped detecting the defect (gradient stops
+#     skipped, alpha treated as opaque, dark override resolution broken) fails.
+#   * tests/fixtures/dark-mode-cards/no-cards.css has no variants at all, so a
+#     broken enumeration reports zero variants and goes red instead of
+#     green-by-vacuity.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+STYLES_CSS="$ROOT_DIR/docs/styles.css"
+FIXTURES="$SCRIPT_DIR/fixtures/dark-mode-cards"
+CHECKER="$SCRIPT_DIR/dark-mode-card-check.js"
+DENO="$HOME/.deno/bin/deno"
+
+echo "Testing Issue #172: dark mode host-card contrast sweep"
+echo "==========================================="
+echo ""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+OUTPUT=""
+
+pass() {
+    echo "  PASS: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Run the checker over a stylesheet, failing loud if it errors out rather than
+# treating "no results" as a clean run.
+run_checker() {
+    local css="$1"
+    if ! OUTPUT="$("$DENO" run --allow-read="$css" "$CHECKER" "$css" < /dev/null 2>&1)"; then
+        echo "$OUTPUT"
+        return 1
+    fi
+    if [ -z "$OUTPUT" ]; then
+        echo "  (checker produced no TEST_RESULT lines for $css)"
+        return 1
+    fi
+    return 0
+}
+
+# Verdict recorded for a named result in the last run, or "MISSING".
+verdict_of() {
+    local name="$1" line
+    line="$(printf '%s\n' "$OUTPUT" | grep "^TEST_RESULT:${name}:" | head -1)"
+    if [ -z "$line" ]; then
+        echo "MISSING"
+    else
+        echo "$line" | cut -d: -f3
+    fi
+}
+
+expect_verdict() {
+    local name="$1" expected="$2" why="$3" actual detail
+    actual="$(verdict_of "$name")"
+    detail="$(printf '%s\n' "$OUTPUT" | grep "^TEST_RESULT:${name}:" | head -1 | cut -d: -f4-)"
+    if [ "$actual" = "$expected" ]; then
+        pass "$name is $expected — $why"
+    else
+        fail "$name is $actual, expected $expected — $why ${detail:+[$detail]}"
+    fi
+}
+
+if [ ! -x "$DENO" ]; then
+    echo "  FAIL: deno not found at $DENO — cannot verify dark mode colours"
+    exit 1
+fi
+
+# --- 1. The real stylesheet: every enumerated variant must meet AA -----------
+
+echo "docs/styles.css — every .host-card variant in dark mode:"
+if ! run_checker "$STYLES_CSS"; then
+    echo "  FAIL: dark-mode-card-check.js failed on docs/styles.css"
+    exit 1
+fi
+
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*)
+            name="$(echo "$line" | cut -d: -f2)"
+            result="$(echo "$line" | cut -d: -f3)"
+            detail="$(echo "$line" | cut -d: -f4-)"
+            if [ "$result" = "PASS" ]; then
+                pass "$name — $detail"
+            else
+                fail "$name — $detail"
+            fi
+            ;;
+        *) [ -n "$line" ] && echo "  $line" ;;
+    esac
+done <<< "$OUTPUT"
+
+echo ""
+
+# --- 2. Self-test: the checker must still detect the defect it guards --------
+
+echo "fixture sweep — the checker's own verdicts on known-good/known-bad CSS:"
+if ! run_checker "$FIXTURES/variants.css"; then
+    echo "  FAIL: dark-mode-card-check.js failed on the fixture stylesheet"
+    exit 1
+fi
+
+expect_verdict "dark-mode-host-cards-variants-discovered" PASS \
+    "fixture variants are enumerated from the CSS"
+expect_verdict "dark-mode-host-cards-fixture-good-card-text" PASS \
+    "a dark wash over var(--card-bg) is readable"
+expect_verdict "dark-mode-host-cards-fixture-good-muted-color" PASS \
+    "muted labels are readable on the dark wash"
+expect_verdict "dark-mode-host-cards-fixture-light-card-text" FAIL \
+    "a light gradient with no dark override is the unfixed defect"
+expect_verdict "dark-mode-host-cards-fixture-light-muted-color" FAIL \
+    "muted labels are worse still on the light gradient"
+expect_verdict "dark-mode-host-cards-fixture-tail-light-card-text" FAIL \
+    "a gradient that starts dark and ends light is caught at its last stop"
+expect_verdict "dark-mode-host-cards-fixture-alpha-wash-card-text" PASS \
+    "a 4% white wash composites to a dark surface, it is not opaque white"
+expect_verdict "dark-mode-host-cards-fixture-alpha-solid-card-text" FAIL \
+    "a 98% white wash composites to a light surface"
+
+# The pseudo-element rule in the fixture paints no card surface — enumerating it
+# would measure a decoration rather than the card.
+if printf '%s\n' "$OUTPUT" | grep -q "^TEST_RESULT:dark-mode-host-cards-fixture-good::before"; then
+    fail "enumeration picked up a ::before decoration rule as a variant"
+else
+    pass "enumeration ignores ::before/::after decoration rules"
+fi
+
+echo ""
+
+# --- 3. Guard-degradation: a broken enumeration must go red, not green ------
+
+echo "guard-degradation — a stylesheet with no variants must not pass by vacuity:"
+if ! run_checker "$FIXTURES/no-cards.css"; then
+    echo "  FAIL: dark-mode-card-check.js failed on the empty fixture"
+    exit 1
+fi
+
+expect_verdict "dark-mode-host-cards-variants-discovered" FAIL \
+    "discovering zero .host-card variants is itself a failure"
+
+echo ""
+echo "==========================================="
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$PASS_COUNT" -eq 0 ]; then
+    echo "TESTS FAILED - no results produced"
+    exit 1
+fi
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "TESTS FAILED"
+    exit 1
+fi
+
+echo "All tests passed!"


### PR DESCRIPTION
## Summary

Adds a WCAG contrast regression guard that covers **every** `.host-card` variant
in dark mode, rather than the three the existing checker names. Closes #172.

The same defect shipped three times — #165 (Bootstrap `.table`), #169 (`.mia`)
and #171 (`.mobile`, `.outdated-macos`): a component hardcodes a light
background, survives the `[data-theme="dark"]` switch, and the dark palette's
light text renders on it unreadably. Each was found by a human looking at a
phone screenshot because nothing in the suite covered the class of defect.

- `tests/dark-mode-card-check.js` **enumerates** the `.host-card.<variant>`
  rules in `docs/styles.css` (base cascade and dark theme, ignoring `::before` /
  `::after` decoration rules) and measures each one. A variant added later is
  covered with no test edit.
- For each variant it resolves the background the dark theme actually applies —
  the `[data-theme="dark"] .host-card.<variant>` override if present, else the
  base variant rule, else the inherited `.host-card` background — composites
  every background layer and **every gradient stop** over the dark `--card-bg`,
  and asserts ≥ 4.5:1 against `--card-text` and `--muted-color`.
- Translucent `rgba(...)` washes are composited before the ratio is computed,
  never treated as opaque; the `0.98` alpha on the old light gradients is the
  whole reason the defect is subtle.
- Discovering **zero** variants is itself a `FAIL`, and the discovered count is
  reported in the `TEST_RESULT` detail, so a stylesheet rename or a CSS-parsing
  regression cannot turn the guard green by vacuity.
- `tests/test-dark-mode-host-cards.sh` is the shell harness, following the
  existing `TEST_RESULT:<name>:<PASS|FAIL>:<detail>` convention. It is picked up
  automatically by `./quality.sh`, which globs `tests/test-*.sh`.
- CSS parsing and colour maths move to `tests/css-colour-lib.js`, shared by the
  new sweep and the existing `tests/dark-mode-table-check.js` (behaviour of the
  latter is unchanged — all 26 of its results still pass).

**Ordering:** both fix sub-issues (#170, #171) have already landed on
`milestone/169-tinas-macbook-unreadable-in-dark-mode`, so this test is green on
the branch it targets. Nothing needs quarantining. Its positive control against
`Develop` is below.

## Evidence

No UI change — this PR adds tests and documentation only, so there is nothing to
screenshot. The dashboard renders identically before and after; the evidence is
the checker's behaviour.

```mermaid
flowchart LR
    A[docs/styles.css] --> B[enumerate .host-card variants]
    B --> C{dark override?}
    C -->|yes| D["[data-theme=dark] rule background"]
    C -->|no| E[base rule background]
    D --> F[composite layers + gradient stops<br/>over the dark --card-bg]
    E --> F
    F --> G{">= 4.5:1 vs --card-text<br/>and --muted-color?"}
    G -->|no| H[TEST_RESULT ... FAIL]
    G -->|yes| I[TEST_RESULT ... PASS]
```

**Positive control — the checker run against the current `Develop` tree** (the
acceptance criterion that it goes red there, flagging exactly the three unfixed
variants):

```
TEST_RESULT:dark-mode-host-cards-variants-discovered:PASS:enumerated 8 .host-card variants from the stylesheet: critical, dead, healthy, historical, mia, mobile, outdated-macos, warning
TEST_RESULT:dark-mode-host-cards-mia-card-text:FAIL:--card-text on .host-card.mia (.host-card.mia) 1.12:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
TEST_RESULT:dark-mode-host-cards-mia-muted-color:FAIL:--muted-color on .host-card.mia (.host-card.mia) 2.38:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
TEST_RESULT:dark-mode-host-cards-mobile-card-text:FAIL:--card-text on .host-card.mobile (.host-card.mobile) 1.01:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
TEST_RESULT:dark-mode-host-cards-mobile-muted-color:FAIL:--muted-color on .host-card.mobile (.host-card.mobile) 2.15:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
TEST_RESULT:dark-mode-host-cards-outdated-macos-card-text:FAIL:--card-text on .host-card.outdated-macos (.host-card.outdated-macos) 1.09:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
TEST_RESULT:dark-mode-host-cards-outdated-macos-muted-color:FAIL:--muted-color on .host-card.outdated-macos (.host-card.outdated-macos) 2.32:1 at worst of 3 stop(s), stop 3 (needs >= 4.5)
```

**On this branch** (both fixes landed) all 8 variants pass, e.g.:

```
PASS: dark-mode-host-cards-mia-card-text — --card-text on .host-card.mia ([data-theme="dark"] .host-card.mia) 10.24:1 at worst of 4 stop(s), layer 1 stop 3 (needs >= 4.5)
PASS: dark-mode-host-cards-warning-card-text — --card-text on .host-card.warning (.host-card) 12.24:1 at worst of 1 stop(s), stop 1 (needs >= 4.5)
```

`./quality.sh`: 63/63 passed, including `test-dark-mode-host-cards` and the
unchanged `test-dark-mode-table`.

## Test Plan

New — `tests/test-dark-mode-host-cards.sh` (27 assertions, three stages):

1. **The real stylesheet** — every enumerated `.host-card` variant in
   `docs/styles.css` must meet 4.5:1 against `--card-text` and `--muted-color`.
2. **Self-test of the detector** against
   `tests/fixtures/dark-mode-cards/variants.css`, which pins the verdicts the
   checker must produce:
   - `fixture-good` (dark wash over `var(--card-bg)`) → PASS
   - `fixture-light` (light gradient, no dark override) → FAIL — the unfixed
     defect
   - `fixture-tail-light` (gradient starting dark, ending near-white) → FAIL —
     fails only if every stop is evaluated
   - `fixture-alpha-wash` (`rgba(255,255,255,0.04)`) → PASS — passes only if
     alpha is composited rather than treated as opaque
   - `fixture-alpha-solid` (`rgba(255,255,255,0.98)`) → FAIL
   - `.host-card.fixture-good::before` must not be enumerated as a variant
3. **Guard-degradation** against `tests/fixtures/dark-mode-cards/no-cards.css` —
   discovering zero variants must report FAIL, not a clean sweep.

Unchanged — `tests/test-dark-mode-table.sh` still passes all 26 results after
its helpers moved to `tests/css-colour-lib.js`. No existing test was removed or
modified.
