### PR TITLE
Truncate the host-card hostname instead of wrapping it (Issue #174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,39 @@ decorated variant is covered without a test edit. The fixtures in
 `tests/status-overflow.test.html` carries the matching browser cases, which
 hit-test the rendered badge with `document.elementFromPoint()`.
 
+#### The hostname truncates, it never wraps (Issue #174)
+
+`.host-card h5` carried `overflow: hidden; text-overflow: ellipsis` with no
+`white-space: nowrap`. `text-overflow` only fires on text that overflows a
+**single** line, so a long hostname such as `Tinas-MacBook-Air` wrapped instead
+— "Air" dropped onto a second line, the header grew taller and pushed into the
+"OFF THE GRID" badge.
+
+The header is a flex row, and a flex container cannot truncate its own children,
+so the ellipsis is applied to the hostname **text run** rather than the header:
+each card template wraps the hostname in `<span class="hostname-text">`, which
+carries `min-width: 0`, `overflow: hidden`, `text-overflow: ellipsis` and
+`white-space: nowrap`. The machine-type and "Worker silent" badges are its
+siblings with `flex-shrink: 0`, so they stay beside the ellipsis rather than
+being clipped away, and the span carries a `title` attribute so the full
+hostname is still readable on a phone.
+
+```mermaid
+flowchart LR
+    A[".host-card h5 — display: flex, overflow: hidden"] --> B["span.hostname-text<br/>min-width: 0, nowrap, ellipsis"]
+    A --> C["span.badge — flex-shrink: 0<br/>Mac mini / Worker silent"]
+    B -->|"title attribute"| D["full hostname on hover/long-press"]
+```
+
+`tests/test-status-overflow.sh` runs `tests/hostname-truncation-check.js`, which
+locates the element holding the hostname text run in **every** `<h5>` card
+template in `docs/dashboard.js`, resolves the CSS applying to it and asks whether
+that box can truncate — so the header may be restructured freely as long as the
+hostname still lands in a truncating box with its badges intact. The fixtures in
+`tests/fixtures/hostname-truncation/` are the checker's self-test, and
+`tests/status-overflow.test.html` carries the matching browser cases, which
+measure the rendered line boxes of a `Tinas-MacBook-Air` card.
+
 ### Emoji Legend
 
 - 💀 Dead machines (in Silicon Heaven)

--- a/docs/archive/pr-summaries/pr-summary-174.md
+++ b/docs/archive/pr-summaries/pr-summary-174.md
@@ -1,0 +1,42 @@
+## Summary
+
+`.host-card h5` carried `min-width: 0; overflow: hidden; text-overflow: ellipsis` with no `white-space: nowrap`. `text-overflow` only fires on text that overflows a **single** line, so the hostname wrapped rather than overflowing, the ellipsis never triggered and `overflow: hidden` had nothing to clip — `Tinas-MacBook-Air` dropped "Air" onto a second line and the taller header pushed into the "OFF THE GRID" badge (the #169 signature). Closes #174.
+
+The header is a flex row, and a flex container cannot truncate its own children, so the ellipsis is applied to the hostname **text run** instead of the header. All four `<h5>` card templates in `docs/dashboard.js` (dead, historical, MIA and active) now wrap the hostname in `<span class="hostname-text" title="…">`, which carries `min-width: 0`, `overflow: hidden`, `text-overflow: ellipsis` and `white-space: nowrap`. `.host-card h5` becomes the flex row (so the plain MIA header gets the same treatment as the active one) and `.host-card h5 .badge` gets `flex-shrink: 0`, so the machine-type ("Mac mini") and "Worker silent" badges stay beside the ellipsis rather than being clipped away. The `title` attribute keeps the full hostname readable where the truncation is aggressive, i.e. on a phone.
+
+```mermaid
+flowchart LR
+    A[".host-card h5 — display: flex, overflow: hidden"] --> B["span.hostname-text<br/>min-width: 0, nowrap, ellipsis"]
+    A --> C["span.badge — flex-shrink: 0<br/>Mac mini / Worker silent"]
+    B -->|"title attribute"| D["full hostname on hover / long-press"]
+```
+
+## Evidence
+
+**No screenshot: no browser was available on this host.** Playwright MCP was not configured for this run, and the Chromium build under `~/Library/Caches/ms-playwright/` hung without producing a frame on every invocation (headless old and new, sandboxed and not, including on a trivial `data:` URL) — so `tests/status-overflow.test.html` could not be rendered here. The browser cases were added anyway and run in any environment that has a working Chromium; the shell gate below is what CI enforces.
+
+Automated verification, run against the unfixed tree and the fixed one:
+
+| Check | Unfixed | Fixed |
+| --- | --- | --- |
+| `tests/hostname-truncation-check.js` on `docs/styles.css` + `docs/dashboard.js` | 13 failures across all 4 header templates (wrapping, inert ellipsis, no `title`, badge inside the truncating box) | 25 checks, 0 failures |
+| `tests/test-status-overflow.sh` | red — Test 6 reports "13 hostname truncation check(s) failed" | 36 assertions, all pass |
+| `./quality.sh` | — | 64 / 64 passed |
+
+The unfixed verdicts, straight from the checker before the fix:
+
+```text
+TEST_RESULT:hostname-truncation-line-1154-cannot-wrap:FAIL:the hostname text run sits in
+  <h5 class="mb-0"> with white-space: normal — the text wraps onto a second line instead of
+  overflowing, so the ellipsis never fires
+TEST_RESULT:hostname-truncation-line-1254-badges-not-clipped:FAIL:1 badge(s) beside the
+  hostname, flex-shrink: 1 — a badge sits inside the truncating box and would be clipped away
+```
+
+## Test Plan
+
+- **Added `tests/hostname-truncation-check.js`** — for every `<h5>` host-card header template in `docs/dashboard.js` it locates the element that actually holds the hostname *text run*, resolves the CSS applying to that element, and asks whether the resulting box can truncate: `white-space` cannot wrap, `overflow`/`text-overflow` make the ellipsis effective, the box can shrink below its content width, the full hostname stays discoverable via `title`, the header lays its children out in a row, and the badges sit outside the truncating box with `flex-shrink: 0`. It asserts an outcome rather than a declaration in a fixed selector, so the header may be restructured freely as long as the hostname still truncates with its badges intact — and it goes red the moment `white-space: nowrap` is dropped.
+- **Extended `tests/test-status-overflow.sh`** with Tests 6–8. Test 6 sweeps the real stylesheet and dashboard (it failed with 13 failures before the fix and passes after — closing the gap left by Test 4, which only ever checked `min-width: 0`). Test 7 is the checker's self-test against `tests/fixtures/hostname-truncation/pre-fix.{css,js}`, the exact pre-fix state, where the wrapping, missing-`title` and clipped-badge verdicts must still come back FAIL. Test 8 is guard degradation: `no-headers.js` must make discovery go red rather than pass by vacuity.
+- **Extended `tests/status-overflow.test.html`** with four Issue #174 browser cases (MIA and active header shapes, `Tinas-MacBook-Air` at 320px/360px, a longer name at a 280px phone width, and a short `GRQ-23` control that must *not* be truncated). Each measures the rendered result: the hostname's client rects must form exactly one line box, `scrollWidth > clientWidth` must match the expected truncation, the status badge must share the hostname's line and stay inside the card, and every machine-type / "Worker silent" badge must have a non-zero box inside the card bounds.
+- **Updated `README.md`** with a "The hostname truncates, it never wraps (Issue #174)" section, including a Mermaid diagram of the header layout.
+- Version bumped to 1.1.25 and synced with `./update_version.sh`.

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,5 +1,5 @@
 // Version constant - this will be updated by the git hook
-const VERSION = "1.1.24";
+const VERSION = "1.1.25";
 
 // Set page title with version
 document.title = `GRQ Health Dashboard v${VERSION}`;
@@ -1094,7 +1094,7 @@ function createHostCard(hostname, data) {
             <div class="col-lg-6 col-xl-4">
                 <div class="host-card dead" data-status="dead">
                     <div class="d-flex justify-content-between align-items-center mb-3">
-                        <h5 class="mb-0">${emoji} ${safeHostname}</h5>
+                        <h5 class="mb-0"><span class="hostname-text" title="${safeHostname}">${emoji} ${safeHostname}</span></h5>
                         <span class="health-status dead">Dead</span>
                     </div>
                     ${location ? `<div class="location mb-2"><small class="text-muted">📍 ${location}</small></div>` : ''}
@@ -1120,7 +1120,7 @@ function createHostCard(hostname, data) {
             <div class="col-lg-6 col-xl-4">
                 <div class="host-card historical" data-status="historical">
                     <div class="d-flex justify-content-between align-items-center mb-3">
-                        <h5 class="mb-0">${emoji} ${safeHostname}</h5>
+                        <h5 class="mb-0"><span class="hostname-text" title="${safeHostname}">${emoji} ${safeHostname}</span></h5>
                         <span class="health-status historical">Historical</span>
                     </div>
                     ${location ? `<div class="location mb-2"><small class="text-muted">📍 ${location}</small></div>` : ''}
@@ -1151,7 +1151,7 @@ function createHostCard(hostname, data) {
             <div class="col-lg-6 col-xl-4">
                 <div class="host-card mia" data-status="mia">
                     <div class="d-flex justify-content-between align-items-center mb-3">
-                        <h5 class="mb-0">${miaEmoji} ${safeHostname}</h5>
+                        <h5 class="mb-0"><span class="hostname-text" title="${safeHostname}">${miaEmoji} ${safeHostname}</span></h5>
                         <span class="health-status mia">Off the Grid</span>
                     </div>
                     ${location ? `<div class="location mb-2"><small class="text-muted">📍 ${location}</small></div>` : ''}
@@ -1252,7 +1252,7 @@ function createHostCard(hostname, data) {
             <div class="host-card ${statusClass}${mobileClass}${outdatedMacClass}" data-status="${healthStatus}" data-hostname="${escapeHtml(hostname)}">
                 <div class="d-flex justify-content-between align-items-center mb-3">
                     <h5 class="mb-0 d-flex align-items-center">
-                        ${emoji} ${safeHostname}
+                        <span class="hostname-text" title="${safeHostname}">${emoji} ${safeHostname}</span>
                         ${data.machine_type && data.machine_type !== 'unknown' && data.machine_type !== '' ? `<span class="badge bg-secondary ms-2" style="font-size: 0.7rem;">${escapeHtml(data.machine_type)}</span>` : ''}
                         ${workerSilentBadge}
                     </h5>

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="./styles.css?v=1.1.24" rel="stylesheet">
+    <link href="./styles.css?v=1.1.25" rel="stylesheet">
     <link href="./theme.css?v=1.1.20" rel="stylesheet">
 </head>
 <body>
@@ -124,14 +124,14 @@
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="./theme.js?v=1.1.20"></script>
-    <script src="./dashboard.js?v=1.1.24"></script>
+    <script src="./dashboard.js?v=1.1.25"></script>
     
     <!-- PWA Service Worker Registration -->
     <script>
         // Register service worker only if supported
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./sw.js?v=1.1.24')
+                navigator.serviceWorker.register('./sw.js?v=1.1.25')
                     .then((registration) => {
                         console.log('Service Worker registered successfully:', registration.scope);
                         

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -327,11 +327,29 @@ body.offline-mode .alert-warning {
     isolation: isolate;
 }
 
-/* Ensure hostname truncates properly without pushing status badge out */
+/* Ensure hostname truncates properly without pushing status badge out.
+   Issue #174: text-overflow: ellipsis only fires on text that overflows a
+   *single* line, so the hostname text run needs white-space: nowrap — without
+   it the text simply wrapped and the ellipsis never triggered. The rules are
+   split because the header is a flex row: a flex container cannot truncate its
+   children, so the ellipsis is applied to .hostname-text (the text run itself)
+   and the machine-type / worker-silent badges stay beside it, unclipped. */
 .host-card h5 {
     min-width: 0;
     overflow: hidden;
+    display: flex;
+    align-items: center;
+}
+
+.host-card h5 .hostname-text {
+    min-width: 0;
+    overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.host-card h5 .badge {
+    flex-shrink: 0;
 }
 
 .host-card:hover {

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,8 +1,8 @@
 // GRQ Health Dashboard Service Worker
-// Version: 1.1.24
+// Version: 1.1.25
 
-const CACHE_NAME = 'grq-health-v1.1.24';
-const STATIC_CACHE_NAME = 'grq-health-static-v1.1.24';
+const CACHE_NAME = 'grq-health-v1.1.25';
+const STATIC_CACHE_NAME = 'grq-health-static-v1.1.25';
 
 // Files to cache for offline functionality
 const STATIC_FILES = [
@@ -11,7 +11,7 @@ const STATIC_FILES = [
   './styles.css',
   './theme.css?v=1.1.19',
   './theme.js?v=1.1.19',
-  './dashboard.js?v=1.1.24',
+  './dashboard.js?v=1.1.25',
   './medical-check.png',
   './unhealthy.png',
   './manifest.json',

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ fi
 # Configuration
 JSON_FILE="docs/index.json"
 HEARTBEAT_THRESHOLD_HOURS=8
-VERSION="1.1.24"
+VERSION="1.1.25"
 
 # Per-user stale threshold (in hours) used by the dashboard to flag hosts when an expected user is missing/stuck.
 # IMPORTANT: The stale threshold must be significantly larger than the heartbeat threshold to avoid false positives.

--- a/tests/fixtures/hostname-truncation/no-headers.js
+++ b/tests/fixtures/hostname-truncation/no-headers.js
@@ -1,0 +1,5 @@
+// A template file with no host-card header at all. Discovery must go red here
+// rather than reporting a clean sweep over nothing.
+function renderNothing() {
+    return `<div class="host-card"><p>No header in sight.</p></div>`;
+}

--- a/tests/fixtures/hostname-truncation/pre-fix.css
+++ b/tests/fixtures/hostname-truncation/pre-fix.css
@@ -1,0 +1,13 @@
+/* The docs/styles.css state that shipped the Issue #174 defect: the truncation
+   rule is inert because `text-overflow: ellipsis` only fires on text that
+   overflows a single line, and nothing stops the hostname wrapping. */
+.host-card h5 {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.health-status {
+    flex-shrink: 0;
+    white-space: nowrap;
+}

--- a/tests/fixtures/hostname-truncation/pre-fix.js
+++ b/tests/fixtures/hostname-truncation/pre-fix.js
@@ -1,0 +1,29 @@
+// The docs/dashboard.js header templates as they stood before Issue #174: the
+// hostname text run sits directly in the <h5>, with the machine-type badge as
+// a sibling, and nothing carries the full hostname for a truncated card.
+function renderPreFixCards() {
+    const safeHostname = escapeHtml(hostname);
+
+    const mia = `
+        <div class="host-card mia">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="mb-0">🏖️ ${safeHostname}</h5>
+                <span class="health-status mia">Off the Grid</span>
+            </div>
+        </div>
+    `;
+
+    const active = `
+        <div class="host-card healthy">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="mb-0 d-flex align-items-center">
+                    ${emoji} ${safeHostname}
+                    <span class="badge bg-secondary ms-2">${escapeHtml(data.machine_type)}</span>
+                </h5>
+                <span class="health-status healthy">healthy</span>
+            </div>
+        </div>
+    `;
+
+    return mia + active;
+}

--- a/tests/hostname-truncation-check.js
+++ b/tests/hostname-truncation-check.js
@@ -1,0 +1,200 @@
+// Issue #174: the host-card hostname must truncate with an ellipsis on a single
+// line instead of wrapping onto a second one.
+//
+// `.host-card h5` carried `overflow: hidden; text-overflow: ellipsis` without
+// `white-space: nowrap`, so the text wrapped rather than overflowing and the
+// ellipsis never fired — `Tinas-MacBook-Air` dropped "Air" onto a second line
+// and pushed the header into the "OFF THE GRID" badge (Issue #169).
+//
+// This checker locates, per host-card header template in dashboard.js, the
+// element that actually holds the hostname *text run*, resolves the CSS that
+// applies to that element, and asks whether the resulting box can truncate.
+// It is not a search for a declaration in a fixed selector: moving the rule,
+// renaming the class, or restructuring the header is fine as long as the
+// hostname text still lands in a truncating box with its badges intact.
+//
+// Usage: deno run --allow-read hostname-truncation-check.js <styles.css> <dashboard.js>
+
+import { declarations, report, rules, stripComments } from "./css-colour-lib.js";
+
+const [cssPath, jsPath] = Deno.args;
+if (!cssPath || !jsPath) {
+    console.error("usage: hostname-truncation-check.js <styles.css> <dashboard.js>");
+    Deno.exit(2);
+}
+
+const css = stripComments(await Deno.readTextFile(cssPath));
+const js = await Deno.readTextFile(jsPath);
+const allRules = [...rules(css)];
+const NAME = "hostname-truncation";
+const DARK = '[data-theme="dark"]';
+
+// Theme-prefixed rules style the same element, so they join the same cascade.
+const bare = (selector) => selector.startsWith(`${DARK} `) ? selector.slice(DARK.length + 1) : selector;
+
+// Declarations from every rule whose selector is in `candidates`, merged in
+// source order so later rules win — a sufficient stand-in for the cascade here,
+// where the selectors involved carry comparable specificity.
+function resolved(candidates) {
+    const wanted = new Set(candidates);
+    const merged = {};
+    for (const rule of allRules) {
+        if (!rule.selectors.some((s) => wanted.has(bare(s)))) continue;
+        Object.assign(merged, declarations(rule.body));
+    }
+    return merged;
+}
+
+// --- Header template discovery ---------------------------------------------
+
+// The hostname text run, however the template spells it.
+const HOSTNAME_TOKEN = /\$\{\s*(?:safeHostname|escapeHtml\(\s*hostname\s*\))\s*\}/;
+
+const attr = (tag, name) => tag.match(new RegExp(`${name}="([^"]*)"`))?.[1] ?? null;
+const classesOf = (tag) => (attr(tag, "class") ?? "").split(/\s+/).filter(Boolean);
+
+// Walk the header's inner markup and return the innermost element open at the
+// point the hostname text appears, plus every other element in the header.
+function analyseHeader(h5Tag, inner) {
+    const hostnameAt = inner.search(HOSTNAME_TOKEN);
+    const stack = [{ tag: h5Tag, name: "h5", start: 0, end: inner.length }];
+    let holder = stack[0];
+    let holderFound = false;
+    const others = [];
+
+    const VOID = ["br", "img", "input", "hr", "meta", "link"];
+    for (const match of inner.matchAll(/<(\/?)([a-zA-Z0-9]+)([^>]*?)(\/?)>/g)) {
+        const [full, closing, name, , selfClosing] = match;
+        if (closing) {
+            const popped = stack.pop();
+            if (!popped) continue;
+            popped.end = match.index;
+            // Pops run innermost-first, so the first containing element wins.
+            if (!holderFound && popped.start <= hostnameAt && popped.end >= hostnameAt) {
+                holder = popped;
+                holderFound = true;
+            }
+            continue;
+        }
+        const element = { tag: full, name, start: match.index };
+        others.push(element);
+        if (!selfClosing && !VOID.includes(name)) stack.push(element);
+    }
+    for (const unclosed of stack) unclosed.end = inner.length;
+
+    return { holder, others: others.filter((e) => e !== holder) };
+}
+
+function findHeaders() {
+    const headers = [];
+    // The inner capture must not cross another `<h5`, so a prose mention of the
+    // tag cannot swallow the real template that follows it.
+    for (const match of js.matchAll(/<h5([^>]*)>((?:(?!<h5)[\s\S])*?)<\/h5>/g)) {
+        const [, attrs, inner] = match;
+        if (!HOSTNAME_TOKEN.test(inner)) continue;
+        const line = js.slice(0, match.index).split("\n").length;
+        headers.push({ line, h5Tag: `<h5${attrs}>`, ...analyseHeader(`<h5${attrs}>`, inner) });
+    }
+    return headers;
+}
+
+const headers = findHeaders();
+report(
+    `${NAME}-headers-discovered`,
+    headers.length > 0,
+    headers.length > 0
+        ? `found ${headers.length} host-card header template(s) at line(s) ${headers.map((h) => h.line).join(", ")}`
+        : "no <h5> host-card header carrying the hostname was found — the sweep would pass by vacuity",
+);
+
+// --- The sweep -------------------------------------------------------------
+
+// Selectors that could style the hostname holder, given where it sits.
+function candidatesFor(holder) {
+    if (holder.name === "h5") return [".host-card h5", ...classesOf(holder.tag).map((c) => `.host-card h5.${c}`)];
+    return classesOf(holder.tag).flatMap((c) => [
+        `.${c}`,
+        `.host-card h5 .${c}`,
+        `.host-card h5 > .${c}`,
+        `.host-card h5 ${holder.name}.${c}`,
+    ]);
+}
+
+const isFlex = (decl, tag) => (decl["display"] ?? "").trim() === "flex" || classesOf(tag).includes("d-flex");
+
+for (const header of headers) {
+    const id = `line-${header.line}`;
+    const { holder } = header;
+    const decl = resolved(candidatesFor(holder));
+    const h5Decl = resolved([".host-card h5"]);
+
+    const whiteSpace = (decl["white-space"] ?? "normal").trim();
+    const overflow = (decl["overflow"] ?? "visible").trim();
+    const textOverflow = (decl["text-overflow"] ?? "clip").trim();
+    const nowrap = ["nowrap", "pre"].includes(whiteSpace);
+
+    report(
+        `${NAME}-${id}-cannot-wrap`,
+        nowrap,
+        `the hostname text run sits in <${holder.name} class="${classesOf(holder.tag).join(" ")}"> ` +
+            `with white-space: ${whiteSpace}` +
+            (nowrap ? "" : " — the text wraps onto a second line instead of overflowing, so the ellipsis never fires"),
+    );
+
+    report(
+        `${NAME}-${id}-ellipsis-effective`,
+        nowrap && overflow === "hidden" && textOverflow === "ellipsis",
+        `hostname box: white-space: ${whiteSpace}, overflow: ${overflow}, text-overflow: ${textOverflow}` +
+            (nowrap && overflow === "hidden" && textOverflow === "ellipsis"
+                ? " — overflowing text is clipped with an ellipsis"
+                : " — all three are needed before a long hostname truncates"),
+    );
+
+    // A flex item refuses to shrink below its content width unless its automatic
+    // minimum size is neutralised, so the ellipsis would never be reached.
+    const shrinkable = (decl["min-width"] ?? "").trim() === "0" || overflow === "hidden";
+    report(
+        `${NAME}-${id}-can-shrink`,
+        shrinkable,
+        `hostname box has min-width: ${decl["min-width"] ?? "auto"}, overflow: ${overflow}` +
+            (shrinkable ? "" : " — it cannot shrink below its content width, so truncation never starts"),
+    );
+
+    // Truncation hides characters, and the dashboard is read on phones — the
+    // full hostname has to stay discoverable.
+    const title = attr(holder.tag, "title");
+    report(
+        `${NAME}-${id}-full-hostname-discoverable`,
+        title !== null && HOSTNAME_TOKEN.test(title),
+        title === null
+            ? "the truncating element carries no title attribute — the hidden characters are unrecoverable"
+            : `the truncating element exposes the full hostname via title="${title}"`,
+    );
+
+    // A truncating span only sits beside the machine-type / worker-silent
+    // badges if the header lays its children out in a row.
+    if (holder.name !== "h5") {
+        report(
+            `${NAME}-${id}-header-is-a-row`,
+            isFlex(h5Decl, header.h5Tag),
+            `header <h5 class="${classesOf(header.h5Tag).join(" ")}"> display: ${h5Decl["display"] ?? "block"}` +
+                (isFlex(h5Decl, header.h5Tag)
+                    ? " — the hostname box and its badges share one line"
+                    : " — the badges would sit inside the text flow rather than beside the truncating box"),
+        );
+    }
+
+    // The badges must be siblings of the truncating box, not inside it, or the
+    // ellipsis would eat "Mac mini" / "Worker silent" before the hostname.
+    const badges = header.others.filter((e) => classesOf(e.tag).includes("badge"));
+    const badgeDecl = resolved([".host-card h5 .badge", ".badge"]);
+    const badgesKept = badges.every((b) => b.start < holder.start || b.start > holder.end);
+    report(
+        `${NAME}-${id}-badges-not-clipped`,
+        badges.length === 0 || (badgesKept && (badgeDecl["flex-shrink"] ?? "").trim() === "0"),
+        badges.length === 0
+            ? "this header carries no badges beside the hostname"
+            : `${badges.length} badge(s) beside the hostname, flex-shrink: ${badgeDecl["flex-shrink"] ?? "1"}` +
+                (badgesKept ? "" : " — a badge sits inside the truncating box and would be clipped away"),
+    );
+}

--- a/tests/status-overflow.test.html
+++ b/tests/status-overflow.test.html
@@ -113,6 +113,12 @@
     <div id="decoration-results"></div>
     <div id="decoration-summary" class="summary"></div>
 
+    <h1>Hostname Truncation Tests - Issue #174</h1>
+    <p style="color: white;">Testing that a long hostname truncates with an ellipsis on <em>one</em> line instead of wrapping onto a second one, while the machine-type and "Worker silent" badges stay visible.</p>
+
+    <div id="truncation-results"></div>
+    <div id="truncation-summary" class="summary"></div>
+
     <script>
         // Test function to check if an element overflows its container
         function checkOverflow(container, element) {
@@ -500,6 +506,196 @@
                 `;
             }, 50);
         }, 150);
+    </script>
+
+    <script>
+        // Issue #174: `.host-card h5` carried `overflow: hidden` and
+        // `text-overflow: ellipsis` with no `white-space: nowrap`. The ellipsis
+        // only fires on text that overflows a *single* line, so the hostname
+        // wrapped instead — `Tinas-MacBook-Air` dropped "Air" onto a second
+        // line and the taller header pushed into the "OFF THE GRID" badge.
+        //
+        // These cases render both header shapes dashboard.js emits against the
+        // real docs/styles.css and measure the rendered boxes.
+        const truncationCases = [
+            {
+                name: 'MIA header — long hostname truncates on one line',
+                hostname: 'Tinas-MacBook-Air',
+                emoji: '🏖️',
+                variant: 'mia',
+                status: 'Off the Grid',
+                flexHeader: false,
+                badges: [],
+                width: 320,
+                expectTruncated: true
+            },
+            {
+                name: 'Active header — long hostname with machine-type and Worker silent badges',
+                hostname: 'Tinas-MacBook-Air',
+                emoji: '🍭',
+                variant: 'healthy',
+                status: 'healthy',
+                flexHeader: true,
+                badges: [
+                    { className: 'badge bg-secondary ms-2', label: 'MacBook Air' },
+                    { className: 'badge bg-warning text-dark ms-2 worker-silent-badge', label: 'Worker silent' }
+                ],
+                width: 360,
+                expectTruncated: true
+            },
+            {
+                name: 'Active header — very long hostname in a phone-width card',
+                hostname: 'Tinas-MacBook-Air-In-The-Back-Room',
+                emoji: '',
+                variant: 'warning',
+                status: 'warning',
+                flexHeader: true,
+                badges: [{ className: 'badge bg-secondary ms-2', label: 'Mac mini' }],
+                width: 280,
+                expectTruncated: true
+            },
+            {
+                name: 'Active header — a short hostname is left alone',
+                hostname: 'GRQ-23',
+                emoji: '',
+                variant: 'healthy',
+                status: 'healthy',
+                flexHeader: true,
+                badges: [{ className: 'badge bg-secondary ms-2', label: 'Mac mini' }],
+                width: 420,
+                expectTruncated: false
+            }
+        ];
+
+        // Mirrors the header markup docs/dashboard.js emits: the hostname text
+        // run lives in its own truncating span, badges are its siblings.
+        function truncationCardHtml(testCase) {
+            const badges = testCase.badges
+                .map((badge) => `<span class="${badge.className}" style="font-size: 0.7rem;">${badge.label}</span>`)
+                .join('');
+            const headerClass = testCase.flexHeader ? 'mb-0 d-flex align-items-center' : 'mb-0';
+            const prefix = testCase.emoji ? `${testCase.emoji} ` : '';
+            return `
+                <div class="card-preview" style="width: ${testCase.width}px; overflow: visible;">
+                    <div class="host-card ${testCase.variant}">
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <h5 class="${headerClass}">
+                                <span class="hostname-text" title="${testCase.hostname}">${prefix}${testCase.hostname}</span>
+                                ${badges}
+                            </h5>
+                            <span class="health-status ${testCase.variant}">${testCase.status}</span>
+                        </div>
+                        <div class="row">
+                            <div class="col-6">
+                                <small class="text-muted">OS</small>
+                                <div class="fw-bold">macOS 15.0</div>
+                            </div>
+                            <div class="col-6">
+                                <small class="text-muted">Uptime</small>
+                                <div class="fw-bold">5d</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }
+
+        // Two boxes share a line when their vertical extents overlap.
+        function sharesLine(a, b) {
+            return a.top < b.bottom && b.top < a.bottom;
+        }
+
+        setTimeout(() => {
+            const resultsDiv = document.getElementById('truncation-results');
+            resultsDiv.innerHTML = truncationCases.map((testCase, index) => `
+                <div class="test-case">
+                    <h3>Truncation ${index + 1}: ${testCase.name}</h3>
+                    <p>Hostname: <code>${testCase.hostname}</code>, Container: ${testCase.width}px</p>
+                    <div id="trunc-container-${index}">${truncationCardHtml(testCase)}</div>
+                    <div id="trunc-result-${index}"></div>
+                </div>
+            `).join('');
+
+            let passCount = 0;
+            let failCount = 0;
+            let checkCount = 0;
+
+            const record = (lines, ok, message) => {
+                checkCount++;
+                if (ok) {
+                    passCount++;
+                    lines.push(`<p class="pass">PASS: ${message}</p>`);
+                } else {
+                    failCount++;
+                    lines.push(`<p class="fail">FAIL: ${message}</p>`);
+                }
+            };
+
+            setTimeout(() => {
+                truncationCases.forEach((testCase, index) => {
+                    const root = document.querySelector(`#trunc-container-${index}`);
+                    const card = root.querySelector('.host-card');
+                    const header = root.querySelector('h5');
+                    const hostname = root.querySelector('.hostname-text');
+                    const statusBadge = root.querySelector('.health-status');
+                    const lines = [];
+
+                    if (!card || !header || !hostname || !statusBadge) {
+                        record(lines, false, 'Could not find the card, header, hostname and badge elements');
+                        document.getElementById(`trunc-result-${index}`).innerHTML = lines.join('');
+                        return;
+                    }
+
+                    const style = getComputedStyle(hostname);
+                    record(lines, style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre',
+                        `the hostname text run cannot wrap (white-space: ${style.whiteSpace})`);
+
+                    // One text line, measured rather than assumed: a wrapped
+                    // hostname renders two client rects for the same text run.
+                    const range = document.createRange();
+                    range.selectNodeContents(hostname);
+                    const lineCount = range.getClientRects().length;
+                    record(lines, lineCount === 1,
+                        `the hostname renders on a single line (${lineCount} line box(es))`);
+
+                    const truncated = hostname.scrollWidth > hostname.clientWidth;
+                    record(lines, truncated === testCase.expectTruncated,
+                        testCase.expectTruncated
+                            ? `the long hostname is clipped with an ellipsis (content ${hostname.scrollWidth}px in a ${hostname.clientWidth}px box)`
+                            : `the short hostname is shown in full (content ${hostname.scrollWidth}px in a ${hostname.clientWidth}px box)`);
+
+                    record(lines, hostname.title === testCase.hostname,
+                        `the full hostname stays discoverable via title="${hostname.title}"`);
+
+                    const headerRect = header.getBoundingClientRect();
+                    const statusRect = statusBadge.getBoundingClientRect();
+                    const cardRect = card.getBoundingClientRect();
+
+                    record(lines, sharesLine(headerRect, statusRect),
+                        'the status badge stays on the hostname line');
+                    record(lines, statusRect.right <= cardRect.right + 0.5,
+                        `the status badge stays inside the card (${(cardRect.right - statusRect.right).toFixed(1)}px to spare)`);
+
+                    root.querySelectorAll('.badge').forEach((badge) => {
+                        const rect = badge.getBoundingClientRect();
+                        const label = badge.textContent.trim();
+                        record(lines, rect.width > 0 && rect.height > 0 && rect.right <= cardRect.right + 0.5,
+                            `the "${label}" badge stays visible and unclipped (${rect.width.toFixed(1)}×${rect.height.toFixed(1)}px)`);
+                    });
+
+                    document.getElementById(`trunc-result-${index}`).innerHTML = lines.join('');
+                });
+
+                const summaryDiv = document.getElementById('truncation-summary');
+                summaryDiv.className = `summary ${failCount === 0 ? 'all-pass' : 'has-failures'}`;
+                summaryDiv.innerHTML = `
+                    <h2>Hostname Truncation Summary (Issue #174)</h2>
+                    <p>Passed: ${passCount} / ${checkCount}</p>
+                    <p>Failed: ${failCount} / ${checkCount}</p>
+                    ${failCount === 0 ? '<p>All checks passed! Long hostnames truncate on one line and the badges survive.</p>' : '<p>Some checks failed. The hostname is wrapping or a badge is being clipped.</p>'}
+                `;
+            }, 50);
+        }, 200);
     </script>
 </body>
 </html>

--- a/tests/test-status-overflow.sh
+++ b/tests/test-status-overflow.sh
@@ -6,6 +6,10 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STYLES_CSS="$SCRIPT_DIR/../docs/styles.css"
+DASHBOARD_JS_PATH="$SCRIPT_DIR/../docs/dashboard.js"
+TRUNCATION_CHECKER="$SCRIPT_DIR/hostname-truncation-check.js"
+TRUNCATION_FIXTURES="$SCRIPT_DIR/fixtures/hostname-truncation"
+DENO="$HOME/.deno/bin/deno"
 
 echo "Testing Issue #17: Status badge overflow fix"
 echo "============================================="
@@ -59,6 +63,114 @@ echo "Test 5: Checking overflow consistency across card variants..."
 # .host-card.critical, .host-card.warning, .host-card.healthy) rely on the
 # base .host-card having overflow: hidden, which Test 1 already verified.
 echo "  PASS: Base .host-card should handle overflow for all variants"
+
+# --- Issue #174: the hostname must truncate, not wrap ------------------------
+#
+# Test 4 above only ever checked `min-width: 0`, which is how `.host-card h5`
+# shipped `overflow: hidden; text-overflow: ellipsis` with no `white-space:
+# nowrap`. The ellipsis never fired, so `Tinas-MacBook-Air` wrapped onto a
+# second line and pushed the header into the "OFF THE GRID" badge (Issue #169).
+#
+# tests/hostname-truncation-check.js closes that gap: for every host-card header
+# template in docs/dashboard.js it locates the element that actually holds the
+# hostname *text run*, resolves the CSS applying to that element, and asks
+# whether the box can truncate — so restructuring the header is fine as long as
+# the hostname still lands in a truncating box with its badges intact.
+
+TRUNCATION_OUTPUT=""
+
+run_truncation_checker() {
+    local css="$1" js="$2"
+    if ! TRUNCATION_OUTPUT="$("$DENO" run --allow-read "$TRUNCATION_CHECKER" "$css" "$js" < /dev/null 2>&1)"; then
+        echo "$TRUNCATION_OUTPUT"
+        return 1
+    fi
+    if [ -z "$TRUNCATION_OUTPUT" ]; then
+        echo "  (checker produced no TEST_RESULT lines for $css + $js)"
+        return 1
+    fi
+    return 0
+}
+
+truncation_verdict() {
+    local name="$1" line
+    line="$(printf '%s\n' "$TRUNCATION_OUTPUT" | grep "^TEST_RESULT:${name}:" | head -1)"
+    if [ -z "$line" ]; then
+        echo "MISSING"
+    else
+        echo "$line" | cut -d: -f3
+    fi
+}
+
+expect_truncation_verdict() {
+    local name="$1" expected="$2" why="$3" actual
+    actual="$(truncation_verdict "$name")"
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS: $name is $expected — $why"
+    else
+        echo "  FAIL: $name is $actual, expected $expected — $why"
+        exit 1
+    fi
+}
+
+echo "Test 6: Checking that the hostname truncates instead of wrapping (Issue #174)..."
+if [ ! -x "$DENO" ]; then
+    echo "  FAIL: deno not found at $DENO — cannot verify hostname truncation"
+    exit 1
+fi
+
+if ! run_truncation_checker "$STYLES_CSS" "$DASHBOARD_JS_PATH"; then
+    echo "  FAIL: hostname-truncation-check.js failed on docs/styles.css + docs/dashboard.js"
+    exit 1
+fi
+
+TRUNCATION_FAILURES=0
+while IFS= read -r line; do
+    case "$line" in
+        TEST_RESULT:*)
+            name="$(echo "$line" | cut -d: -f2)"
+            result="$(echo "$line" | cut -d: -f3)"
+            detail="$(echo "$line" | cut -d: -f4-)"
+            if [ "$result" = "PASS" ]; then
+                echo "  PASS: $name — $detail"
+            else
+                echo "  FAIL: $name — $detail"
+                TRUNCATION_FAILURES=$((TRUNCATION_FAILURES + 1))
+            fi
+            ;;
+        *) [ -n "$line" ] && echo "  $line" ;;
+    esac
+done <<< "$TRUNCATION_OUTPUT"
+
+if [ "$TRUNCATION_FAILURES" -gt 0 ]; then
+    echo "  FAIL: $TRUNCATION_FAILURES hostname truncation check(s) failed"
+    exit 1
+fi
+
+echo "Test 7: Self-test — the checker must still detect the pre-fix defect..."
+if ! run_truncation_checker "$TRUNCATION_FIXTURES/pre-fix.css" "$TRUNCATION_FIXTURES/pre-fix.js"; then
+    echo "  FAIL: hostname-truncation-check.js failed on the pre-fix fixture"
+    exit 1
+fi
+
+expect_truncation_verdict "hostname-truncation-headers-discovered" PASS \
+    "the fixture's header templates are enumerated"
+expect_truncation_verdict "hostname-truncation-line-10-cannot-wrap" FAIL \
+    "the MIA header without white-space: nowrap is the unfixed defect"
+expect_truncation_verdict "hostname-truncation-line-19-cannot-wrap" FAIL \
+    "the active-host header without white-space: nowrap is the unfixed defect"
+expect_truncation_verdict "hostname-truncation-line-19-badges-not-clipped" FAIL \
+    "a machine-type badge inside the truncating box would be ellipsised away"
+expect_truncation_verdict "hostname-truncation-line-10-full-hostname-discoverable" FAIL \
+    "a truncated hostname with no title attribute is unrecoverable"
+
+echo "Test 8: Guard-degradation — a template with no header must not pass by vacuity..."
+if ! run_truncation_checker "$STYLES_CSS" "$TRUNCATION_FIXTURES/no-headers.js"; then
+    echo "  FAIL: hostname-truncation-check.js failed on the empty fixture"
+    exit 1
+fi
+expect_truncation_verdict "hostname-truncation-headers-discovered" FAIL \
+    "discovering zero host-card headers is itself a failure"
 
 echo ""
 echo "============================================="


### PR DESCRIPTION
## Summary

`.host-card h5` carried `min-width: 0; overflow: hidden; text-overflow: ellipsis` with no `white-space: nowrap`. `text-overflow` only fires on text that overflows a **single** line, so the hostname wrapped rather than overflowing, the ellipsis never triggered and `overflow: hidden` had nothing to clip — `Tinas-MacBook-Air` dropped "Air" onto a second line and the taller header pushed into the "OFF THE GRID" badge (the #169 signature). Closes #174.

The header is a flex row, and a flex container cannot truncate its own children, so the ellipsis is applied to the hostname **text run** instead of the header. All four `<h5>` card templates in `docs/dashboard.js` (dead, historical, MIA and active) now wrap the hostname in `<span class="hostname-text" title="…">`, which carries `min-width: 0`, `overflow: hidden`, `text-overflow: ellipsis` and `white-space: nowrap`. `.host-card h5` becomes the flex row (so the plain MIA header gets the same treatment as the active one) and `.host-card h5 .badge` gets `flex-shrink: 0`, so the machine-type ("Mac mini") and "Worker silent" badges stay beside the ellipsis rather than being clipped away. The `title` attribute keeps the full hostname readable where the truncation is aggressive, i.e. on a phone.

```mermaid
flowchart LR
    A[".host-card h5 — display: flex, overflow: hidden"] --> B["span.hostname-text<br/>min-width: 0, nowrap, ellipsis"]
    A --> C["span.badge — flex-shrink: 0<br/>Mac mini / Worker silent"]
    B -->|"title attribute"| D["full hostname on hover / long-press"]
```

## Evidence

**No screenshot: no browser was available on this host.** Playwright MCP was not configured for this run, and the Chromium build under `~/Library/Caches/ms-playwright/` hung without producing a frame on every invocation (headless old and new, sandboxed and not, including on a trivial `data:` URL) — so `tests/status-overflow.test.html` could not be rendered here. The browser cases were added anyway and run in any environment that has a working Chromium; the shell gate below is what CI enforces.

Automated verification, run against the unfixed tree and the fixed one:

| Check | Unfixed | Fixed |
| --- | --- | --- |
| `tests/hostname-truncation-check.js` on `docs/styles.css` + `docs/dashboard.js` | 13 failures across all 4 header templates (wrapping, inert ellipsis, no `title`, badge inside the truncating box) | 25 checks, 0 failures |
| `tests/test-status-overflow.sh` | red — Test 6 reports "13 hostname truncation check(s) failed" | 36 assertions, all pass |
| `./quality.sh` | — | 64 / 64 passed |

The unfixed verdicts, straight from the checker before the fix:

```text
TEST_RESULT:hostname-truncation-line-1154-cannot-wrap:FAIL:the hostname text run sits in
  <h5 class="mb-0"> with white-space: normal — the text wraps onto a second line instead of
  overflowing, so the ellipsis never fires
TEST_RESULT:hostname-truncation-line-1254-badges-not-clipped:FAIL:1 badge(s) beside the
  hostname, flex-shrink: 1 — a badge sits inside the truncating box and would be clipped away
```

## Test Plan

- **Added `tests/hostname-truncation-check.js`** — for every `<h5>` host-card header template in `docs/dashboard.js` it locates the element that actually holds the hostname *text run*, resolves the CSS applying to that element, and asks whether the resulting box can truncate: `white-space` cannot wrap, `overflow`/`text-overflow` make the ellipsis effective, the box can shrink below its content width, the full hostname stays discoverable via `title`, the header lays its children out in a row, and the badges sit outside the truncating box with `flex-shrink: 0`. It asserts an outcome rather than a declaration in a fixed selector, so the header may be restructured freely as long as the hostname still truncates with its badges intact — and it goes red the moment `white-space: nowrap` is dropped.
- **Extended `tests/test-status-overflow.sh`** with Tests 6–8. Test 6 sweeps the real stylesheet and dashboard (it failed with 13 failures before the fix and passes after — closing the gap left by Test 4, which only ever checked `min-width: 0`). Test 7 is the checker's self-test against `tests/fixtures/hostname-truncation/pre-fix.{css,js}`, the exact pre-fix state, where the wrapping, missing-`title` and clipped-badge verdicts must still come back FAIL. Test 8 is guard degradation: `no-headers.js` must make discovery go red rather than pass by vacuity.
- **Extended `tests/status-overflow.test.html`** with four Issue #174 browser cases (MIA and active header shapes, `Tinas-MacBook-Air` at 320px/360px, a longer name at a 280px phone width, and a short `GRQ-23` control that must *not* be truncated). Each measures the rendered result: the hostname's client rects must form exactly one line box, `scrollWidth > clientWidth` must match the expected truncation, the status badge must share the hostname's line and stay inside the card, and every machine-type / "Worker silent" badge must have a non-zero box inside the card bounds.
- **Updated `README.md`** with a "The hostname truncates, it never wraps (Issue #174)" section, including a Mermaid diagram of the header layout.
- Version bumped to 1.1.25 and synced with `./update_version.sh`.
